### PR TITLE
MapDateTimeImmutable: support multiple formats and timezones

### DIFF
--- a/src/Compiler/Mapper/Object/MapDate.php
+++ b/src/Compiler/Mapper/Object/MapDate.php
@@ -1,0 +1,19 @@
+<?php declare(strict_types = 1);
+
+namespace ShipMonk\InputMapper\Compiler\Mapper\Object;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_PARAMETER)]
+class MapDate extends MapDateTimeImmutable
+{
+
+    public function __construct(
+        string $formatDescription = 'date string in Y-m-d format',
+        ?string $timezone = null,
+    )
+    {
+        parent::__construct('!Y-m-d', $formatDescription, $timezone);
+    }
+
+}

--- a/src/Compiler/Mapper/Object/MapDateTimeImmutable.php
+++ b/src/Compiler/Mapper/Object/MapDateTimeImmutable.php
@@ -22,7 +22,9 @@ class MapDateTimeImmutable implements MapperCompiler
 {
 
     /**
-     * @param string|non-empty-list<string> $format
+     * @param string|non-empty-list<string> $format if multiple formats are provided, they will be tried in sequence as provided
+     * @param ?string $defaultTimezone timezone used when timezone in not explicitly specified in input value
+     * @param ?string $targetTimezone timezone to which the result is converted (regardless of the whether timezone was specified in input)
      */
     public function __construct(
         public readonly string|array $format = [DateTimeInterface::RFC3339, DateTimeInterface::RFC3339_EXTENDED],

--- a/src/Compiler/Php/PhpCodePrinter.php
+++ b/src/Compiler/Php/PhpCodePrinter.php
@@ -108,13 +108,17 @@ class PhpCodePrinter extends Standard
 
     protected function pExpr_New(New_ $node): string
     {
+        $argsFormatted = match (count($node->args)) {
+            0 => '()',
+            1 => '(' . $this->p($node->args[0]) . ')',
+            default => '(' . $this->pCommaSeparatedMultiline($node->args, true) . "{$this->nl})",
+        };
+
         if ($node->class instanceof Class_) {
-            $args = count($node->args) > 0 ? '(' . $this->pCommaSeparatedMultiline($node->args, true) . "{$this->nl})" : '';
-            return 'new ' . $this->pClassCommon($node->class, $args);
+            return 'new ' . $this->pClassCommon($node->class, $argsFormatted);
         }
 
-        return 'new ' . $this->pNewVariable($node->class)
-            . '(' . $this->pCommaSeparatedMultiline($node->args, true) . "{$this->nl})";
+        return 'new ' . $this->pNewVariable($node->class) . $argsFormatted;
     }
 
 }

--- a/tests/Compiler/Mapper/Object/Data/DateStandaloneMapper.php
+++ b/tests/Compiler/Mapper/Object/Data/DateStandaloneMapper.php
@@ -1,0 +1,40 @@
+<?php declare (strict_types=1);
+
+namespace ShipMonkTests\InputMapper\Compiler\Mapper\Object\Data;
+
+use DateTimeImmutable;
+use ShipMonk\InputMapper\Runtime\Exception\MappingFailedException;
+use ShipMonk\InputMapper\Runtime\Mapper;
+use ShipMonk\InputMapper\Runtime\MapperProvider;
+use function is_string;
+
+/**
+ * Generated mapper. Do not edit directly.
+ *
+ * @implements Mapper<DateTimeImmutable>
+ */
+class DateStandaloneMapper implements Mapper
+{
+    public function __construct(private readonly MapperProvider $provider)
+    {
+    }
+
+    /**
+     * @param  list<string|int> $path
+     * @throws MappingFailedException
+     */
+    public function map(mixed $data, array $path = []): DateTimeImmutable
+    {
+        if (!is_string($data)) {
+            throw MappingFailedException::incorrectType($data, $path, 'string');
+        }
+
+        $mapped = DateTimeImmutable::createFromFormat('!Y-m-d', $data);
+
+        if ($mapped === false) {
+            throw MappingFailedException::incorrectValue($data, $path, 'date string in Y-m-d format');
+        }
+
+        return $mapped;
+    }
+}

--- a/tests/Compiler/Mapper/Object/Data/DateStandaloneWithTimeZoneMapper.php
+++ b/tests/Compiler/Mapper/Object/Data/DateStandaloneWithTimeZoneMapper.php
@@ -30,9 +30,7 @@ class DateStandaloneWithTimeZoneMapper implements Mapper
             throw MappingFailedException::incorrectType($data, $path, 'string');
         }
 
-        $timezone = new DateTimeZone(
-            'Europe/Prague',
-        );
+        $timezone = new DateTimeZone('Europe/Prague');
         $mapped = DateTimeImmutable::createFromFormat('!Y-m-d', $data, $timezone);
 
         if ($mapped === false) {

--- a/tests/Compiler/Mapper/Object/Data/DateStandaloneWithTimeZoneMapper.php
+++ b/tests/Compiler/Mapper/Object/Data/DateStandaloneWithTimeZoneMapper.php
@@ -1,0 +1,45 @@
+<?php declare (strict_types=1);
+
+namespace ShipMonkTests\InputMapper\Compiler\Mapper\Object\Data;
+
+use DateTimeImmutable;
+use DateTimeZone;
+use ShipMonk\InputMapper\Runtime\Exception\MappingFailedException;
+use ShipMonk\InputMapper\Runtime\Mapper;
+use ShipMonk\InputMapper\Runtime\MapperProvider;
+use function is_string;
+
+/**
+ * Generated mapper. Do not edit directly.
+ *
+ * @implements Mapper<DateTimeImmutable>
+ */
+class DateStandaloneWithTimeZoneMapper implements Mapper
+{
+    public function __construct(private readonly MapperProvider $provider)
+    {
+    }
+
+    /**
+     * @param  list<string|int> $path
+     * @throws MappingFailedException
+     */
+    public function map(mixed $data, array $path = []): DateTimeImmutable
+    {
+        if (!is_string($data)) {
+            throw MappingFailedException::incorrectType($data, $path, 'string');
+        }
+
+        $timezone = new DateTimeZone(
+            'Europe/Prague',
+        );
+        $mapped = DateTimeImmutable::createFromFormat('!Y-m-d', $data, $timezone);
+
+        if ($mapped === false) {
+            throw MappingFailedException::incorrectValue($data, $path, 'date string in Y-m-d format');
+        }
+
+        $mapped = $mapped->setTimezone($timezone);
+        return $mapped;
+    }
+}

--- a/tests/Compiler/Mapper/Object/Data/DateTimeImmutableMapper.php
+++ b/tests/Compiler/Mapper/Object/Data/DateTimeImmutableMapper.php
@@ -32,6 +32,10 @@ class DateTimeImmutableMapper implements Mapper
         $mapped = DateTimeImmutable::createFromFormat('Y-m-d\\TH:i:sP', $data);
 
         if ($mapped === false) {
+            $mapped = DateTimeImmutable::createFromFormat('Y-m-d\\TH:i:s.vP', $data);
+        }
+
+        if ($mapped === false) {
             throw MappingFailedException::incorrectValue($data, $path, 'date-time string in RFC 3339 format');
         }
 

--- a/tests/Compiler/Mapper/Object/Data/DateTimeImmutableWithTargetTimeZoneMapper.php
+++ b/tests/Compiler/Mapper/Object/Data/DateTimeImmutableWithTargetTimeZoneMapper.php
@@ -14,7 +14,7 @@ use function is_string;
  *
  * @implements Mapper<DateTimeImmutable>
  */
-class DateStandaloneWithTimeZoneMapper implements Mapper
+class DateTimeImmutableWithTargetTimeZoneMapper implements Mapper
 {
     public function __construct(private readonly MapperProvider $provider)
     {
@@ -30,13 +30,17 @@ class DateStandaloneWithTimeZoneMapper implements Mapper
             throw MappingFailedException::incorrectType($data, $path, 'string');
         }
 
-        $timezone = new DateTimeZone('Europe/Prague');
-        $mapped = DateTimeImmutable::createFromFormat('!Y-m-d', $data, $timezone);
+        $mapped = DateTimeImmutable::createFromFormat('Y-m-d\\TH:i:sP', $data);
 
         if ($mapped === false) {
-            throw MappingFailedException::incorrectValue($data, $path, 'date string in Y-m-d format');
+            $mapped = DateTimeImmutable::createFromFormat('Y-m-d\\TH:i:s.vP', $data);
         }
 
+        if ($mapped === false) {
+            throw MappingFailedException::incorrectValue($data, $path, 'date-time string in RFC 3339 format');
+        }
+
+        $mapped = $mapped->setTimezone(new DateTimeZone('Europe/Prague'));
         return $mapped;
     }
 }

--- a/tests/Compiler/Mapper/Object/Data/DateTimeImmutableWithTimeZoneMapper.php
+++ b/tests/Compiler/Mapper/Object/Data/DateTimeImmutableWithTimeZoneMapper.php
@@ -1,0 +1,49 @@
+<?php declare (strict_types=1);
+
+namespace ShipMonkTests\InputMapper\Compiler\Mapper\Object\Data;
+
+use DateTimeImmutable;
+use DateTimeZone;
+use ShipMonk\InputMapper\Runtime\Exception\MappingFailedException;
+use ShipMonk\InputMapper\Runtime\Mapper;
+use ShipMonk\InputMapper\Runtime\MapperProvider;
+use function is_string;
+
+/**
+ * Generated mapper. Do not edit directly.
+ *
+ * @implements Mapper<DateTimeImmutable>
+ */
+class DateTimeImmutableWithTimeZoneMapper implements Mapper
+{
+    public function __construct(private readonly MapperProvider $provider)
+    {
+    }
+
+    /**
+     * @param  list<string|int> $path
+     * @throws MappingFailedException
+     */
+    public function map(mixed $data, array $path = []): DateTimeImmutable
+    {
+        if (!is_string($data)) {
+            throw MappingFailedException::incorrectType($data, $path, 'string');
+        }
+
+        $timezone = new DateTimeZone(
+            'Europe/Prague',
+        );
+        $mapped = DateTimeImmutable::createFromFormat('Y-m-d\\TH:i:sP', $data, $timezone);
+
+        if ($mapped === false) {
+            $mapped = DateTimeImmutable::createFromFormat('Y-m-d\\TH:i:s.vP', $data, $timezone);
+        }
+
+        if ($mapped === false) {
+            throw MappingFailedException::incorrectValue($data, $path, 'date-time string in RFC 3339 format');
+        }
+
+        $mapped = $mapped->setTimezone($timezone);
+        return $mapped;
+    }
+}

--- a/tests/Compiler/Mapper/Object/Data/DateTimeImmutableWithTimeZoneMapper.php
+++ b/tests/Compiler/Mapper/Object/Data/DateTimeImmutableWithTimeZoneMapper.php
@@ -30,9 +30,7 @@ class DateTimeImmutableWithTimeZoneMapper implements Mapper
             throw MappingFailedException::incorrectType($data, $path, 'string');
         }
 
-        $timezone = new DateTimeZone(
-            'Europe/Prague',
-        );
+        $timezone = new DateTimeZone('Europe/Prague');
         $mapped = DateTimeImmutable::createFromFormat('Y-m-d\\TH:i:sP', $data, $timezone);
 
         if ($mapped === false) {

--- a/tests/Compiler/Mapper/Object/Data/DateWithDefaultTimeZoneMapper.php
+++ b/tests/Compiler/Mapper/Object/Data/DateWithDefaultTimeZoneMapper.php
@@ -14,7 +14,7 @@ use function is_string;
  *
  * @implements Mapper<DateTimeImmutable>
  */
-class DateStandaloneWithTimeZoneMapper implements Mapper
+class DateWithDefaultTimeZoneMapper implements Mapper
 {
     public function __construct(private readonly MapperProvider $provider)
     {
@@ -30,7 +30,7 @@ class DateStandaloneWithTimeZoneMapper implements Mapper
             throw MappingFailedException::incorrectType($data, $path, 'string');
         }
 
-        $timezone = new DateTimeZone('Europe/Prague');
+        $timezone = new DateTimeZone('America/New_York');
         $mapped = DateTimeImmutable::createFromFormat('!Y-m-d', $data, $timezone);
 
         if ($mapped === false) {

--- a/tests/Compiler/Mapper/Object/Data/DateWithDistinctDefaultAndTargetTimeZoneMapper.php
+++ b/tests/Compiler/Mapper/Object/Data/DateWithDistinctDefaultAndTargetTimeZoneMapper.php
@@ -14,7 +14,7 @@ use function is_string;
  *
  * @implements Mapper<DateTimeImmutable>
  */
-class DateStandaloneWithTimeZoneMapper implements Mapper
+class DateWithDistinctDefaultAndTargetTimeZoneMapper implements Mapper
 {
     public function __construct(private readonly MapperProvider $provider)
     {
@@ -37,6 +37,7 @@ class DateStandaloneWithTimeZoneMapper implements Mapper
             throw MappingFailedException::incorrectValue($data, $path, 'date string in Y-m-d format');
         }
 
+        $mapped = $mapped->setTimezone(new DateTimeZone('America/New_York'));
         return $mapped;
     }
 }

--- a/tests/Compiler/Mapper/Object/Data/DateWithTargetTimeZoneMapper.php
+++ b/tests/Compiler/Mapper/Object/Data/DateWithTargetTimeZoneMapper.php
@@ -14,7 +14,7 @@ use function is_string;
  *
  * @implements Mapper<DateTimeImmutable>
  */
-class DateStandaloneWithTimeZoneMapper implements Mapper
+class DateWithTargetTimeZoneMapper implements Mapper
 {
     public function __construct(private readonly MapperProvider $provider)
     {
@@ -30,13 +30,13 @@ class DateStandaloneWithTimeZoneMapper implements Mapper
             throw MappingFailedException::incorrectType($data, $path, 'string');
         }
 
-        $timezone = new DateTimeZone('Europe/Prague');
-        $mapped = DateTimeImmutable::createFromFormat('!Y-m-d', $data, $timezone);
+        $mapped = DateTimeImmutable::createFromFormat('!Y-m-d', $data);
 
         if ($mapped === false) {
             throw MappingFailedException::incorrectValue($data, $path, 'date string in Y-m-d format');
         }
 
+        $mapped = $mapped->setTimezone(new DateTimeZone('America/New_York'));
         return $mapped;
     }
 }

--- a/tests/Compiler/Mapper/Object/Data/DateWithTimeZoneMapper.php
+++ b/tests/Compiler/Mapper/Object/Data/DateWithTimeZoneMapper.php
@@ -30,9 +30,7 @@ class DateWithTimeZoneMapper implements Mapper
             throw MappingFailedException::incorrectType($data, $path, 'string');
         }
 
-        $timezone = new DateTimeZone(
-            'Europe/Prague',
-        );
+        $timezone = new DateTimeZone('Europe/Prague');
         $mapped = DateTimeImmutable::createFromFormat('!Y-m-d', $data, $timezone);
 
         if ($mapped === false) {

--- a/tests/Compiler/Mapper/Object/Data/DateWithTimeZoneMapper.php
+++ b/tests/Compiler/Mapper/Object/Data/DateWithTimeZoneMapper.php
@@ -1,0 +1,45 @@
+<?php declare (strict_types=1);
+
+namespace ShipMonkTests\InputMapper\Compiler\Mapper\Object\Data;
+
+use DateTimeImmutable;
+use DateTimeZone;
+use ShipMonk\InputMapper\Runtime\Exception\MappingFailedException;
+use ShipMonk\InputMapper\Runtime\Mapper;
+use ShipMonk\InputMapper\Runtime\MapperProvider;
+use function is_string;
+
+/**
+ * Generated mapper. Do not edit directly.
+ *
+ * @implements Mapper<DateTimeImmutable>
+ */
+class DateWithTimeZoneMapper implements Mapper
+{
+    public function __construct(private readonly MapperProvider $provider)
+    {
+    }
+
+    /**
+     * @param  list<string|int> $path
+     * @throws MappingFailedException
+     */
+    public function map(mixed $data, array $path = []): DateTimeImmutable
+    {
+        if (!is_string($data)) {
+            throw MappingFailedException::incorrectType($data, $path, 'string');
+        }
+
+        $timezone = new DateTimeZone(
+            'Europe/Prague',
+        );
+        $mapped = DateTimeImmutable::createFromFormat('!Y-m-d', $data, $timezone);
+
+        if ($mapped === false) {
+            throw MappingFailedException::incorrectValue($data, $path, 'date string in Y-m-d format');
+        }
+
+        $mapped = $mapped->setTimezone($timezone);
+        return $mapped;
+    }
+}

--- a/tests/Compiler/Mapper/Object/MapDateTest.php
+++ b/tests/Compiler/Mapper/Object/MapDateTest.php
@@ -1,0 +1,53 @@
+<?php declare(strict_types = 1);
+
+namespace ShipMonkTests\InputMapper\Compiler\Mapper\Object;
+
+use DateTimeImmutable;
+use ShipMonk\InputMapper\Compiler\Mapper\Object\MapDate;
+use ShipMonk\InputMapper\Compiler\Mapper\Object\MapDateTimeImmutable;
+use ShipMonk\InputMapper\Runtime\Exception\MappingFailedException;
+use ShipMonk\InputMapper\Runtime\Mapper;
+use ShipMonkTests\InputMapper\Compiler\Mapper\MapperCompilerTestCase;
+
+class MapDateTest extends MapperCompilerTestCase
+{
+
+    public function testCompile(): void
+    {
+        $mapperCompiler = new MapDate();
+
+        /** @var Mapper<DateTimeImmutable> $mapper */
+        $mapper = $this->compileMapper('DateStandalone', $mapperCompiler);
+
+        self::assertSame('1985-04-12T00:00:00.000+00:00', $mapper->map('1985-04-12')->format(DateTimeImmutable::RFC3339_EXTENDED));
+
+        self::assertException(
+            MappingFailedException::class,
+            'Failed to map data at path /: Expected string, got 123',
+            static fn() => $mapper->map(123),
+        );
+
+        self::assertException(
+            MappingFailedException::class,
+            'Failed to map data at path /: Expected string, got null',
+            static fn() => $mapper->map(null),
+        );
+
+        self::assertException(
+            MappingFailedException::class,
+            'Failed to map data at path /: Expected date string in Y-m-d format, got "1985-04-12T23:20:50Z"',
+            static fn() => $mapper->map('1985-04-12T23:20:50Z'),
+        );
+    }
+
+    public function testCompileWithCustomFormatAndTimeZone(): void
+    {
+        $mapperCompiler = new MapDateTimeImmutable(['!Y-m-d'], 'date string in Y-m-d format', 'Europe/Prague');
+
+        /** @var Mapper<DateTimeImmutable> $mapper */
+        $mapper = $this->compileMapper('DateStandaloneWithTimeZone', $mapperCompiler);
+
+        self::assertSame('1985-04-12T00:00:00.000+02:00', $mapper->map('1985-04-12')->format(DateTimeImmutable::RFC3339_EXTENDED));
+    }
+
+}

--- a/tests/Compiler/Mapper/Object/MapDateTimeImmutableTest.php
+++ b/tests/Compiler/Mapper/Object/MapDateTimeImmutableTest.php
@@ -15,8 +15,8 @@ class MapDateTimeImmutableTest extends MapperCompilerTestCase
         $mapperCompiler = new MapDateTimeImmutable();
         $mapper = $this->compileMapper('DateTimeImmutable', $mapperCompiler);
 
-        self::assertEquals(new DateTimeImmutable('1985-04-12T23:20:50Z'), $mapper->map('1985-04-12T23:20:50Z'));
-        self::assertEquals(new DateTimeImmutable('1937-01-01T12:00:27+00:20'), $mapper->map('1937-01-01T12:00:27+00:20'));
+        self::assertSame('1985-04-12T23:20:50.000+00:00', $mapper->map('1985-04-12T23:20:50Z')->format(DateTimeImmutable::RFC3339_EXTENDED));
+        self::assertSame('1937-01-01T12:00:27.000+00:20', $mapper->map('1937-01-01T12:00:27+00:20')->format(DateTimeImmutable::RFC3339_EXTENDED));
 
         self::assertException(
             MappingFailedException::class,
@@ -42,7 +42,7 @@ class MapDateTimeImmutableTest extends MapperCompilerTestCase
         $mapperCompiler = new MapDateTimeImmutable('!Y-m-d', 'date string in Y-m-d format');
         $mapper = $this->compileMapper('Date', $mapperCompiler);
 
-        self::assertEquals(new DateTimeImmutable('1985-04-12T00:00:00Z'), $mapper->map('1985-04-12'));
+        self::assertSame('1985-04-12T00:00:00.000+00:00', $mapper->map('1985-04-12')->format(DateTimeImmutable::RFC3339_EXTENDED));
 
         self::assertException(
             MappingFailedException::class,

--- a/tests/Compiler/Mapper/Object/MapDateTimeImmutableTest.php
+++ b/tests/Compiler/Mapper/Object/MapDateTimeImmutableTest.php
@@ -43,10 +43,22 @@ class MapDateTimeImmutableTest extends MapperCompilerTestCase
 
     public function testCompileWithTimeZone(): void
     {
-        $mapperCompiler = new MapDateTimeImmutable(timezone: 'Europe/Prague');
+        $mapperCompiler = new MapDateTimeImmutable(defaultTimezone: 'Europe/Prague', targetTimezone: 'Europe/Prague');
 
         /** @var Mapper<DateTimeImmutable> $mapper */
         $mapper = $this->compileMapper('DateTimeImmutableWithTimeZone', $mapperCompiler);
+
+        self::assertSame('1985-04-13T01:20:50.000+02:00', $mapper->map('1985-04-12T23:20:50Z')->format(DateTimeImmutable::RFC3339_EXTENDED));
+        self::assertSame('1985-04-13T01:20:50.123+02:00', $mapper->map('1985-04-12T23:20:50.123Z')->format(DateTimeImmutable::RFC3339_EXTENDED));
+        self::assertSame('1937-01-01T12:40:27.000+01:00', $mapper->map('1937-01-01T12:00:27+00:20')->format(DateTimeImmutable::RFC3339_EXTENDED));
+    }
+
+    public function testCompileWithTargetTimeZone(): void
+    {
+        $mapperCompiler = new MapDateTimeImmutable(targetTimezone: 'Europe/Prague');
+
+        /** @var Mapper<DateTimeImmutable> $mapper */
+        $mapper = $this->compileMapper('DateTimeImmutableWithTargetTimeZone', $mapperCompiler);
 
         self::assertSame('1985-04-13T01:20:50.000+02:00', $mapper->map('1985-04-12T23:20:50Z')->format(DateTimeImmutable::RFC3339_EXTENDED));
         self::assertSame('1985-04-13T01:20:50.123+02:00', $mapper->map('1985-04-12T23:20:50.123Z')->format(DateTimeImmutable::RFC3339_EXTENDED));
@@ -83,12 +95,60 @@ class MapDateTimeImmutableTest extends MapperCompilerTestCase
 
     public function testCompileWithCustomFormatAndTimeZone(): void
     {
-        $mapperCompiler = new MapDateTimeImmutable(['!Y-m-d'], 'date string in Y-m-d format', 'Europe/Prague');
+        $mapperCompiler = new MapDateTimeImmutable(
+            format: ['!Y-m-d'],
+            formatDescription: 'date string in Y-m-d format',
+            defaultTimezone: 'Europe/Prague',
+            targetTimezone: 'Europe/Prague',
+        );
 
         /** @var Mapper<DateTimeImmutable> $mapper */
         $mapper = $this->compileMapper('DateWithTimeZone', $mapperCompiler);
 
         self::assertSame('1985-04-12T00:00:00.000+02:00', $mapper->map('1985-04-12')->format(DateTimeImmutable::RFC3339_EXTENDED));
+    }
+
+    public function testCompileWithCustomFormatAndDefaultTimeZone(): void
+    {
+        $mapperCompiler = new MapDateTimeImmutable(
+            format: ['!Y-m-d'],
+            formatDescription: 'date string in Y-m-d format',
+            defaultTimezone: 'America/New_York',
+        );
+
+        /** @var Mapper<DateTimeImmutable> $mapper */
+        $mapper = $this->compileMapper('DateWithDefaultTimeZone', $mapperCompiler);
+
+        self::assertSame('1985-04-12T00:00:00.000-05:00', $mapper->map('1985-04-12')->format(DateTimeImmutable::RFC3339_EXTENDED));
+    }
+
+    public function testCompileWithCustomFormatAndTargetTimeZone(): void
+    {
+        $mapperCompiler = new MapDateTimeImmutable(
+            format: ['!Y-m-d'],
+            formatDescription: 'date string in Y-m-d format',
+            targetTimezone: 'America/New_York',
+        );
+
+        /** @var Mapper<DateTimeImmutable> $mapper */
+        $mapper = $this->compileMapper('DateWithTargetTimeZone', $mapperCompiler);
+
+        self::assertSame('1985-04-11T19:00:00.000-05:00', $mapper->map('1985-04-12')->format(DateTimeImmutable::RFC3339_EXTENDED));
+    }
+
+    public function testCompileWithCustomFormatAndDistinctDefaultAndTargetTimeZone(): void
+    {
+        $mapperCompiler = new MapDateTimeImmutable(
+            format: ['!Y-m-d'],
+            formatDescription: 'date string in Y-m-d format',
+            defaultTimezone: 'Europe/Prague',
+            targetTimezone: 'America/New_York',
+        );
+
+        /** @var Mapper<DateTimeImmutable> $mapper */
+        $mapper = $this->compileMapper('DateWithDistinctDefaultAndTargetTimeZone', $mapperCompiler);
+
+        self::assertSame('1985-04-11T17:00:00.000-05:00', $mapper->map('1985-04-12')->format(DateTimeImmutable::RFC3339_EXTENDED));
     }
 
 }

--- a/tests/Compiler/Mapper/Object/MapDateTimeImmutableTest.php
+++ b/tests/Compiler/Mapper/Object/MapDateTimeImmutableTest.php
@@ -38,6 +38,16 @@ class MapDateTimeImmutableTest extends MapperCompilerTestCase
         );
     }
 
+    public function testCompileWithTimeZone(): void
+    {
+        $mapperCompiler = new MapDateTimeImmutable(timezone: 'Europe/Prague');
+        $mapper = $this->compileMapper('DateTimeImmutableWithTimeZone', $mapperCompiler);
+
+        self::assertSame('1985-04-13T01:20:50.000+02:00', $mapper->map('1985-04-12T23:20:50Z')->format(DateTimeImmutable::RFC3339_EXTENDED));
+        self::assertSame('1985-04-13T01:20:50.123+02:00', $mapper->map('1985-04-12T23:20:50.123Z')->format(DateTimeImmutable::RFC3339_EXTENDED));
+        self::assertSame('1937-01-01T12:40:27.000+01:00', $mapper->map('1937-01-01T12:00:27+00:20')->format(DateTimeImmutable::RFC3339_EXTENDED));
+    }
+
     public function testCompileWithCustomFormat(): void
     {
         $mapperCompiler = new MapDateTimeImmutable('!Y-m-d', 'date string in Y-m-d format');
@@ -62,6 +72,14 @@ class MapDateTimeImmutableTest extends MapperCompilerTestCase
             'Failed to map data at path /: Expected date string in Y-m-d format, got "1985-04-12T23:20:50Z"',
             static fn() => $mapper->map('1985-04-12T23:20:50Z'),
         );
+    }
+
+    public function testCompileWithCustomFormatAndTimeZone(): void
+    {
+        $mapperCompiler = new MapDateTimeImmutable(['!Y-m-d'], 'date string in Y-m-d format', 'Europe/Prague');
+        $mapper = $this->compileMapper('DateWithTimeZone', $mapperCompiler);
+
+        self::assertSame('1985-04-12T00:00:00.000+02:00', $mapper->map('1985-04-12')->format(DateTimeImmutable::RFC3339_EXTENDED));
     }
 
 }

--- a/tests/Compiler/Mapper/Object/MapDateTimeImmutableTest.php
+++ b/tests/Compiler/Mapper/Object/MapDateTimeImmutableTest.php
@@ -16,6 +16,7 @@ class MapDateTimeImmutableTest extends MapperCompilerTestCase
         $mapper = $this->compileMapper('DateTimeImmutable', $mapperCompiler);
 
         self::assertSame('1985-04-12T23:20:50.000+00:00', $mapper->map('1985-04-12T23:20:50Z')->format(DateTimeImmutable::RFC3339_EXTENDED));
+        self::assertSame('1985-04-12T23:20:50.123+00:00', $mapper->map('1985-04-12T23:20:50.123Z')->format(DateTimeImmutable::RFC3339_EXTENDED));
         self::assertSame('1937-01-01T12:00:27.000+00:20', $mapper->map('1937-01-01T12:00:27+00:20')->format(DateTimeImmutable::RFC3339_EXTENDED));
 
         self::assertException(

--- a/tests/Compiler/Mapper/Object/MapDateTimeImmutableTest.php
+++ b/tests/Compiler/Mapper/Object/MapDateTimeImmutableTest.php
@@ -5,6 +5,7 @@ namespace ShipMonkTests\InputMapper\Compiler\Mapper\Object;
 use DateTimeImmutable;
 use ShipMonk\InputMapper\Compiler\Mapper\Object\MapDateTimeImmutable;
 use ShipMonk\InputMapper\Runtime\Exception\MappingFailedException;
+use ShipMonk\InputMapper\Runtime\Mapper;
 use ShipMonkTests\InputMapper\Compiler\Mapper\MapperCompilerTestCase;
 
 class MapDateTimeImmutableTest extends MapperCompilerTestCase
@@ -13,6 +14,8 @@ class MapDateTimeImmutableTest extends MapperCompilerTestCase
     public function testCompile(): void
     {
         $mapperCompiler = new MapDateTimeImmutable();
+
+        /** @var Mapper<DateTimeImmutable> $mapper */
         $mapper = $this->compileMapper('DateTimeImmutable', $mapperCompiler);
 
         self::assertSame('1985-04-12T23:20:50.000+00:00', $mapper->map('1985-04-12T23:20:50Z')->format(DateTimeImmutable::RFC3339_EXTENDED));
@@ -41,6 +44,8 @@ class MapDateTimeImmutableTest extends MapperCompilerTestCase
     public function testCompileWithTimeZone(): void
     {
         $mapperCompiler = new MapDateTimeImmutable(timezone: 'Europe/Prague');
+
+        /** @var Mapper<DateTimeImmutable> $mapper */
         $mapper = $this->compileMapper('DateTimeImmutableWithTimeZone', $mapperCompiler);
 
         self::assertSame('1985-04-13T01:20:50.000+02:00', $mapper->map('1985-04-12T23:20:50Z')->format(DateTimeImmutable::RFC3339_EXTENDED));
@@ -51,6 +56,8 @@ class MapDateTimeImmutableTest extends MapperCompilerTestCase
     public function testCompileWithCustomFormat(): void
     {
         $mapperCompiler = new MapDateTimeImmutable('!Y-m-d', 'date string in Y-m-d format');
+
+        /** @var Mapper<DateTimeImmutable> $mapper */
         $mapper = $this->compileMapper('Date', $mapperCompiler);
 
         self::assertSame('1985-04-12T00:00:00.000+00:00', $mapper->map('1985-04-12')->format(DateTimeImmutable::RFC3339_EXTENDED));
@@ -77,6 +84,8 @@ class MapDateTimeImmutableTest extends MapperCompilerTestCase
     public function testCompileWithCustomFormatAndTimeZone(): void
     {
         $mapperCompiler = new MapDateTimeImmutable(['!Y-m-d'], 'date string in Y-m-d format', 'Europe/Prague');
+
+        /** @var Mapper<DateTimeImmutable> $mapper */
         $mapper = $this->compileMapper('DateWithTimeZone', $mapperCompiler);
 
         self::assertSame('1985-04-12T00:00:00.000+02:00', $mapper->map('1985-04-12')->format(DateTimeImmutable::RFC3339_EXTENDED));


### PR DESCRIPTION
Because its a compiler, adding new options like this have not performance overhead if you dont need them.