### PR TITLE
Type aware validators

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -48,7 +48,7 @@
         "check:composer": "composer normalize --dry-run --no-check-lock --no-update-lock",
         "check:cs": "phpcs",
         "check:ec": "ec src tests",
-        "check:tests": "phpunit -vvv tests",
+        "check:tests": "phpunit tests",
         "check:types": "phpstan analyse -vvv",
         "fix:cs": "phpcbf"
     }

--- a/src/Compiler/Exception/CannotCompileMapperException.php
+++ b/src/Compiler/Exception/CannotCompileMapperException.php
@@ -3,19 +3,12 @@
 namespace ShipMonk\InputMapper\Compiler\Exception;
 
 use LogicException;
-use PHPStan\PhpDocParser\Ast\Type\TypeNode;
 use ShipMonk\InputMapper\Compiler\Mapper\MapperCompiler;
 use ShipMonk\InputMapper\Compiler\Validator\ValidatorCompiler;
 use Throwable;
 
-class CannotCreateMapperCompilerException extends LogicException
+class CannotCompileMapperException extends LogicException
 {
-
-    public static function fromType(TypeNode $type, ?string $reason = null, ?Throwable $previous = null): self
-    {
-        $reason = $reason !== null ? ", because {$reason}" : '';
-        return new self("Cannot create mapper for type {$type}{$reason}", 0, $previous);
-    }
 
     public static function withIncompatibleValidator(
         ValidatorCompiler $validatorCompiler,
@@ -26,8 +19,8 @@ class CannotCreateMapperCompilerException extends LogicException
         $validatorCompilerClass = $validatorCompiler::class;
         $validatorInputType = $validatorCompiler->getInputType();
         $mapperOutputType = $mapperCompiler->getOutputType();
-        $reason = "mapper output type {$mapperOutputType} is not compatible with validator input type {$validatorInputType}";
-        return new self("Cannot create mapper with validator {$validatorCompilerClass}, because {$reason}", 0, $previous);
+        $reason = "mapper output type '{$mapperOutputType}' is not compatible with validator input type '{$validatorInputType}'";
+        return new self("Cannot compile mapper with validator {$validatorCompilerClass}, because {$reason}", 0, $previous);
     }
 
 }

--- a/src/Compiler/Exception/CannotCompileMapperException.php
+++ b/src/Compiler/Exception/CannotCompileMapperException.php
@@ -3,12 +3,26 @@
 namespace ShipMonk\InputMapper\Compiler\Exception;
 
 use LogicException;
+use PHPStan\PhpDocParser\Ast\Type\TypeNode;
 use ShipMonk\InputMapper\Compiler\Mapper\MapperCompiler;
 use ShipMonk\InputMapper\Compiler\Validator\ValidatorCompiler;
 use Throwable;
 
 class CannotCompileMapperException extends LogicException
 {
+
+    public static function withIncompatibleMapper(
+        MapperCompiler $mapperCompiler,
+        TypeNode $inputType,
+        ?Throwable $previous = null
+    ): self
+    {
+        $mapperCompilerClass = $mapperCompiler::class;
+        $mapperInputType = $mapperCompiler->getInputType();
+
+        $reason = "its input type '{$mapperInputType}' is not super type of '{$inputType}'";
+        return new self("Cannot compile mapper {$mapperCompilerClass}, because {$reason}", 0, $previous);
+    }
 
     public static function withIncompatibleValidator(
         ValidatorCompiler $validatorCompiler,

--- a/src/Compiler/Mapper/Array/MapArray.php
+++ b/src/Compiler/Mapper/Array/MapArray.php
@@ -55,15 +55,15 @@ class MapArray implements MapperCompiler
         return new CompiledExpr($builder->var($mappedVariableName), $statements);
     }
 
-    public function getInputType(PhpCodeBuilder $builder): TypeNode
+    public function getInputType(): TypeNode
     {
         return new IdentifierTypeNode('mixed');
     }
 
-    public function getOutputType(PhpCodeBuilder $builder): TypeNode
+    public function getOutputType(): TypeNode
     {
-        $keyType = $this->keyMapperCompiler->getOutputType($builder);
-        $valueType = $this->valueMapperCompiler->getOutputType($builder);
+        $keyType = $this->keyMapperCompiler->getOutputType();
+        $valueType = $this->valueMapperCompiler->getOutputType();
         $args = PhpDocTypeUtils::isMixed($keyType) ? [$valueType] : [$keyType, $valueType];
         return new GenericTypeNode(new IdentifierTypeNode('array'), $args);
     }

--- a/src/Compiler/Mapper/Array/MapArrayShape.php
+++ b/src/Compiler/Mapper/Array/MapArrayShape.php
@@ -91,12 +91,12 @@ class MapArrayShape implements MapperCompiler
         return new CompiledExpr($builder->var($mappedVariableName), $statements);
     }
 
-    public function getInputType(PhpCodeBuilder $builder): TypeNode
+    public function getInputType(): TypeNode
     {
         return new IdentifierTypeNode('mixed');
     }
 
-    public function getOutputType(PhpCodeBuilder $builder): TypeNode
+    public function getOutputType(): TypeNode
     {
         $items = [];
 
@@ -104,7 +104,7 @@ class MapArrayShape implements MapperCompiler
             $items[] = new ArrayShapeItemNode(
                 new ConstExprStringNode($mapping->key),
                 $mapping->optional,
-                $mapping->mapper->getOutputType($builder),
+                $mapping->mapper->getOutputType(),
             );
         }
 

--- a/src/Compiler/Mapper/Array/MapList.php
+++ b/src/Compiler/Mapper/Array/MapList.php
@@ -55,14 +55,14 @@ class MapList implements MapperCompiler
         return new CompiledExpr($builder->var($mappedVariableName), $statements);
     }
 
-    public function getInputType(PhpCodeBuilder $builder): TypeNode
+    public function getInputType(): TypeNode
     {
         return new IdentifierTypeNode('mixed');
     }
 
-    public function getOutputType(PhpCodeBuilder $builder): TypeNode
+    public function getOutputType(): TypeNode
     {
-        $itemType = $this->itemMapperCompiler->getOutputType($builder);
+        $itemType = $this->itemMapperCompiler->getOutputType();
         return new GenericTypeNode(new IdentifierTypeNode('list'), [$itemType]);
     }
 

--- a/src/Compiler/Mapper/MapperCompiler.php
+++ b/src/Compiler/Mapper/MapperCompiler.php
@@ -12,8 +12,8 @@ interface MapperCompiler
 
     public function compile(Expr $value, Expr $path, PhpCodeBuilder $builder): CompiledExpr;
 
-    public function getInputType(PhpCodeBuilder $builder): TypeNode;
+    public function getInputType(): TypeNode;
 
-    public function getOutputType(PhpCodeBuilder $builder): TypeNode;
+    public function getOutputType(): TypeNode;
 
 }

--- a/src/Compiler/Mapper/MapperCompiler.php
+++ b/src/Compiler/Mapper/MapperCompiler.php
@@ -5,11 +5,15 @@ namespace ShipMonk\InputMapper\Compiler\Mapper;
 use PhpParser\Node\Expr;
 use PHPStan\PhpDocParser\Ast\Type\TypeNode;
 use ShipMonk\InputMapper\Compiler\CompiledExpr;
+use ShipMonk\InputMapper\Compiler\Exception\CannotCompileMapperException;
 use ShipMonk\InputMapper\Compiler\Php\PhpCodeBuilder;
 
 interface MapperCompiler
 {
 
+    /**
+     * @throws CannotCompileMapperException
+     */
     public function compile(Expr $value, Expr $path, PhpCodeBuilder $builder): CompiledExpr;
 
     public function getInputType(): TypeNode;

--- a/src/Compiler/Mapper/Mixed/MapMixed.php
+++ b/src/Compiler/Mapper/Mixed/MapMixed.php
@@ -19,12 +19,12 @@ class MapMixed implements MapperCompiler
         return new CompiledExpr($value);
     }
 
-    public function getInputType(PhpCodeBuilder $builder): TypeNode
+    public function getInputType(): TypeNode
     {
         return new IdentifierTypeNode('mixed');
     }
 
-    public function getOutputType(PhpCodeBuilder $builder): TypeNode
+    public function getOutputType(): TypeNode
     {
         return new IdentifierTypeNode('mixed');
     }

--- a/src/Compiler/Mapper/Object/DelegateMapperCompiler.php
+++ b/src/Compiler/Mapper/Object/DelegateMapperCompiler.php
@@ -31,14 +31,14 @@ class DelegateMapperCompiler implements MapperCompiler
         return new CompiledExpr($mapped);
     }
 
-    public function getInputType(PhpCodeBuilder $builder): TypeNode
+    public function getInputType(): TypeNode
     {
         return new IdentifierTypeNode('mixed');
     }
 
-    public function getOutputType(PhpCodeBuilder $builder): TypeNode
+    public function getOutputType(): TypeNode
     {
-        return new IdentifierTypeNode($builder->importClass($this->className));
+        return new IdentifierTypeNode($this->className);
     }
 
 }

--- a/src/Compiler/Mapper/Object/MapDateTimeImmutable.php
+++ b/src/Compiler/Mapper/Object/MapDateTimeImmutable.php
@@ -116,14 +116,14 @@ class MapDateTimeImmutable implements MapperCompiler
         return new CompiledExpr($builder->var($mappedVariableName), $statements);
     }
 
-    public function getInputType(PhpCodeBuilder $builder): TypeNode
+    public function getInputType(): TypeNode
     {
         return new IdentifierTypeNode('mixed');
     }
 
-    public function getOutputType(PhpCodeBuilder $builder): TypeNode
+    public function getOutputType(): TypeNode
     {
-        return new IdentifierTypeNode($builder->importClass(DateTimeImmutable::class));
+        return new IdentifierTypeNode(DateTimeImmutable::class);
     }
 
 }

--- a/src/Compiler/Mapper/Object/MapEnum.php
+++ b/src/Compiler/Mapper/Object/MapEnum.php
@@ -59,14 +59,14 @@ class MapEnum implements MapperCompiler
         return new CompiledExpr($builder->var($enumVariableName), $statements);
     }
 
-    public function getInputType(PhpCodeBuilder $builder): TypeNode
+    public function getInputType(): TypeNode
     {
-        return $this->backingValueMapperCompiler->getInputType($builder);
+        return $this->backingValueMapperCompiler->getInputType();
     }
 
-    public function getOutputType(PhpCodeBuilder $builder): TypeNode
+    public function getOutputType(): TypeNode
     {
-        return new IdentifierTypeNode($builder->importClass($this->enumName));
+        return new IdentifierTypeNode($this->enumName);
     }
 
 }

--- a/src/Compiler/Mapper/Object/MapObject.php
+++ b/src/Compiler/Mapper/Object/MapObject.php
@@ -107,14 +107,14 @@ class MapObject implements MapperCompiler
         );
     }
 
-    public function getInputType(PhpCodeBuilder $builder): TypeNode
+    public function getInputType(): TypeNode
     {
         return new IdentifierTypeNode('mixed');
     }
 
-    public function getOutputType(PhpCodeBuilder $builder): TypeNode
+    public function getOutputType(): TypeNode
     {
-        return new IdentifierTypeNode($builder->importClass($this->className));
+        return new IdentifierTypeNode($this->className);
     }
 
     /**

--- a/src/Compiler/Mapper/Scalar/MapBool.php
+++ b/src/Compiler/Mapper/Scalar/MapBool.php
@@ -32,12 +32,12 @@ class MapBool implements MapperCompiler
         return new CompiledExpr($value, $statements);
     }
 
-    public function getInputType(PhpCodeBuilder $builder): TypeNode
+    public function getInputType(): TypeNode
     {
         return new IdentifierTypeNode('mixed');
     }
 
-    public function getOutputType(PhpCodeBuilder $builder): TypeNode
+    public function getOutputType(): TypeNode
     {
         return new IdentifierTypeNode('bool');
     }

--- a/src/Compiler/Mapper/Scalar/MapFloat.php
+++ b/src/Compiler/Mapper/Scalar/MapFloat.php
@@ -71,12 +71,12 @@ class MapFloat implements MapperCompiler
         return new CompiledExpr($builder->var($mappedVariableName), $statements);
     }
 
-    public function getInputType(PhpCodeBuilder $builder): TypeNode
+    public function getInputType(): TypeNode
     {
         return new IdentifierTypeNode('mixed');
     }
 
-    public function getOutputType(PhpCodeBuilder $builder): TypeNode
+    public function getOutputType(): TypeNode
     {
         return new IdentifierTypeNode('float');
     }

--- a/src/Compiler/Mapper/Scalar/MapInt.php
+++ b/src/Compiler/Mapper/Scalar/MapInt.php
@@ -32,12 +32,12 @@ class MapInt implements MapperCompiler
         return new CompiledExpr($value, $statements);
     }
 
-    public function getInputType(PhpCodeBuilder $builder): TypeNode
+    public function getInputType(): TypeNode
     {
         return new IdentifierTypeNode('mixed');
     }
 
-    public function getOutputType(PhpCodeBuilder $builder): TypeNode
+    public function getOutputType(): TypeNode
     {
         return new IdentifierTypeNode('int');
     }

--- a/src/Compiler/Mapper/Scalar/MapString.php
+++ b/src/Compiler/Mapper/Scalar/MapString.php
@@ -32,12 +32,12 @@ class MapString implements MapperCompiler
         return new CompiledExpr($value, $statements);
     }
 
-    public function getInputType(PhpCodeBuilder $builder): TypeNode
+    public function getInputType(): TypeNode
     {
         return new IdentifierTypeNode('mixed');
     }
 
-    public function getOutputType(PhpCodeBuilder $builder): TypeNode
+    public function getOutputType(): TypeNode
     {
         return new IdentifierTypeNode('string');
     }

--- a/src/Compiler/Mapper/Wrapper/ChainMapperCompiler.php
+++ b/src/Compiler/Mapper/Wrapper/ChainMapperCompiler.php
@@ -47,16 +47,16 @@ class ChainMapperCompiler implements MapperCompiler
         return new CompiledExpr($value, $statements);
     }
 
-    public function getInputType(PhpCodeBuilder $builder): TypeNode
+    public function getInputType(): TypeNode
     {
         $first = 0;
-        return $this->mapperCompilers[$first]->getInputType($builder);
+        return $this->mapperCompilers[$first]->getInputType();
     }
 
-    public function getOutputType(PhpCodeBuilder $builder): TypeNode
+    public function getOutputType(): TypeNode
     {
         $last = count($this->mapperCompilers) - 1;
-        return $this->mapperCompilers[$last]->getOutputType($builder);
+        return $this->mapperCompilers[$last]->getOutputType();
     }
 
 }

--- a/src/Compiler/Mapper/Wrapper/MapNullable.php
+++ b/src/Compiler/Mapper/Wrapper/MapNullable.php
@@ -41,14 +41,14 @@ class MapNullable implements MapperCompiler
         return new CompiledExpr($builder->var($mappedVariableName), $statements);
     }
 
-    public function getInputType(PhpCodeBuilder $builder): TypeNode
+    public function getInputType(): TypeNode
     {
-        return PhpDocTypeUtils::makeNullable($this->innerMapperCompiler->getInputType($builder));
+        return PhpDocTypeUtils::makeNullable($this->innerMapperCompiler->getInputType());
     }
 
-    public function getOutputType(PhpCodeBuilder $builder): TypeNode
+    public function getOutputType(): TypeNode
     {
-        return PhpDocTypeUtils::makeNullable($this->innerMapperCompiler->getOutputType($builder));
+        return PhpDocTypeUtils::makeNullable($this->innerMapperCompiler->getOutputType());
     }
 
 }

--- a/src/Compiler/Mapper/Wrapper/MapOptional.php
+++ b/src/Compiler/Mapper/Wrapper/MapOptional.php
@@ -36,16 +36,16 @@ class MapOptional implements UndefinedAwareMapperCompiler
         return new CompiledExpr($mapped);
     }
 
-    public function getInputType(PhpCodeBuilder $builder): TypeNode
+    public function getInputType(): TypeNode
     {
-        return $this->mapperCompiler->getInputType($builder);
+        return $this->mapperCompiler->getInputType();
     }
 
-    public function getOutputType(PhpCodeBuilder $builder): TypeNode
+    public function getOutputType(): TypeNode
     {
         return new GenericTypeNode(
-            new IdentifierTypeNode($builder->importClass(Optional::class)),
-            [$this->mapperCompiler->getOutputType($builder)],
+            new IdentifierTypeNode(Optional::class),
+            [$this->mapperCompiler->getOutputType()],
         );
     }
 

--- a/src/Compiler/Mapper/Wrapper/ValidatedMapperCompiler.php
+++ b/src/Compiler/Mapper/Wrapper/ValidatedMapperCompiler.php
@@ -6,8 +6,10 @@ use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\Variable;
 use PHPStan\PhpDocParser\Ast\Type\TypeNode;
 use ShipMonk\InputMapper\Compiler\CompiledExpr;
+use ShipMonk\InputMapper\Compiler\Exception\CannotCompileMapperException;
 use ShipMonk\InputMapper\Compiler\Mapper\MapperCompiler;
 use ShipMonk\InputMapper\Compiler\Php\PhpCodeBuilder;
+use ShipMonk\InputMapper\Compiler\Type\PhpDocTypeUtils;
 use ShipMonk\InputMapper\Compiler\Validator\ValidatorCompiler;
 
 class ValidatedMapperCompiler implements MapperCompiler
@@ -23,9 +25,13 @@ class ValidatedMapperCompiler implements MapperCompiler
     {
     }
 
+    /**
+     * @throws CannotCompileMapperException
+     */
     public function compile(Expr $value, Expr $path, PhpCodeBuilder $builder): CompiledExpr
     {
         $mapper = $this->mapperCompiler->compile($value, $path, $builder);
+        $mapperOutputType = $this->mapperCompiler->getOutputType();
         $statements = $mapper->statements;
 
         if ($mapper->expr instanceof Variable) {
@@ -38,6 +44,12 @@ class ValidatedMapperCompiler implements MapperCompiler
         }
 
         foreach ($this->validatorCompilers as $validatorCompiler) {
+            $validatorInputType = $validatorCompiler->getInputType();
+
+            if (!PhpDocTypeUtils::isSubTypeOf($mapperOutputType, $validatorInputType)) {
+                throw CannotCompileMapperException::withIncompatibleValidator($validatorCompiler, $this->mapperCompiler);
+            }
+
             foreach ($validatorCompiler->compile($mapperVariable, $path, $builder) as $statement) {
                 $statements[] = $statement;
             }

--- a/src/Compiler/Mapper/Wrapper/ValidatedMapperCompiler.php
+++ b/src/Compiler/Mapper/Wrapper/ValidatedMapperCompiler.php
@@ -46,14 +46,14 @@ class ValidatedMapperCompiler implements MapperCompiler
         return new CompiledExpr($mapperVariable, $statements);
     }
 
-    public function getInputType(PhpCodeBuilder $builder): TypeNode
+    public function getInputType(): TypeNode
     {
-        return $this->mapperCompiler->getInputType($builder);
+        return $this->mapperCompiler->getInputType();
     }
 
-    public function getOutputType(PhpCodeBuilder $builder): TypeNode
+    public function getOutputType(): TypeNode
     {
-        return $this->mapperCompiler->getOutputType($builder);
+        return $this->mapperCompiler->getOutputType();
     }
 
 }

--- a/src/Compiler/Mapper/Wrapper/ValidatedMapperCompiler.php
+++ b/src/Compiler/Mapper/Wrapper/ValidatedMapperCompiler.php
@@ -50,7 +50,7 @@ class ValidatedMapperCompiler implements MapperCompiler
                 throw CannotCompileMapperException::withIncompatibleValidator($validatorCompiler, $this->mapperCompiler);
             }
 
-            foreach ($validatorCompiler->compile($mapperVariable, $path, $builder) as $statement) {
+            foreach ($validatorCompiler->compile($mapperVariable, $mapperOutputType, $path, $builder) as $statement) {
                 $statements[] = $statement;
             }
         }

--- a/src/Compiler/Validator/Array/AssertListItem.php
+++ b/src/Compiler/Validator/Array/AssertListItem.php
@@ -29,7 +29,7 @@ class AssertListItem implements ValidatorCompiler
     /**
      * @return list<Stmt>
      */
-    public function compile(Expr $value, Expr $path, PhpCodeBuilder $builder): array
+    public function compile(Expr $value, TypeNode $type, Expr $path, PhpCodeBuilder $builder): array
     {
         [$itemVariableName, $indexVariableName] = $builder->uniqVariableNames('item', 'index');
         $foreachBody = [];
@@ -38,7 +38,7 @@ class AssertListItem implements ValidatorCompiler
             $itemValue = $builder->var($itemVariableName);
             $itemPath = $builder->arrayImmutableAppend($path, $builder->var($indexVariableName));
 
-            foreach ($validator->compile($itemValue, $itemPath, $builder) as $statement) {
+            foreach ($validator->compile($itemValue, $type, $itemPath, $builder) as $statement) {
                 $foreachBody[] = $statement;
             }
         }

--- a/src/Compiler/Validator/AssertRuntime.php
+++ b/src/Compiler/Validator/AssertRuntime.php
@@ -5,6 +5,8 @@ namespace ShipMonk\InputMapper\Compiler\Validator;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Stmt;
 use PhpParser\Node\Stmt\Expression;
+use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
+use PHPStan\PhpDocParser\Ast\Type\TypeNode;
 use ShipMonk\InputMapper\Compiler\Php\PhpCodeBuilder;
 use ShipMonk\InputMapper\Runtime\Exception\MappingFailedException;
 
@@ -35,6 +37,11 @@ abstract class AssertRuntime implements ValidatorCompiler
                 ),
             ),
         ];
+    }
+
+    public function getInputType(): TypeNode
+    {
+        return new IdentifierTypeNode('mixed');
     }
 
 }

--- a/src/Compiler/Validator/AssertRuntime.php
+++ b/src/Compiler/Validator/AssertRuntime.php
@@ -24,6 +24,7 @@ abstract class AssertRuntime implements ValidatorCompiler
      */
     public function compile(
         Expr $value,
+        TypeNode $type,
         Expr $path,
         PhpCodeBuilder $builder,
     ): array

--- a/src/Compiler/Validator/Float/AssertFloatMultipleOf.php
+++ b/src/Compiler/Validator/Float/AssertFloatMultipleOf.php
@@ -28,6 +28,7 @@ class AssertFloatMultipleOf implements ValidatorCompiler
      */
     public function compile(
         Expr $value,
+        TypeNode $type,
         Expr $path,
         PhpCodeBuilder $builder,
     ): array

--- a/src/Compiler/Validator/Float/AssertFloatMultipleOf.php
+++ b/src/Compiler/Validator/Float/AssertFloatMultipleOf.php
@@ -7,6 +7,8 @@ use Nette\Utils\Floats;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\BinaryOp\Div;
 use PhpParser\Node\Stmt;
+use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
+use PHPStan\PhpDocParser\Ast\Type\TypeNode;
 use ShipMonk\InputMapper\Compiler\Php\PhpCodeBuilder;
 use ShipMonk\InputMapper\Compiler\Validator\ValidatorCompiler;
 use ShipMonk\InputMapper\Runtime\Exception\MappingFailedException;
@@ -30,14 +32,12 @@ class AssertFloatMultipleOf implements ValidatorCompiler
         PhpCodeBuilder $builder,
     ): array
     {
-        $isFloat = $builder->funcCall($builder->importFunction('is_float'), [$value]);
-
         $isMultipleOf = $builder->staticCall($builder->importClass(Floats::class), 'isInteger', [
             new Div($value, $builder->val($this->value)),
         ]);
 
         return [
-            $builder->if($builder->and($isFloat, $builder->not($isMultipleOf)), [
+            $builder->if($builder->not($isMultipleOf), [
                 $builder->throw(
                     $builder->staticCall(
                         $builder->importClass(MappingFailedException::class),
@@ -47,6 +47,11 @@ class AssertFloatMultipleOf implements ValidatorCompiler
                 ),
             ]),
         ];
+    }
+
+    public function getInputType(): TypeNode
+    {
+        return new IdentifierTypeNode('float');
     }
 
 }

--- a/src/Compiler/Validator/Float/AssertFloatRange.php
+++ b/src/Compiler/Validator/Float/AssertFloatRange.php
@@ -6,10 +6,11 @@ use Attribute;
 use Nette\Utils\Floats;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Stmt;
+use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
+use PHPStan\PhpDocParser\Ast\Type\TypeNode;
 use ShipMonk\InputMapper\Compiler\Php\PhpCodeBuilder;
 use ShipMonk\InputMapper\Compiler\Validator\ValidatorCompiler;
 use ShipMonk\InputMapper\Runtime\Exception\MappingFailedException;
-use function count;
 
 #[Attribute(Attribute::TARGET_PARAMETER | Attribute::TARGET_PROPERTY)]
 class AssertFloatRange implements ValidatorCompiler
@@ -83,12 +84,12 @@ class AssertFloatRange implements ValidatorCompiler
             ]);
         }
 
-        if (count($statements) > 0) {
-            $isFloat = $builder->funcCall($builder->importFunction('is_float'), [$value]);
-            $statements = [$builder->if($isFloat, $statements)];
-        }
-
         return $statements;
+    }
+
+    public function getInputType(): TypeNode
+    {
+        return new IdentifierTypeNode('float');
     }
 
 }

--- a/src/Compiler/Validator/Float/AssertFloatRange.php
+++ b/src/Compiler/Validator/Float/AssertFloatRange.php
@@ -30,6 +30,7 @@ class AssertFloatRange implements ValidatorCompiler
      */
     public function compile(
         Expr $value,
+        TypeNode $type,
         Expr $path,
         PhpCodeBuilder $builder,
     ): array

--- a/src/Compiler/Validator/Int/AssertIntMultipleOf.php
+++ b/src/Compiler/Validator/Int/AssertIntMultipleOf.php
@@ -27,6 +27,7 @@ class AssertIntMultipleOf implements ValidatorCompiler
      */
     public function compile(
         Expr $value,
+        TypeNode $type,
         Expr $path,
         PhpCodeBuilder $builder,
     ): array

--- a/src/Compiler/Validator/Int/AssertIntMultipleOf.php
+++ b/src/Compiler/Validator/Int/AssertIntMultipleOf.php
@@ -6,6 +6,8 @@ use Attribute;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\BinaryOp\Mod;
 use PhpParser\Node\Stmt;
+use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
+use PHPStan\PhpDocParser\Ast\Type\TypeNode;
 use ShipMonk\InputMapper\Compiler\Php\PhpCodeBuilder;
 use ShipMonk\InputMapper\Compiler\Validator\ValidatorCompiler;
 use ShipMonk\InputMapper\Runtime\Exception\MappingFailedException;
@@ -29,11 +31,10 @@ class AssertIntMultipleOf implements ValidatorCompiler
         PhpCodeBuilder $builder,
     ): array
     {
-        $isInt = $builder->funcCall($builder->importFunction('is_int'), [$value]);
         $modulo = new Mod($value, $builder->val($this->value));
 
         return [
-            $builder->if($builder->and($isInt, $builder->notSame($modulo, $builder->val(0))), [
+            $builder->if($builder->notSame($modulo, $builder->val(0)), [
                 $builder->throw(
                     $builder->staticCall(
                         $builder->importClass(MappingFailedException::class),
@@ -43,6 +44,11 @@ class AssertIntMultipleOf implements ValidatorCompiler
                 ),
             ]),
         ];
+    }
+
+    public function getInputType(): TypeNode
+    {
+        return new IdentifierTypeNode('int');
     }
 
 }

--- a/src/Compiler/Validator/Int/AssertIntRange.php
+++ b/src/Compiler/Validator/Int/AssertIntRange.php
@@ -5,10 +5,11 @@ namespace ShipMonk\InputMapper\Compiler\Validator\Int;
 use Attribute;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Stmt;
+use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
+use PHPStan\PhpDocParser\Ast\Type\TypeNode;
 use ShipMonk\InputMapper\Compiler\Php\PhpCodeBuilder;
 use ShipMonk\InputMapper\Compiler\Validator\ValidatorCompiler;
 use ShipMonk\InputMapper\Runtime\Exception\MappingFailedException;
-use function count;
 
 #[Attribute(Attribute::TARGET_PARAMETER | Attribute::TARGET_PROPERTY)]
 class AssertIntRange implements ValidatorCompiler
@@ -82,12 +83,12 @@ class AssertIntRange implements ValidatorCompiler
             ]);
         }
 
-        if (count($statements) > 0) {
-            $isInt = $builder->funcCall($builder->importFunction('is_int'), [$value]);
-            $statements = [$builder->if($isInt, $statements)];
-        }
-
         return $statements;
+    }
+
+    public function getInputType(): TypeNode
+    {
+        return new IdentifierTypeNode('int');
     }
 
 }

--- a/src/Compiler/Validator/Int/AssertIntRange.php
+++ b/src/Compiler/Validator/Int/AssertIntRange.php
@@ -29,6 +29,7 @@ class AssertIntRange implements ValidatorCompiler
      */
     public function compile(
         Expr $value,
+        TypeNode $type,
         Expr $path,
         PhpCodeBuilder $builder,
     ): array

--- a/src/Compiler/Validator/Object/AssertDateTimeRange.php
+++ b/src/Compiler/Validator/Object/AssertDateTimeRange.php
@@ -9,6 +9,8 @@ use DateTimeZone;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Stmt;
 use PhpParser\Node\Stmt\Throw_;
+use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
+use PHPStan\PhpDocParser\Ast\Type\TypeNode;
 use ShipMonk\InputMapper\Compiler\Php\PhpCodeBuilder;
 use ShipMonk\InputMapper\Compiler\Validator\ValidatorCompiler;
 use ShipMonk\InputMapper\Runtime\Exception\MappingFailedException;
@@ -83,12 +85,9 @@ class AssertDateTimeRange implements ValidatorCompiler
         }
 
         if (count($statements) > 0) {
-            $isDateTime = $builder->instanceOf($value, $builder->importClass(DateTimeInterface::class));
             $statements = [
-                $builder->if($isDateTime, [
-                    ...$timezoneInitStatements,
-                    ...$statements,
-                ]),
+                ...$timezoneInitStatements,
+                ...$statements,
             ];
         }
 
@@ -114,6 +113,11 @@ class AssertDateTimeRange implements ValidatorCompiler
                 [$value, $path, $builder->val("value {$boundaryDescription} {$boundaryValue}")],
             ),
         );
+    }
+
+    public function getInputType(): TypeNode
+    {
+        return new IdentifierTypeNode(DateTimeInterface::class);
     }
 
 }

--- a/src/Compiler/Validator/Object/AssertDateTimeRange.php
+++ b/src/Compiler/Validator/Object/AssertDateTimeRange.php
@@ -35,6 +35,7 @@ class AssertDateTimeRange implements ValidatorCompiler
      */
     public function compile(
         Expr $value,
+        TypeNode $type,
         Expr $path,
         PhpCodeBuilder $builder,
     ): array

--- a/src/Compiler/Validator/String/AssertStringLength.php
+++ b/src/Compiler/Validator/String/AssertStringLength.php
@@ -39,6 +39,7 @@ class AssertStringLength implements ValidatorCompiler
      */
     public function compile(
         Expr $value,
+        TypeNode $type,
         Expr $path,
         PhpCodeBuilder $builder,
     ): array

--- a/src/Compiler/Validator/String/AssertStringLength.php
+++ b/src/Compiler/Validator/String/AssertStringLength.php
@@ -6,10 +6,11 @@ use Attribute;
 use LogicException;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Stmt;
+use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
+use PHPStan\PhpDocParser\Ast\Type\TypeNode;
 use ShipMonk\InputMapper\Compiler\Php\PhpCodeBuilder;
 use ShipMonk\InputMapper\Compiler\Validator\ValidatorCompiler;
 use ShipMonk\InputMapper\Runtime\Exception\MappingFailedException;
-use function count;
 
 #[Attribute(Attribute::TARGET_PARAMETER | Attribute::TARGET_PROPERTY)]
 class AssertStringLength implements ValidatorCompiler
@@ -82,12 +83,12 @@ class AssertStringLength implements ValidatorCompiler
             }
         }
 
-        if (count($statements) > 0) {
-            $isString = $builder->funcCall($builder->importFunction('is_string'), [$value]);
-            $statements = [$builder->if($isString, $statements)];
-        }
-
         return $statements;
+    }
+
+    public function getInputType(): TypeNode
+    {
+        return new IdentifierTypeNode('string');
     }
 
 }

--- a/src/Compiler/Validator/String/AssertStringMatches.php
+++ b/src/Compiler/Validator/String/AssertStringMatches.php
@@ -5,6 +5,8 @@ namespace ShipMonk\InputMapper\Compiler\Validator\String;
 use Attribute;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Stmt;
+use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
+use PHPStan\PhpDocParser\Ast\Type\TypeNode;
 use ShipMonk\InputMapper\Compiler\Php\PhpCodeBuilder;
 use ShipMonk\InputMapper\Compiler\Validator\ValidatorCompiler;
 use ShipMonk\InputMapper\Runtime\Exception\MappingFailedException;
@@ -29,11 +31,10 @@ class AssertStringMatches implements ValidatorCompiler
         PhpCodeBuilder $builder,
     ): array
     {
-        $isString = $builder->funcCall($builder->importFunction('is_string'), [$value]);
         $matchCount = $builder->funcCall($builder->importFunction('preg_match'), [$builder->val($this->pattern), $value]);
 
         return [
-            $builder->if($builder->and($isString, $builder->notSame($matchCount, $builder->val(1))), [
+            $builder->if($builder->notSame($matchCount, $builder->val(1)), [
                 $builder->throw(
                     $builder->staticCall(
                         $builder->importClass(MappingFailedException::class),
@@ -43,6 +44,11 @@ class AssertStringMatches implements ValidatorCompiler
                 ),
             ]),
         ];
+    }
+
+    public function getInputType(): TypeNode
+    {
+        return new IdentifierTypeNode('string');
     }
 
 }

--- a/src/Compiler/Validator/String/AssertStringMatches.php
+++ b/src/Compiler/Validator/String/AssertStringMatches.php
@@ -27,6 +27,7 @@ class AssertStringMatches implements ValidatorCompiler
      */
     public function compile(
         Expr $value,
+        TypeNode $type,
         Expr $path,
         PhpCodeBuilder $builder,
     ): array

--- a/src/Compiler/Validator/String/AssertUrl.php
+++ b/src/Compiler/Validator/String/AssertUrl.php
@@ -6,6 +6,8 @@ use Attribute;
 use Nette\Utils\Validators;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Stmt;
+use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
+use PHPStan\PhpDocParser\Ast\Type\TypeNode;
 use ShipMonk\InputMapper\Compiler\Php\PhpCodeBuilder;
 use ShipMonk\InputMapper\Compiler\Validator\ValidatorCompiler;
 use ShipMonk\InputMapper\Runtime\Exception\MappingFailedException;
@@ -23,11 +25,10 @@ class AssertUrl implements ValidatorCompiler
         PhpCodeBuilder $builder,
     ): array
     {
-        $isString = $builder->funcCall($builder->importFunction('is_string'), [$value]);
         $isUrl = $builder->staticCall($builder->importClass(Validators::class), 'isUrl', [$value]);
 
         return [
-            $builder->if($builder->and($isString, $builder->not($isUrl)), [
+            $builder->if($builder->not($isUrl), [
                 $builder->throw(
                     $builder->staticCall(
                         $builder->importClass(MappingFailedException::class),
@@ -37,6 +38,11 @@ class AssertUrl implements ValidatorCompiler
                 ),
             ]),
         ];
+    }
+
+    public function getInputType(): TypeNode
+    {
+        return new IdentifierTypeNode('string');
     }
 
 }

--- a/src/Compiler/Validator/String/AssertUrl.php
+++ b/src/Compiler/Validator/String/AssertUrl.php
@@ -21,6 +21,7 @@ class AssertUrl implements ValidatorCompiler
      */
     public function compile(
         Expr $value,
+        TypeNode $type,
         Expr $path,
         PhpCodeBuilder $builder,
     ): array

--- a/src/Compiler/Validator/ValidatorCompiler.php
+++ b/src/Compiler/Validator/ValidatorCompiler.php
@@ -15,6 +15,7 @@ interface ValidatorCompiler
      */
     public function compile(
         Expr $value,
+        TypeNode $type,
         Expr $path,
         PhpCodeBuilder $builder,
     ): array;

--- a/src/Compiler/Validator/ValidatorCompiler.php
+++ b/src/Compiler/Validator/ValidatorCompiler.php
@@ -4,6 +4,7 @@ namespace ShipMonk\InputMapper\Compiler\Validator;
 
 use PhpParser\Node\Expr;
 use PhpParser\Node\Stmt;
+use PHPStan\PhpDocParser\Ast\Type\TypeNode;
 use ShipMonk\InputMapper\Compiler\Php\PhpCodeBuilder;
 
 interface ValidatorCompiler
@@ -17,5 +18,7 @@ interface ValidatorCompiler
         Expr $path,
         PhpCodeBuilder $builder,
     ): array;
+
+    public function getInputType(): TypeNode;
 
 }

--- a/tests/Compiler/Mapper/Data/MapMultiplyBySeven.php
+++ b/tests/Compiler/Mapper/Data/MapMultiplyBySeven.php
@@ -5,7 +5,6 @@ namespace ShipMonkTests\InputMapper\Compiler\Mapper\Data;
 use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
 use PHPStan\PhpDocParser\Ast\Type\TypeNode;
 use ShipMonk\InputMapper\Compiler\Mapper\MapRuntime;
-use ShipMonk\InputMapper\Compiler\Php\PhpCodeBuilder;
 use ShipMonk\InputMapper\Runtime\Exception\MappingFailedException;
 use function is_int;
 
@@ -21,12 +20,12 @@ class MapMultiplyBySeven extends MapRuntime
         return $value * 7;
     }
 
-    public function getInputType(PhpCodeBuilder $builder): TypeNode
+    public function getInputType(): TypeNode
     {
         return new IdentifierTypeNode('mixed');
     }
 
-    public function getOutputType(PhpCodeBuilder $builder): TypeNode
+    public function getOutputType(): TypeNode
     {
         return new IdentifierTypeNode('int');
     }

--- a/tests/Compiler/Mapper/Wrapper/ChainMapperCompilerTest.php
+++ b/tests/Compiler/Mapper/Wrapper/ChainMapperCompilerTest.php
@@ -1,0 +1,43 @@
+<?php declare(strict_types = 1);
+
+namespace ShipMonkTests\InputMapper\Compiler\Mapper\Wrapper;
+
+use ShipMonk\InputMapper\Compiler\Exception\CannotCompileMapperException;
+use ShipMonk\InputMapper\Compiler\Mapper\Scalar\MapInt;
+use ShipMonk\InputMapper\Compiler\Mapper\Scalar\MapString;
+use ShipMonk\InputMapper\Compiler\Mapper\Wrapper\ChainMapperCompiler;
+use ShipMonk\InputMapper\Runtime\Exception\MappingFailedException;
+use ShipMonkTests\InputMapper\Compiler\Mapper\MapperCompilerTestCase;
+use ShipMonkTests\InputMapper\Compiler\Mapper\Wrapper\Data\MapToDouble;
+
+class ChainMapperCompilerTest extends MapperCompilerTestCase
+{
+
+    public function testCompile(): void
+    {
+        $mapperCompiler = new ChainMapperCompiler([new MapInt(), new MapToDouble()]);
+        $mapper = $this->compileMapper('DoubleInt', $mapperCompiler);
+
+        self::assertSame(2, $mapper->map(1));
+        self::assertSame(4, $mapper->map(2));
+        self::assertSame(14, $mapper->map(7));
+
+        self::assertException(
+            MappingFailedException::class,
+            'Failed to map data at path /: Expected int, got "1"',
+            static fn() => $mapper->map('1'),
+        );
+    }
+
+    public function testCompileWithIncompatibleMapper(): void
+    {
+        $mapperCompiler = new ChainMapperCompiler([new MapString(), new MapToDouble()]);
+
+        self::assertException(
+            CannotCompileMapperException::class,
+            'Cannot compile mapper ShipMonkTests\InputMapper\Compiler\Mapper\Wrapper\Data\MapToDouble, because its input type \'int\' is not super type of \'string\'',
+            fn() => $this->compileMapper('DoubleIntIncompatible', $mapperCompiler),
+        );
+    }
+
+}

--- a/tests/Compiler/Mapper/Wrapper/Data/DoubleIntMapper.php
+++ b/tests/Compiler/Mapper/Wrapper/Data/DoubleIntMapper.php
@@ -1,0 +1,33 @@
+<?php declare (strict_types=1);
+
+namespace ShipMonkTests\InputMapper\Compiler\Mapper\Wrapper\Data;
+
+use ShipMonk\InputMapper\Runtime\Exception\MappingFailedException;
+use ShipMonk\InputMapper\Runtime\Mapper;
+use ShipMonk\InputMapper\Runtime\MapperProvider;
+use function is_int;
+
+/**
+ * Generated mapper. Do not edit directly.
+ *
+ * @implements Mapper<int>
+ */
+class DoubleIntMapper implements Mapper
+{
+    public function __construct(private readonly MapperProvider $provider)
+    {
+    }
+
+    /**
+     * @param  list<string|int> $path
+     * @throws MappingFailedException
+     */
+    public function map(mixed $data, array $path = []): int
+    {
+        if (!is_int($data)) {
+            throw MappingFailedException::incorrectType($data, $path, 'int');
+        }
+
+        return MapToDouble::mapValue($data, $path);
+    }
+}

--- a/tests/Compiler/Mapper/Wrapper/Data/MapToDouble.php
+++ b/tests/Compiler/Mapper/Wrapper/Data/MapToDouble.php
@@ -1,0 +1,30 @@
+<?php declare (strict_types = 1);
+
+namespace ShipMonkTests\InputMapper\Compiler\Mapper\Wrapper\Data;
+
+use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
+use PHPStan\PhpDocParser\Ast\Type\TypeNode;
+use ShipMonk\InputMapper\Compiler\Mapper\MapRuntime;
+use function assert;
+use function is_int;
+
+class MapToDouble extends MapRuntime
+{
+
+    public static function mapValue(mixed $value, array $path): int
+    {
+        assert(is_int($value));
+        return $value * 2;
+    }
+
+    public function getInputType(): TypeNode
+    {
+        return new IdentifierTypeNode('int');
+    }
+
+    public function getOutputType(): TypeNode
+    {
+        return new IdentifierTypeNode('int');
+    }
+
+}

--- a/tests/Compiler/MapperFactory/Data/CarInput.php
+++ b/tests/Compiler/MapperFactory/Data/CarInput.php
@@ -7,6 +7,7 @@ use ShipMonk\InputMapper\Compiler\Mapper\Scalar\MapInt;
 use ShipMonk\InputMapper\Compiler\Mapper\Wrapper\ValidatedMapperCompiler;
 use ShipMonk\InputMapper\Compiler\Validator\Int\AssertPositiveInt;
 use ShipMonk\InputMapper\Compiler\Validator\String\AssertStringLength;
+use ShipMonk\InputMapper\Compiler\Validator\String\AssertUrl;
 use ShipMonk\InputMapper\Runtime\Optional;
 
 class CarInput
@@ -23,6 +24,8 @@ class CarInput
         public readonly Optional $brand,
         #[MapList(new ValidatedMapperCompiler(new MapInt(), [new AssertPositiveInt()]))]
         public readonly array $numbers,
+        #[AssertUrl]
+        public readonly ?string $url,
     )
     {
     }

--- a/tests/Compiler/MapperFactory/Data/CarInputWithVarTags.php
+++ b/tests/Compiler/MapperFactory/Data/CarInputWithVarTags.php
@@ -7,6 +7,7 @@ use ShipMonk\InputMapper\Compiler\Mapper\Scalar\MapInt;
 use ShipMonk\InputMapper\Compiler\Mapper\Wrapper\ValidatedMapperCompiler;
 use ShipMonk\InputMapper\Compiler\Validator\Int\AssertPositiveInt;
 use ShipMonk\InputMapper\Compiler\Validator\String\AssertStringLength;
+use ShipMonk\InputMapper\Compiler\Validator\String\AssertUrl;
 use ShipMonk\InputMapper\Runtime\Optional;
 
 class CarInputWithVarTags
@@ -24,6 +25,9 @@ class CarInputWithVarTags
         /** @var array<int> */
         #[MapList(new ValidatedMapperCompiler(new MapInt(), [new AssertPositiveInt()]))]
         public readonly array $numbers,
+
+        #[AssertUrl]
+        public readonly ?string $url,
     )
     {
     }

--- a/tests/Compiler/MapperFactory/DefaultMapperCompilerFactoryTest.php
+++ b/tests/Compiler/MapperFactory/DefaultMapperCompilerFactoryTest.php
@@ -34,6 +34,7 @@ use ShipMonk\InputMapper\Compiler\MapperFactory\DefaultMapperCompilerFactory;
 use ShipMonk\InputMapper\Compiler\Validator\Int\AssertIntRange;
 use ShipMonk\InputMapper\Compiler\Validator\Int\AssertPositiveInt;
 use ShipMonk\InputMapper\Compiler\Validator\String\AssertStringLength;
+use ShipMonk\InputMapper\Compiler\Validator\String\AssertUrl;
 use ShipMonkTests\InputMapper\Compiler\MapperFactory\Data\BrandInput;
 use ShipMonkTests\InputMapper\Compiler\MapperFactory\Data\CarInput;
 use ShipMonkTests\InputMapper\Compiler\MapperFactory\Data\CarInputWithVarTags;
@@ -77,6 +78,7 @@ class DefaultMapperCompilerFactoryTest extends InputMapperTestCase
                 'name' => new ValidatedMapperCompiler(new MapString(), [new AssertStringLength(exact: 7)]),
                 'brand' => new MapOptional(new DelegateMapperCompiler(BrandInput::class)),
                 'numbers' => new MapList(new ValidatedMapperCompiler(new MapInt(), [new AssertPositiveInt()])),
+                'url' => new MapNullable(new ValidatedMapperCompiler(new MapString(), [new AssertUrl()])),
             ]),
         ];
 
@@ -88,6 +90,7 @@ class DefaultMapperCompilerFactoryTest extends InputMapperTestCase
                 'name' => new ValidatedMapperCompiler(new MapString(), [new AssertStringLength(exact: 7)]),
                 'brand' => new MapOptional(new DelegateMapperCompiler(BrandInput::class)),
                 'numbers' => new MapList(new ValidatedMapperCompiler(new MapInt(), [new AssertPositiveInt()])),
+                'url' => new MapNullable(new ValidatedMapperCompiler(new MapString(), [new AssertUrl()])),
             ]),
         ];
 

--- a/tests/Compiler/Validator/Array/Data/ListItemValidatorMapper.php
+++ b/tests/Compiler/Validator/Array/Data/ListItemValidatorMapper.php
@@ -12,7 +12,7 @@ use function is_int;
 /**
  * Generated mapper. Do not edit directly.
  *
- * @implements Mapper<mixed>
+ * @implements Mapper<list<int>>
  */
 class ListItemValidatorMapper implements Mapper
 {
@@ -22,21 +22,36 @@ class ListItemValidatorMapper implements Mapper
 
     /**
      * @param  list<string|int> $path
+     * @return list<int>
      * @throws MappingFailedException
      */
-    public function map(mixed $data, array $path = []): mixed
+    public function map(mixed $data, array $path = []): array
     {
-        if (is_array($data) && array_is_list($data)) {
-            foreach ($data as $index => $item) {
-                if (is_int($item)) {
-                    if ($item <= 0) {
-                        throw MappingFailedException::incorrectValue($item, [...$path, $index], 'value greater than 0');
+        if (!is_array($data) || !array_is_list($data)) {
+            throw MappingFailedException::incorrectType($data, $path, 'list');
+        }
+
+        $mapped = [];
+
+        foreach ($data as $index => $item) {
+            if (!is_int($item)) {
+                throw MappingFailedException::incorrectType($item, [...$path, $index], 'int');
+            }
+
+            $mapped[] = $item;
+        }
+
+        if (is_array($mapped) && array_is_list($mapped)) {
+            foreach ($mapped as $index2 => $item2) {
+                if (is_int($item2)) {
+                    if ($item2 <= 0) {
+                        throw MappingFailedException::incorrectValue($item2, [...$path, $index2], 'value greater than 0');
                     }
                 }
 
             }
         }
 
-        return $data;
+        return $mapped;
     }
 }

--- a/tests/Compiler/Validator/Array/Data/ListItemValidatorMapper.php
+++ b/tests/Compiler/Validator/Array/Data/ListItemValidatorMapper.php
@@ -41,14 +41,9 @@ class ListItemValidatorMapper implements Mapper
             $mapped[] = $item;
         }
 
-        if (is_array($mapped) && array_is_list($mapped)) {
-            foreach ($mapped as $index2 => $item2) {
-                if (is_int($item2)) {
-                    if ($item2 <= 0) {
-                        throw MappingFailedException::incorrectValue($item2, [...$path, $index2], 'value greater than 0');
-                    }
-                }
-
+        foreach ($mapped as $index2 => $item2) {
+            if ($item2 <= 0) {
+                throw MappingFailedException::incorrectValue($item2, [...$path, $index2], 'value greater than 0');
             }
         }
 

--- a/tests/Compiler/Validator/Array/Data/ListItemValidatorWithMultipleValidatorsMapper.php
+++ b/tests/Compiler/Validator/Array/Data/ListItemValidatorWithMultipleValidatorsMapper.php
@@ -41,19 +41,14 @@ class ListItemValidatorWithMultipleValidatorsMapper implements Mapper
             $mapped[] = $item;
         }
 
-        if (is_array($mapped) && array_is_list($mapped)) {
-            foreach ($mapped as $index2 => $item2) {
-                if (is_int($item2)) {
-                    if ($item2 <= 0) {
-                        throw MappingFailedException::incorrectValue($item2, [...$path, $index2], 'value greater than 0');
-                    }
-                }
-
-                if (is_int($item2) && $item2 % 5 !== 0) {
-                    throw MappingFailedException::incorrectValue($item2, [...$path, $index2], 'multiple of 5');
-                }
+        foreach ($mapped as $index2 => $item2) {
+            if ($item2 <= 0) {
+                throw MappingFailedException::incorrectValue($item2, [...$path, $index2], 'value greater than 0');
             }
 
+            if ($item2 % 5 !== 0) {
+                throw MappingFailedException::incorrectValue($item2, [...$path, $index2], 'multiple of 5');
+            }
         }
 
         return $mapped;

--- a/tests/Compiler/Validator/Array/Data/ListItemValidatorWithMultipleValidatorsMapper.php
+++ b/tests/Compiler/Validator/Array/Data/ListItemValidatorWithMultipleValidatorsMapper.php
@@ -8,13 +8,11 @@ use ShipMonk\InputMapper\Runtime\MapperProvider;
 use function array_is_list;
 use function is_array;
 use function is_int;
-use function is_string;
-use function strlen;
 
 /**
  * Generated mapper. Do not edit directly.
  *
- * @implements Mapper<mixed>
+ * @implements Mapper<list<int>>
  */
 class ListItemValidatorWithMultipleValidatorsMapper implements Mapper
 {
@@ -24,27 +22,40 @@ class ListItemValidatorWithMultipleValidatorsMapper implements Mapper
 
     /**
      * @param  list<string|int> $path
+     * @return list<int>
      * @throws MappingFailedException
      */
-    public function map(mixed $data, array $path = []): mixed
+    public function map(mixed $data, array $path = []): array
     {
-        if (is_array($data) && array_is_list($data)) {
-            foreach ($data as $index => $item) {
-                if (is_int($item)) {
-                    if ($item <= 0) {
-                        throw MappingFailedException::incorrectValue($item, [...$path, $index], 'value greater than 0');
-                    }
-                }
-
-                if (is_string($item)) {
-                    if (strlen($item) !== 5) {
-                        throw MappingFailedException::incorrectValue($item, [...$path, $index], 'string with exactly 5 characters');
-                    }
-                }
-
-            }
+        if (!is_array($data) || !array_is_list($data)) {
+            throw MappingFailedException::incorrectType($data, $path, 'list');
         }
 
-        return $data;
+        $mapped = [];
+
+        foreach ($data as $index => $item) {
+            if (!is_int($item)) {
+                throw MappingFailedException::incorrectType($item, [...$path, $index], 'int');
+            }
+
+            $mapped[] = $item;
+        }
+
+        if (is_array($mapped) && array_is_list($mapped)) {
+            foreach ($mapped as $index2 => $item2) {
+                if (is_int($item2)) {
+                    if ($item2 <= 0) {
+                        throw MappingFailedException::incorrectValue($item2, [...$path, $index2], 'value greater than 0');
+                    }
+                }
+
+                if (is_int($item2) && $item2 % 5 !== 0) {
+                    throw MappingFailedException::incorrectValue($item2, [...$path, $index2], 'multiple of 5');
+                }
+            }
+
+        }
+
+        return $mapped;
     }
 }

--- a/tests/Compiler/Validator/AssertRuntimeTest.php
+++ b/tests/Compiler/Validator/AssertRuntimeTest.php
@@ -2,6 +2,7 @@
 
 namespace ShipMonkTests\InputMapper\Compiler\Validator;
 
+use ShipMonk\InputMapper\Compiler\Mapper\Mixed\MapMixed;
 use ShipMonk\InputMapper\Runtime\Exception\MappingFailedException;
 use ShipMonkTests\InputMapper\Compiler\Validator\Data\AssertMultipleOfSeven;
 
@@ -10,9 +11,9 @@ class AssertRuntimeTest extends ValidatorCompilerTestCase
 
     public function testRuntimeValidator(): void
     {
+        $mapperCompiler = new MapMixed();
         $validatorCompiler = new AssertMultipleOfSeven();
-
-        $validator = $this->compileValidator('MultipleOfSevenValidator', $validatorCompiler);
+        $validator = $this->compileValidator('MultipleOfSevenValidator', $mapperCompiler, $validatorCompiler);
 
         $validator->map(0);
         $validator->map(7);

--- a/tests/Compiler/Validator/Float/AssertFloatMultipleOfTest.php
+++ b/tests/Compiler/Validator/Float/AssertFloatMultipleOfTest.php
@@ -2,6 +2,7 @@
 
 namespace ShipMonkTests\InputMapper\Compiler\Validator\Float;
 
+use ShipMonk\InputMapper\Compiler\Mapper\Scalar\MapFloat;
 use ShipMonk\InputMapper\Compiler\Validator\Float\AssertFloatMultipleOf;
 use ShipMonk\InputMapper\Runtime\Exception\MappingFailedException;
 use ShipMonkTests\InputMapper\Compiler\Validator\ValidatorCompilerTestCase;
@@ -11,8 +12,9 @@ class AssertFloatMultipleOfTest extends ValidatorCompilerTestCase
 
     public function testFloatWithAtMostTwoDecimalPlaces(): void
     {
+        $mapperCompiler = new MapFloat();
         $validatorCompiler = new AssertFloatMultipleOf(0.01);
-        $validator = $this->compileValidator('FloatWithAtMostTwoDecimalPlaces', $validatorCompiler);
+        $validator = $this->compileValidator('FloatWithAtMostTwoDecimalPlaces', $mapperCompiler, $validatorCompiler);
 
         $validator->map(+1.0);
         $validator->map(+1.2);
@@ -21,9 +23,6 @@ class AssertFloatMultipleOfTest extends ValidatorCompilerTestCase
         $validator->map(-1.0);
         $validator->map(-1.2);
         $validator->map(-1.23);
-
-        $validator->map(null);
-        $validator->map([]);
 
         self::assertException(
             MappingFailedException::class,
@@ -40,18 +39,15 @@ class AssertFloatMultipleOfTest extends ValidatorCompilerTestCase
 
     public function testFloatMultipleOfFive(): void
     {
+        $mapperCompiler = new MapFloat();
         $validatorCompiler = new AssertFloatMultipleOf(5.0);
-        $validator = $this->compileValidator('FloatMultipleOfFive', $validatorCompiler);
+        $validator = $this->compileValidator('FloatMultipleOfFive', $mapperCompiler, $validatorCompiler);
 
         $validator->map(+5.0);
         $validator->map(+65.0);
 
         $validator->map(-5.0);
         $validator->map(-65.0);
-
-        $validator->map(7);
-        $validator->map(null);
-        $validator->map([]);
 
         self::assertException(
             MappingFailedException::class,

--- a/tests/Compiler/Validator/Float/AssertFloatRangeTest.php
+++ b/tests/Compiler/Validator/Float/AssertFloatRangeTest.php
@@ -2,6 +2,7 @@
 
 namespace ShipMonkTests\InputMapper\Compiler\Validator\Float;
 
+use ShipMonk\InputMapper\Compiler\Mapper\Scalar\MapFloat;
 use ShipMonk\InputMapper\Compiler\Validator\Float\AssertFloatRange;
 use ShipMonk\InputMapper\Runtime\Exception\MappingFailedException;
 use ShipMonkTests\InputMapper\Compiler\Validator\ValidatorCompilerTestCase;
@@ -11,25 +12,23 @@ class AssertFloatRangeTest extends ValidatorCompilerTestCase
 
     public function testNoopFloatRangeValidator(): void
     {
+        $mapperCompiler = new MapFloat();
         $validatorCompiler = new AssertFloatRange();
-        $validator = $this->compileValidator('NoopFloatRangeValidator', $validatorCompiler);
+        $validator = $this->compileValidator('NoopFloatRangeValidator', $mapperCompiler, $validatorCompiler);
 
         $validator->map(123);
         $validator->map(1.2);
-        $validator->map(null);
-        $validator->map([]);
         self::assertTrue(true); // @phpstan-ignore-line always true
     }
 
     public function testFloatRangeValidatorWithInclusiveLowerBound(): void
     {
+        $mapperCompiler = new MapFloat();
         $validatorCompiler = new AssertFloatRange(gte: 5.0);
-        $validator = $this->compileValidator('FloatRangeValidatorWithInclusiveLowerBound', $validatorCompiler);
+        $validator = $this->compileValidator('FloatRangeValidatorWithInclusiveLowerBound', $mapperCompiler, $validatorCompiler);
 
         $validator->map(5.0);
         $validator->map(6.0);
-        $validator->map(null);
-        $validator->map([]);
 
         self::assertException(
             MappingFailedException::class,
@@ -40,12 +39,11 @@ class AssertFloatRangeTest extends ValidatorCompilerTestCase
 
     public function testFloatRangeValidatorWithExclusiveLowerBound(): void
     {
+        $mapperCompiler = new MapFloat();
         $validatorCompiler = new AssertFloatRange(gt: 5.0);
-        $validator = $this->compileValidator('FloatRangeValidatorWithExclusiveLowerBound', $validatorCompiler);
+        $validator = $this->compileValidator('FloatRangeValidatorWithExclusiveLowerBound', $mapperCompiler, $validatorCompiler);
 
         $validator->map(6.0);
-        $validator->map(null);
-        $validator->map([]);
 
         self::assertException(
             MappingFailedException::class,
@@ -56,13 +54,12 @@ class AssertFloatRangeTest extends ValidatorCompilerTestCase
 
     public function testFloatRangeValidatorWithInclusiveUpperBound(): void
     {
+        $mapperCompiler = new MapFloat();
         $validatorCompiler = new AssertFloatRange(lte: 5.0);
-        $validator = $this->compileValidator('FloatRangeValidatorWithInclusiveUpperBound', $validatorCompiler);
+        $validator = $this->compileValidator('FloatRangeValidatorWithInclusiveUpperBound', $mapperCompiler, $validatorCompiler);
 
         $validator->map(5.0);
         $validator->map(4.0);
-        $validator->map(null);
-        $validator->map([]);
 
         self::assertException(
             MappingFailedException::class,
@@ -73,12 +70,11 @@ class AssertFloatRangeTest extends ValidatorCompilerTestCase
 
     public function testFloatRangeValidatorWithExclusiveUpperBound(): void
     {
+        $mapperCompiler = new MapFloat();
         $validatorCompiler = new AssertFloatRange(lt: 5.0);
-        $validator = $this->compileValidator('FloatRangeValidatorWithExclusiveUpperBound', $validatorCompiler);
+        $validator = $this->compileValidator('FloatRangeValidatorWithExclusiveUpperBound', $mapperCompiler, $validatorCompiler);
 
         $validator->map(4.0);
-        $validator->map(null);
-        $validator->map([]);
 
         self::assertException(
             MappingFailedException::class,
@@ -89,14 +85,13 @@ class AssertFloatRangeTest extends ValidatorCompilerTestCase
 
     public function testFloatRangeValidatorWithInclusiveLowerAndUpperBound(): void
     {
+        $mapperCompiler = new MapFloat();
         $validatorCompiler = new AssertFloatRange(gte: 5.0, lte: 10.0);
-        $validator = $this->compileValidator('FloatRangeValidatorWithInclusiveLowerAndUpperBound', $validatorCompiler);
+        $validator = $this->compileValidator('FloatRangeValidatorWithInclusiveLowerAndUpperBound', $mapperCompiler, $validatorCompiler);
 
         $validator->map(5.0);
         $validator->map(6.0);
         $validator->map(10.0);
-        $validator->map(null);
-        $validator->map([]);
 
         self::assertException(
             MappingFailedException::class,

--- a/tests/Compiler/Validator/Float/Data/FloatMultipleOfFiveMapper.php
+++ b/tests/Compiler/Validator/Float/Data/FloatMultipleOfFiveMapper.php
@@ -48,7 +48,7 @@ class FloatMultipleOfFiveMapper implements Mapper
             throw MappingFailedException::incorrectType($data, $path, 'float');
         }
 
-        if (is_float($mapped) && !Floats::isInteger($mapped / 5.0)) {
+        if (!Floats::isInteger($mapped / 5.0)) {
             throw MappingFailedException::incorrectValue($mapped, $path, 'multiple of 5');
         }
 

--- a/tests/Compiler/Validator/Float/Data/FloatMultipleOfFiveMapper.php
+++ b/tests/Compiler/Validator/Float/Data/FloatMultipleOfFiveMapper.php
@@ -6,15 +6,22 @@ use Nette\Utils\Floats;
 use ShipMonk\InputMapper\Runtime\Exception\MappingFailedException;
 use ShipMonk\InputMapper\Runtime\Mapper;
 use ShipMonk\InputMapper\Runtime\MapperProvider;
+use function floatval;
+use function is_finite;
 use function is_float;
+use function is_int;
 
 /**
  * Generated mapper. Do not edit directly.
  *
- * @implements Mapper<mixed>
+ * @implements Mapper<float>
  */
 class FloatMultipleOfFiveMapper implements Mapper
 {
+    private const MIN_SAFE_INTEGER = -9007199254740991;
+
+    private const MAX_SAFE_INTEGER = 9007199254740991;
+
     public function __construct(private readonly MapperProvider $provider)
     {
     }
@@ -23,12 +30,28 @@ class FloatMultipleOfFiveMapper implements Mapper
      * @param  list<string|int> $path
      * @throws MappingFailedException
      */
-    public function map(mixed $data, array $path = []): mixed
+    public function map(mixed $data, array $path = []): float
     {
-        if (is_float($data) && !Floats::isInteger($data / 5.0)) {
-            throw MappingFailedException::incorrectValue($data, $path, 'multiple of 5');
+        if (is_float($data)) {
+            if (!is_finite($data)) {
+                throw MappingFailedException::incorrectType($data, $path, 'finite float');
+            }
+
+            $mapped = $data;
+        } elseif (is_int($data)) {
+            if ($data < self::MIN_SAFE_INTEGER || $data > self::MAX_SAFE_INTEGER) {
+                throw MappingFailedException::incorrectValue($data, $path, 'float or int with value that can be losslessly converted to float');
+            }
+
+            $mapped = floatval($data);
+        } else {
+            throw MappingFailedException::incorrectType($data, $path, 'float');
         }
 
-        return $data;
+        if (is_float($mapped) && !Floats::isInteger($mapped / 5.0)) {
+            throw MappingFailedException::incorrectValue($mapped, $path, 'multiple of 5');
+        }
+
+        return $mapped;
     }
 }

--- a/tests/Compiler/Validator/Float/Data/FloatRangeValidatorWithExclusiveLowerBoundMapper.php
+++ b/tests/Compiler/Validator/Float/Data/FloatRangeValidatorWithExclusiveLowerBoundMapper.php
@@ -6,15 +6,22 @@ use Nette\Utils\Floats;
 use ShipMonk\InputMapper\Runtime\Exception\MappingFailedException;
 use ShipMonk\InputMapper\Runtime\Mapper;
 use ShipMonk\InputMapper\Runtime\MapperProvider;
+use function floatval;
+use function is_finite;
 use function is_float;
+use function is_int;
 
 /**
  * Generated mapper. Do not edit directly.
  *
- * @implements Mapper<mixed>
+ * @implements Mapper<float>
  */
 class FloatRangeValidatorWithExclusiveLowerBoundMapper implements Mapper
 {
+    private const MIN_SAFE_INTEGER = -9007199254740991;
+
+    private const MAX_SAFE_INTEGER = 9007199254740991;
+
     public function __construct(private readonly MapperProvider $provider)
     {
     }
@@ -23,14 +30,30 @@ class FloatRangeValidatorWithExclusiveLowerBoundMapper implements Mapper
      * @param  list<string|int> $path
      * @throws MappingFailedException
      */
-    public function map(mixed $data, array $path = []): mixed
+    public function map(mixed $data, array $path = []): float
     {
         if (is_float($data)) {
-            if (Floats::isLessThanOrEqualTo($data, 5.0)) {
-                throw MappingFailedException::incorrectValue($data, $path, 'value greater than 5');
+            if (!is_finite($data)) {
+                throw MappingFailedException::incorrectType($data, $path, 'finite float');
+            }
+
+            $mapped = $data;
+        } elseif (is_int($data)) {
+            if ($data < self::MIN_SAFE_INTEGER || $data > self::MAX_SAFE_INTEGER) {
+                throw MappingFailedException::incorrectValue($data, $path, 'float or int with value that can be losslessly converted to float');
+            }
+
+            $mapped = floatval($data);
+        } else {
+            throw MappingFailedException::incorrectType($data, $path, 'float');
+        }
+
+        if (is_float($mapped)) {
+            if (Floats::isLessThanOrEqualTo($mapped, 5.0)) {
+                throw MappingFailedException::incorrectValue($mapped, $path, 'value greater than 5');
             }
         }
 
-        return $data;
+        return $mapped;
     }
 }

--- a/tests/Compiler/Validator/Float/Data/FloatRangeValidatorWithExclusiveLowerBoundMapper.php
+++ b/tests/Compiler/Validator/Float/Data/FloatRangeValidatorWithExclusiveLowerBoundMapper.php
@@ -48,10 +48,8 @@ class FloatRangeValidatorWithExclusiveLowerBoundMapper implements Mapper
             throw MappingFailedException::incorrectType($data, $path, 'float');
         }
 
-        if (is_float($mapped)) {
-            if (Floats::isLessThanOrEqualTo($mapped, 5.0)) {
-                throw MappingFailedException::incorrectValue($mapped, $path, 'value greater than 5');
-            }
+        if (Floats::isLessThanOrEqualTo($mapped, 5.0)) {
+            throw MappingFailedException::incorrectValue($mapped, $path, 'value greater than 5');
         }
 
         return $mapped;

--- a/tests/Compiler/Validator/Float/Data/FloatRangeValidatorWithExclusiveUpperBoundMapper.php
+++ b/tests/Compiler/Validator/Float/Data/FloatRangeValidatorWithExclusiveUpperBoundMapper.php
@@ -6,15 +6,22 @@ use Nette\Utils\Floats;
 use ShipMonk\InputMapper\Runtime\Exception\MappingFailedException;
 use ShipMonk\InputMapper\Runtime\Mapper;
 use ShipMonk\InputMapper\Runtime\MapperProvider;
+use function floatval;
+use function is_finite;
 use function is_float;
+use function is_int;
 
 /**
  * Generated mapper. Do not edit directly.
  *
- * @implements Mapper<mixed>
+ * @implements Mapper<float>
  */
 class FloatRangeValidatorWithExclusiveUpperBoundMapper implements Mapper
 {
+    private const MIN_SAFE_INTEGER = -9007199254740991;
+
+    private const MAX_SAFE_INTEGER = 9007199254740991;
+
     public function __construct(private readonly MapperProvider $provider)
     {
     }
@@ -23,14 +30,30 @@ class FloatRangeValidatorWithExclusiveUpperBoundMapper implements Mapper
      * @param  list<string|int> $path
      * @throws MappingFailedException
      */
-    public function map(mixed $data, array $path = []): mixed
+    public function map(mixed $data, array $path = []): float
     {
         if (is_float($data)) {
-            if (Floats::isGreaterThanOrEqualTo($data, 5.0)) {
-                throw MappingFailedException::incorrectValue($data, $path, 'value less than 5');
+            if (!is_finite($data)) {
+                throw MappingFailedException::incorrectType($data, $path, 'finite float');
+            }
+
+            $mapped = $data;
+        } elseif (is_int($data)) {
+            if ($data < self::MIN_SAFE_INTEGER || $data > self::MAX_SAFE_INTEGER) {
+                throw MappingFailedException::incorrectValue($data, $path, 'float or int with value that can be losslessly converted to float');
+            }
+
+            $mapped = floatval($data);
+        } else {
+            throw MappingFailedException::incorrectType($data, $path, 'float');
+        }
+
+        if (is_float($mapped)) {
+            if (Floats::isGreaterThanOrEqualTo($mapped, 5.0)) {
+                throw MappingFailedException::incorrectValue($mapped, $path, 'value less than 5');
             }
         }
 
-        return $data;
+        return $mapped;
     }
 }

--- a/tests/Compiler/Validator/Float/Data/FloatRangeValidatorWithExclusiveUpperBoundMapper.php
+++ b/tests/Compiler/Validator/Float/Data/FloatRangeValidatorWithExclusiveUpperBoundMapper.php
@@ -48,10 +48,8 @@ class FloatRangeValidatorWithExclusiveUpperBoundMapper implements Mapper
             throw MappingFailedException::incorrectType($data, $path, 'float');
         }
 
-        if (is_float($mapped)) {
-            if (Floats::isGreaterThanOrEqualTo($mapped, 5.0)) {
-                throw MappingFailedException::incorrectValue($mapped, $path, 'value less than 5');
-            }
+        if (Floats::isGreaterThanOrEqualTo($mapped, 5.0)) {
+            throw MappingFailedException::incorrectValue($mapped, $path, 'value less than 5');
         }
 
         return $mapped;

--- a/tests/Compiler/Validator/Float/Data/FloatRangeValidatorWithInclusiveLowerAndUpperBoundMapper.php
+++ b/tests/Compiler/Validator/Float/Data/FloatRangeValidatorWithInclusiveLowerAndUpperBoundMapper.php
@@ -48,14 +48,12 @@ class FloatRangeValidatorWithInclusiveLowerAndUpperBoundMapper implements Mapper
             throw MappingFailedException::incorrectType($data, $path, 'float');
         }
 
-        if (is_float($mapped)) {
-            if (Floats::isLessThan($mapped, 5.0)) {
-                throw MappingFailedException::incorrectValue($mapped, $path, 'value greater than or equal to 5');
-            }
+        if (Floats::isLessThan($mapped, 5.0)) {
+            throw MappingFailedException::incorrectValue($mapped, $path, 'value greater than or equal to 5');
+        }
 
-            if (Floats::isGreaterThan($mapped, 10.0)) {
-                throw MappingFailedException::incorrectValue($mapped, $path, 'value less than or equal to 10');
-            }
+        if (Floats::isGreaterThan($mapped, 10.0)) {
+            throw MappingFailedException::incorrectValue($mapped, $path, 'value less than or equal to 10');
         }
 
         return $mapped;

--- a/tests/Compiler/Validator/Float/Data/FloatRangeValidatorWithInclusiveLowerAndUpperBoundMapper.php
+++ b/tests/Compiler/Validator/Float/Data/FloatRangeValidatorWithInclusiveLowerAndUpperBoundMapper.php
@@ -6,15 +6,22 @@ use Nette\Utils\Floats;
 use ShipMonk\InputMapper\Runtime\Exception\MappingFailedException;
 use ShipMonk\InputMapper\Runtime\Mapper;
 use ShipMonk\InputMapper\Runtime\MapperProvider;
+use function floatval;
+use function is_finite;
 use function is_float;
+use function is_int;
 
 /**
  * Generated mapper. Do not edit directly.
  *
- * @implements Mapper<mixed>
+ * @implements Mapper<float>
  */
 class FloatRangeValidatorWithInclusiveLowerAndUpperBoundMapper implements Mapper
 {
+    private const MIN_SAFE_INTEGER = -9007199254740991;
+
+    private const MAX_SAFE_INTEGER = 9007199254740991;
+
     public function __construct(private readonly MapperProvider $provider)
     {
     }
@@ -23,18 +30,34 @@ class FloatRangeValidatorWithInclusiveLowerAndUpperBoundMapper implements Mapper
      * @param  list<string|int> $path
      * @throws MappingFailedException
      */
-    public function map(mixed $data, array $path = []): mixed
+    public function map(mixed $data, array $path = []): float
     {
         if (is_float($data)) {
-            if (Floats::isLessThan($data, 5.0)) {
-                throw MappingFailedException::incorrectValue($data, $path, 'value greater than or equal to 5');
+            if (!is_finite($data)) {
+                throw MappingFailedException::incorrectType($data, $path, 'finite float');
             }
 
-            if (Floats::isGreaterThan($data, 10.0)) {
-                throw MappingFailedException::incorrectValue($data, $path, 'value less than or equal to 10');
+            $mapped = $data;
+        } elseif (is_int($data)) {
+            if ($data < self::MIN_SAFE_INTEGER || $data > self::MAX_SAFE_INTEGER) {
+                throw MappingFailedException::incorrectValue($data, $path, 'float or int with value that can be losslessly converted to float');
+            }
+
+            $mapped = floatval($data);
+        } else {
+            throw MappingFailedException::incorrectType($data, $path, 'float');
+        }
+
+        if (is_float($mapped)) {
+            if (Floats::isLessThan($mapped, 5.0)) {
+                throw MappingFailedException::incorrectValue($mapped, $path, 'value greater than or equal to 5');
+            }
+
+            if (Floats::isGreaterThan($mapped, 10.0)) {
+                throw MappingFailedException::incorrectValue($mapped, $path, 'value less than or equal to 10');
             }
         }
 
-        return $data;
+        return $mapped;
     }
 }

--- a/tests/Compiler/Validator/Float/Data/FloatRangeValidatorWithInclusiveLowerBoundMapper.php
+++ b/tests/Compiler/Validator/Float/Data/FloatRangeValidatorWithInclusiveLowerBoundMapper.php
@@ -48,10 +48,8 @@ class FloatRangeValidatorWithInclusiveLowerBoundMapper implements Mapper
             throw MappingFailedException::incorrectType($data, $path, 'float');
         }
 
-        if (is_float($mapped)) {
-            if (Floats::isLessThan($mapped, 5.0)) {
-                throw MappingFailedException::incorrectValue($mapped, $path, 'value greater than or equal to 5');
-            }
+        if (Floats::isLessThan($mapped, 5.0)) {
+            throw MappingFailedException::incorrectValue($mapped, $path, 'value greater than or equal to 5');
         }
 
         return $mapped;

--- a/tests/Compiler/Validator/Float/Data/FloatRangeValidatorWithInclusiveLowerBoundMapper.php
+++ b/tests/Compiler/Validator/Float/Data/FloatRangeValidatorWithInclusiveLowerBoundMapper.php
@@ -6,15 +6,22 @@ use Nette\Utils\Floats;
 use ShipMonk\InputMapper\Runtime\Exception\MappingFailedException;
 use ShipMonk\InputMapper\Runtime\Mapper;
 use ShipMonk\InputMapper\Runtime\MapperProvider;
+use function floatval;
+use function is_finite;
 use function is_float;
+use function is_int;
 
 /**
  * Generated mapper. Do not edit directly.
  *
- * @implements Mapper<mixed>
+ * @implements Mapper<float>
  */
 class FloatRangeValidatorWithInclusiveLowerBoundMapper implements Mapper
 {
+    private const MIN_SAFE_INTEGER = -9007199254740991;
+
+    private const MAX_SAFE_INTEGER = 9007199254740991;
+
     public function __construct(private readonly MapperProvider $provider)
     {
     }
@@ -23,14 +30,30 @@ class FloatRangeValidatorWithInclusiveLowerBoundMapper implements Mapper
      * @param  list<string|int> $path
      * @throws MappingFailedException
      */
-    public function map(mixed $data, array $path = []): mixed
+    public function map(mixed $data, array $path = []): float
     {
         if (is_float($data)) {
-            if (Floats::isLessThan($data, 5.0)) {
-                throw MappingFailedException::incorrectValue($data, $path, 'value greater than or equal to 5');
+            if (!is_finite($data)) {
+                throw MappingFailedException::incorrectType($data, $path, 'finite float');
+            }
+
+            $mapped = $data;
+        } elseif (is_int($data)) {
+            if ($data < self::MIN_SAFE_INTEGER || $data > self::MAX_SAFE_INTEGER) {
+                throw MappingFailedException::incorrectValue($data, $path, 'float or int with value that can be losslessly converted to float');
+            }
+
+            $mapped = floatval($data);
+        } else {
+            throw MappingFailedException::incorrectType($data, $path, 'float');
+        }
+
+        if (is_float($mapped)) {
+            if (Floats::isLessThan($mapped, 5.0)) {
+                throw MappingFailedException::incorrectValue($mapped, $path, 'value greater than or equal to 5');
             }
         }
 
-        return $data;
+        return $mapped;
     }
 }

--- a/tests/Compiler/Validator/Float/Data/FloatRangeValidatorWithInclusiveUpperBoundMapper.php
+++ b/tests/Compiler/Validator/Float/Data/FloatRangeValidatorWithInclusiveUpperBoundMapper.php
@@ -6,15 +6,22 @@ use Nette\Utils\Floats;
 use ShipMonk\InputMapper\Runtime\Exception\MappingFailedException;
 use ShipMonk\InputMapper\Runtime\Mapper;
 use ShipMonk\InputMapper\Runtime\MapperProvider;
+use function floatval;
+use function is_finite;
 use function is_float;
+use function is_int;
 
 /**
  * Generated mapper. Do not edit directly.
  *
- * @implements Mapper<mixed>
+ * @implements Mapper<float>
  */
 class FloatRangeValidatorWithInclusiveUpperBoundMapper implements Mapper
 {
+    private const MIN_SAFE_INTEGER = -9007199254740991;
+
+    private const MAX_SAFE_INTEGER = 9007199254740991;
+
     public function __construct(private readonly MapperProvider $provider)
     {
     }
@@ -23,14 +30,30 @@ class FloatRangeValidatorWithInclusiveUpperBoundMapper implements Mapper
      * @param  list<string|int> $path
      * @throws MappingFailedException
      */
-    public function map(mixed $data, array $path = []): mixed
+    public function map(mixed $data, array $path = []): float
     {
         if (is_float($data)) {
-            if (Floats::isGreaterThan($data, 5.0)) {
-                throw MappingFailedException::incorrectValue($data, $path, 'value less than or equal to 5');
+            if (!is_finite($data)) {
+                throw MappingFailedException::incorrectType($data, $path, 'finite float');
+            }
+
+            $mapped = $data;
+        } elseif (is_int($data)) {
+            if ($data < self::MIN_SAFE_INTEGER || $data > self::MAX_SAFE_INTEGER) {
+                throw MappingFailedException::incorrectValue($data, $path, 'float or int with value that can be losslessly converted to float');
+            }
+
+            $mapped = floatval($data);
+        } else {
+            throw MappingFailedException::incorrectType($data, $path, 'float');
+        }
+
+        if (is_float($mapped)) {
+            if (Floats::isGreaterThan($mapped, 5.0)) {
+                throw MappingFailedException::incorrectValue($mapped, $path, 'value less than or equal to 5');
             }
         }
 
-        return $data;
+        return $mapped;
     }
 }

--- a/tests/Compiler/Validator/Float/Data/FloatRangeValidatorWithInclusiveUpperBoundMapper.php
+++ b/tests/Compiler/Validator/Float/Data/FloatRangeValidatorWithInclusiveUpperBoundMapper.php
@@ -48,10 +48,8 @@ class FloatRangeValidatorWithInclusiveUpperBoundMapper implements Mapper
             throw MappingFailedException::incorrectType($data, $path, 'float');
         }
 
-        if (is_float($mapped)) {
-            if (Floats::isGreaterThan($mapped, 5.0)) {
-                throw MappingFailedException::incorrectValue($mapped, $path, 'value less than or equal to 5');
-            }
+        if (Floats::isGreaterThan($mapped, 5.0)) {
+            throw MappingFailedException::incorrectValue($mapped, $path, 'value less than or equal to 5');
         }
 
         return $mapped;

--- a/tests/Compiler/Validator/Float/Data/FloatWithAtMostTwoDecimalPlacesMapper.php
+++ b/tests/Compiler/Validator/Float/Data/FloatWithAtMostTwoDecimalPlacesMapper.php
@@ -6,15 +6,22 @@ use Nette\Utils\Floats;
 use ShipMonk\InputMapper\Runtime\Exception\MappingFailedException;
 use ShipMonk\InputMapper\Runtime\Mapper;
 use ShipMonk\InputMapper\Runtime\MapperProvider;
+use function floatval;
+use function is_finite;
 use function is_float;
+use function is_int;
 
 /**
  * Generated mapper. Do not edit directly.
  *
- * @implements Mapper<mixed>
+ * @implements Mapper<float>
  */
 class FloatWithAtMostTwoDecimalPlacesMapper implements Mapper
 {
+    private const MIN_SAFE_INTEGER = -9007199254740991;
+
+    private const MAX_SAFE_INTEGER = 9007199254740991;
+
     public function __construct(private readonly MapperProvider $provider)
     {
     }
@@ -23,12 +30,28 @@ class FloatWithAtMostTwoDecimalPlacesMapper implements Mapper
      * @param  list<string|int> $path
      * @throws MappingFailedException
      */
-    public function map(mixed $data, array $path = []): mixed
+    public function map(mixed $data, array $path = []): float
     {
-        if (is_float($data) && !Floats::isInteger($data / 0.01)) {
-            throw MappingFailedException::incorrectValue($data, $path, 'multiple of 0.01');
+        if (is_float($data)) {
+            if (!is_finite($data)) {
+                throw MappingFailedException::incorrectType($data, $path, 'finite float');
+            }
+
+            $mapped = $data;
+        } elseif (is_int($data)) {
+            if ($data < self::MIN_SAFE_INTEGER || $data > self::MAX_SAFE_INTEGER) {
+                throw MappingFailedException::incorrectValue($data, $path, 'float or int with value that can be losslessly converted to float');
+            }
+
+            $mapped = floatval($data);
+        } else {
+            throw MappingFailedException::incorrectType($data, $path, 'float');
         }
 
-        return $data;
+        if (is_float($mapped) && !Floats::isInteger($mapped / 0.01)) {
+            throw MappingFailedException::incorrectValue($mapped, $path, 'multiple of 0.01');
+        }
+
+        return $mapped;
     }
 }

--- a/tests/Compiler/Validator/Float/Data/FloatWithAtMostTwoDecimalPlacesMapper.php
+++ b/tests/Compiler/Validator/Float/Data/FloatWithAtMostTwoDecimalPlacesMapper.php
@@ -48,7 +48,7 @@ class FloatWithAtMostTwoDecimalPlacesMapper implements Mapper
             throw MappingFailedException::incorrectType($data, $path, 'float');
         }
 
-        if (is_float($mapped) && !Floats::isInteger($mapped / 0.01)) {
+        if (!Floats::isInteger($mapped / 0.01)) {
             throw MappingFailedException::incorrectValue($mapped, $path, 'multiple of 0.01');
         }
 

--- a/tests/Compiler/Validator/Float/Data/NoopFloatRangeValidatorMapper.php
+++ b/tests/Compiler/Validator/Float/Data/NoopFloatRangeValidatorMapper.php
@@ -5,14 +5,22 @@ namespace ShipMonkTests\InputMapper\Compiler\Validator\Float\Data;
 use ShipMonk\InputMapper\Runtime\Exception\MappingFailedException;
 use ShipMonk\InputMapper\Runtime\Mapper;
 use ShipMonk\InputMapper\Runtime\MapperProvider;
+use function floatval;
+use function is_finite;
+use function is_float;
+use function is_int;
 
 /**
  * Generated mapper. Do not edit directly.
  *
- * @implements Mapper<mixed>
+ * @implements Mapper<float>
  */
 class NoopFloatRangeValidatorMapper implements Mapper
 {
+    private const MIN_SAFE_INTEGER = -9007199254740991;
+
+    private const MAX_SAFE_INTEGER = 9007199254740991;
+
     public function __construct(private readonly MapperProvider $provider)
     {
     }
@@ -21,8 +29,24 @@ class NoopFloatRangeValidatorMapper implements Mapper
      * @param  list<string|int> $path
      * @throws MappingFailedException
      */
-    public function map(mixed $data, array $path = []): mixed
+    public function map(mixed $data, array $path = []): float
     {
-        return $data;
+        if (is_float($data)) {
+            if (!is_finite($data)) {
+                throw MappingFailedException::incorrectType($data, $path, 'finite float');
+            }
+
+            $mapped = $data;
+        } elseif (is_int($data)) {
+            if ($data < self::MIN_SAFE_INTEGER || $data > self::MAX_SAFE_INTEGER) {
+                throw MappingFailedException::incorrectValue($data, $path, 'float or int with value that can be losslessly converted to float');
+            }
+
+            $mapped = floatval($data);
+        } else {
+            throw MappingFailedException::incorrectType($data, $path, 'float');
+        }
+
+        return $mapped;
     }
 }

--- a/tests/Compiler/Validator/Int/AssertIntMultipleOfTest.php
+++ b/tests/Compiler/Validator/Int/AssertIntMultipleOfTest.php
@@ -2,6 +2,7 @@
 
 namespace ShipMonkTests\InputMapper\Compiler\Validator\Int;
 
+use ShipMonk\InputMapper\Compiler\Mapper\Scalar\MapInt;
 use ShipMonk\InputMapper\Compiler\Validator\Int\AssertIntMultipleOf;
 use ShipMonk\InputMapper\Runtime\Exception\MappingFailedException;
 use ShipMonkTests\InputMapper\Compiler\Validator\ValidatorCompilerTestCase;
@@ -11,18 +12,15 @@ class AssertIntMultipleOfTest extends ValidatorCompilerTestCase
 
     public function testIntMultipleOfFive(): void
     {
+        $mapperCompiler = new MapInt();
         $validatorCompiler = new AssertIntMultipleOf(5);
-        $validator = $this->compileValidator('IntMultipleOfFive', $validatorCompiler);
+        $validator = $this->compileValidator('IntMultipleOfFive', $mapperCompiler, $validatorCompiler);
 
         $validator->map(+5);
         $validator->map(+65);
 
         $validator->map(-5);
         $validator->map(-65);
-
-        $validator->map(1.23);
-        $validator->map(null);
-        $validator->map([]);
 
         self::assertException(
             MappingFailedException::class,

--- a/tests/Compiler/Validator/Int/AssertIntRangeTest.php
+++ b/tests/Compiler/Validator/Int/AssertIntRangeTest.php
@@ -2,6 +2,7 @@
 
 namespace ShipMonkTests\InputMapper\Compiler\Validator\Int;
 
+use ShipMonk\InputMapper\Compiler\Mapper\Scalar\MapInt;
 use ShipMonk\InputMapper\Compiler\Validator\Int\AssertIntRange;
 use ShipMonk\InputMapper\Runtime\Exception\MappingFailedException;
 use ShipMonkTests\InputMapper\Compiler\Validator\ValidatorCompilerTestCase;
@@ -11,24 +12,22 @@ class AssertIntRangeTest extends ValidatorCompilerTestCase
 
     public function testNoopIntRangeValidator(): void
     {
+        $mapperCompiler = new MapInt();
         $validatorCompiler = new AssertIntRange();
-        $validator = $this->compileValidator('NoopIntRangeValidator', $validatorCompiler);
+        $validator = $this->compileValidator('NoopIntRangeValidator', $mapperCompiler, $validatorCompiler);
 
         $validator->map(123);
-        $validator->map(null);
-        $validator->map([]);
         self::assertTrue(true); // @phpstan-ignore-line always true
     }
 
     public function testIntRangeValidatorWithInclusiveLowerBound(): void
     {
+        $mapperCompiler = new MapInt();
         $validatorCompiler = new AssertIntRange(gte: 5);
-        $validator = $this->compileValidator('IntRangeValidatorWithInclusiveLowerBound', $validatorCompiler);
+        $validator = $this->compileValidator('IntRangeValidatorWithInclusiveLowerBound', $mapperCompiler, $validatorCompiler);
 
         $validator->map(5);
         $validator->map(6);
-        $validator->map(null);
-        $validator->map([]);
 
         self::assertException(
             MappingFailedException::class,
@@ -39,12 +38,11 @@ class AssertIntRangeTest extends ValidatorCompilerTestCase
 
     public function testIntRangeValidatorWithExclusiveLowerBound(): void
     {
+        $mapperCompiler = new MapInt();
         $validatorCompiler = new AssertIntRange(gt: 5);
-        $validator = $this->compileValidator('IntRangeValidatorWithExclusiveLowerBound', $validatorCompiler);
+        $validator = $this->compileValidator('IntRangeValidatorWithExclusiveLowerBound', $mapperCompiler, $validatorCompiler);
 
         $validator->map(6);
-        $validator->map(null);
-        $validator->map([]);
 
         self::assertException(
             MappingFailedException::class,
@@ -55,13 +53,12 @@ class AssertIntRangeTest extends ValidatorCompilerTestCase
 
     public function testIntRangeValidatorWithInclusiveUpperBound(): void
     {
+        $mapperCompiler = new MapInt();
         $validatorCompiler = new AssertIntRange(lte: 5);
-        $validator = $this->compileValidator('IntRangeValidatorWithInclusiveUpperBound', $validatorCompiler);
+        $validator = $this->compileValidator('IntRangeValidatorWithInclusiveUpperBound', $mapperCompiler, $validatorCompiler);
 
         $validator->map(5);
         $validator->map(4);
-        $validator->map(null);
-        $validator->map([]);
 
         self::assertException(
             MappingFailedException::class,
@@ -72,12 +69,11 @@ class AssertIntRangeTest extends ValidatorCompilerTestCase
 
     public function testIntRangeValidatorWithExclusiveUpperBound(): void
     {
+        $mapperCompiler = new MapInt();
         $validatorCompiler = new AssertIntRange(lt: 5);
-        $validator = $this->compileValidator('IntRangeValidatorWithExclusiveUpperBound', $validatorCompiler);
+        $validator = $this->compileValidator('IntRangeValidatorWithExclusiveUpperBound', $mapperCompiler, $validatorCompiler);
 
         $validator->map(4);
-        $validator->map(null);
-        $validator->map([]);
 
         self::assertException(
             MappingFailedException::class,
@@ -88,14 +84,13 @@ class AssertIntRangeTest extends ValidatorCompilerTestCase
 
     public function testIntRangeValidatorWithInclusiveLowerAndUpperBound(): void
     {
+        $mapperCompiler = new MapInt();
         $validatorCompiler = new AssertIntRange(gte: 5, lte: 10);
-        $validator = $this->compileValidator('IntRangeValidatorWithInclusiveLowerAndUpperBound', $validatorCompiler);
+        $validator = $this->compileValidator('IntRangeValidatorWithInclusiveLowerAndUpperBound', $mapperCompiler, $validatorCompiler);
 
         $validator->map(5);
         $validator->map(6);
         $validator->map(10);
-        $validator->map(null);
-        $validator->map([]);
 
         self::assertException(
             MappingFailedException::class,

--- a/tests/Compiler/Validator/Int/Data/IntMultipleOfFiveMapper.php
+++ b/tests/Compiler/Validator/Int/Data/IntMultipleOfFiveMapper.php
@@ -28,7 +28,7 @@ class IntMultipleOfFiveMapper implements Mapper
             throw MappingFailedException::incorrectType($data, $path, 'int');
         }
 
-        if (is_int($data) && $data % 5 !== 0) {
+        if ($data % 5 !== 0) {
             throw MappingFailedException::incorrectValue($data, $path, 'multiple of 5');
         }
 

--- a/tests/Compiler/Validator/Int/Data/IntMultipleOfFiveMapper.php
+++ b/tests/Compiler/Validator/Int/Data/IntMultipleOfFiveMapper.php
@@ -10,7 +10,7 @@ use function is_int;
 /**
  * Generated mapper. Do not edit directly.
  *
- * @implements Mapper<mixed>
+ * @implements Mapper<int>
  */
 class IntMultipleOfFiveMapper implements Mapper
 {
@@ -22,8 +22,12 @@ class IntMultipleOfFiveMapper implements Mapper
      * @param  list<string|int> $path
      * @throws MappingFailedException
      */
-    public function map(mixed $data, array $path = []): mixed
+    public function map(mixed $data, array $path = []): int
     {
+        if (!is_int($data)) {
+            throw MappingFailedException::incorrectType($data, $path, 'int');
+        }
+
         if (is_int($data) && $data % 5 !== 0) {
             throw MappingFailedException::incorrectValue($data, $path, 'multiple of 5');
         }

--- a/tests/Compiler/Validator/Int/Data/IntRangeValidatorWithExclusiveLowerBoundMapper.php
+++ b/tests/Compiler/Validator/Int/Data/IntRangeValidatorWithExclusiveLowerBoundMapper.php
@@ -10,7 +10,7 @@ use function is_int;
 /**
  * Generated mapper. Do not edit directly.
  *
- * @implements Mapper<mixed>
+ * @implements Mapper<int>
  */
 class IntRangeValidatorWithExclusiveLowerBoundMapper implements Mapper
 {
@@ -22,8 +22,12 @@ class IntRangeValidatorWithExclusiveLowerBoundMapper implements Mapper
      * @param  list<string|int> $path
      * @throws MappingFailedException
      */
-    public function map(mixed $data, array $path = []): mixed
+    public function map(mixed $data, array $path = []): int
     {
+        if (!is_int($data)) {
+            throw MappingFailedException::incorrectType($data, $path, 'int');
+        }
+
         if (is_int($data)) {
             if ($data <= 5) {
                 throw MappingFailedException::incorrectValue($data, $path, 'value greater than 5');

--- a/tests/Compiler/Validator/Int/Data/IntRangeValidatorWithExclusiveLowerBoundMapper.php
+++ b/tests/Compiler/Validator/Int/Data/IntRangeValidatorWithExclusiveLowerBoundMapper.php
@@ -28,10 +28,8 @@ class IntRangeValidatorWithExclusiveLowerBoundMapper implements Mapper
             throw MappingFailedException::incorrectType($data, $path, 'int');
         }
 
-        if (is_int($data)) {
-            if ($data <= 5) {
-                throw MappingFailedException::incorrectValue($data, $path, 'value greater than 5');
-            }
+        if ($data <= 5) {
+            throw MappingFailedException::incorrectValue($data, $path, 'value greater than 5');
         }
 
         return $data;

--- a/tests/Compiler/Validator/Int/Data/IntRangeValidatorWithExclusiveUpperBoundMapper.php
+++ b/tests/Compiler/Validator/Int/Data/IntRangeValidatorWithExclusiveUpperBoundMapper.php
@@ -28,10 +28,8 @@ class IntRangeValidatorWithExclusiveUpperBoundMapper implements Mapper
             throw MappingFailedException::incorrectType($data, $path, 'int');
         }
 
-        if (is_int($data)) {
-            if ($data >= 5) {
-                throw MappingFailedException::incorrectValue($data, $path, 'value less than 5');
-            }
+        if ($data >= 5) {
+            throw MappingFailedException::incorrectValue($data, $path, 'value less than 5');
         }
 
         return $data;

--- a/tests/Compiler/Validator/Int/Data/IntRangeValidatorWithExclusiveUpperBoundMapper.php
+++ b/tests/Compiler/Validator/Int/Data/IntRangeValidatorWithExclusiveUpperBoundMapper.php
@@ -10,7 +10,7 @@ use function is_int;
 /**
  * Generated mapper. Do not edit directly.
  *
- * @implements Mapper<mixed>
+ * @implements Mapper<int>
  */
 class IntRangeValidatorWithExclusiveUpperBoundMapper implements Mapper
 {
@@ -22,8 +22,12 @@ class IntRangeValidatorWithExclusiveUpperBoundMapper implements Mapper
      * @param  list<string|int> $path
      * @throws MappingFailedException
      */
-    public function map(mixed $data, array $path = []): mixed
+    public function map(mixed $data, array $path = []): int
     {
+        if (!is_int($data)) {
+            throw MappingFailedException::incorrectType($data, $path, 'int');
+        }
+
         if (is_int($data)) {
             if ($data >= 5) {
                 throw MappingFailedException::incorrectValue($data, $path, 'value less than 5');

--- a/tests/Compiler/Validator/Int/Data/IntRangeValidatorWithInclusiveLowerAndUpperBoundMapper.php
+++ b/tests/Compiler/Validator/Int/Data/IntRangeValidatorWithInclusiveLowerAndUpperBoundMapper.php
@@ -10,7 +10,7 @@ use function is_int;
 /**
  * Generated mapper. Do not edit directly.
  *
- * @implements Mapper<mixed>
+ * @implements Mapper<int>
  */
 class IntRangeValidatorWithInclusiveLowerAndUpperBoundMapper implements Mapper
 {
@@ -22,8 +22,12 @@ class IntRangeValidatorWithInclusiveLowerAndUpperBoundMapper implements Mapper
      * @param  list<string|int> $path
      * @throws MappingFailedException
      */
-    public function map(mixed $data, array $path = []): mixed
+    public function map(mixed $data, array $path = []): int
     {
+        if (!is_int($data)) {
+            throw MappingFailedException::incorrectType($data, $path, 'int');
+        }
+
         if (is_int($data)) {
             if ($data < 5) {
                 throw MappingFailedException::incorrectValue($data, $path, 'value greater than or equal to 5');

--- a/tests/Compiler/Validator/Int/Data/IntRangeValidatorWithInclusiveLowerAndUpperBoundMapper.php
+++ b/tests/Compiler/Validator/Int/Data/IntRangeValidatorWithInclusiveLowerAndUpperBoundMapper.php
@@ -28,14 +28,12 @@ class IntRangeValidatorWithInclusiveLowerAndUpperBoundMapper implements Mapper
             throw MappingFailedException::incorrectType($data, $path, 'int');
         }
 
-        if (is_int($data)) {
-            if ($data < 5) {
-                throw MappingFailedException::incorrectValue($data, $path, 'value greater than or equal to 5');
-            }
+        if ($data < 5) {
+            throw MappingFailedException::incorrectValue($data, $path, 'value greater than or equal to 5');
+        }
 
-            if ($data > 10) {
-                throw MappingFailedException::incorrectValue($data, $path, 'value less than or equal to 10');
-            }
+        if ($data > 10) {
+            throw MappingFailedException::incorrectValue($data, $path, 'value less than or equal to 10');
         }
 
         return $data;

--- a/tests/Compiler/Validator/Int/Data/IntRangeValidatorWithInclusiveLowerBoundMapper.php
+++ b/tests/Compiler/Validator/Int/Data/IntRangeValidatorWithInclusiveLowerBoundMapper.php
@@ -10,7 +10,7 @@ use function is_int;
 /**
  * Generated mapper. Do not edit directly.
  *
- * @implements Mapper<mixed>
+ * @implements Mapper<int>
  */
 class IntRangeValidatorWithInclusiveLowerBoundMapper implements Mapper
 {
@@ -22,8 +22,12 @@ class IntRangeValidatorWithInclusiveLowerBoundMapper implements Mapper
      * @param  list<string|int> $path
      * @throws MappingFailedException
      */
-    public function map(mixed $data, array $path = []): mixed
+    public function map(mixed $data, array $path = []): int
     {
+        if (!is_int($data)) {
+            throw MappingFailedException::incorrectType($data, $path, 'int');
+        }
+
         if (is_int($data)) {
             if ($data < 5) {
                 throw MappingFailedException::incorrectValue($data, $path, 'value greater than or equal to 5');

--- a/tests/Compiler/Validator/Int/Data/IntRangeValidatorWithInclusiveLowerBoundMapper.php
+++ b/tests/Compiler/Validator/Int/Data/IntRangeValidatorWithInclusiveLowerBoundMapper.php
@@ -28,10 +28,8 @@ class IntRangeValidatorWithInclusiveLowerBoundMapper implements Mapper
             throw MappingFailedException::incorrectType($data, $path, 'int');
         }
 
-        if (is_int($data)) {
-            if ($data < 5) {
-                throw MappingFailedException::incorrectValue($data, $path, 'value greater than or equal to 5');
-            }
+        if ($data < 5) {
+            throw MappingFailedException::incorrectValue($data, $path, 'value greater than or equal to 5');
         }
 
         return $data;

--- a/tests/Compiler/Validator/Int/Data/IntRangeValidatorWithInclusiveUpperBoundMapper.php
+++ b/tests/Compiler/Validator/Int/Data/IntRangeValidatorWithInclusiveUpperBoundMapper.php
@@ -10,7 +10,7 @@ use function is_int;
 /**
  * Generated mapper. Do not edit directly.
  *
- * @implements Mapper<mixed>
+ * @implements Mapper<int>
  */
 class IntRangeValidatorWithInclusiveUpperBoundMapper implements Mapper
 {
@@ -22,8 +22,12 @@ class IntRangeValidatorWithInclusiveUpperBoundMapper implements Mapper
      * @param  list<string|int> $path
      * @throws MappingFailedException
      */
-    public function map(mixed $data, array $path = []): mixed
+    public function map(mixed $data, array $path = []): int
     {
+        if (!is_int($data)) {
+            throw MappingFailedException::incorrectType($data, $path, 'int');
+        }
+
         if (is_int($data)) {
             if ($data > 5) {
                 throw MappingFailedException::incorrectValue($data, $path, 'value less than or equal to 5');

--- a/tests/Compiler/Validator/Int/Data/IntRangeValidatorWithInclusiveUpperBoundMapper.php
+++ b/tests/Compiler/Validator/Int/Data/IntRangeValidatorWithInclusiveUpperBoundMapper.php
@@ -28,10 +28,8 @@ class IntRangeValidatorWithInclusiveUpperBoundMapper implements Mapper
             throw MappingFailedException::incorrectType($data, $path, 'int');
         }
 
-        if (is_int($data)) {
-            if ($data > 5) {
-                throw MappingFailedException::incorrectValue($data, $path, 'value less than or equal to 5');
-            }
+        if ($data > 5) {
+            throw MappingFailedException::incorrectValue($data, $path, 'value less than or equal to 5');
         }
 
         return $data;

--- a/tests/Compiler/Validator/Int/Data/NoopIntRangeValidatorMapper.php
+++ b/tests/Compiler/Validator/Int/Data/NoopIntRangeValidatorMapper.php
@@ -5,11 +5,12 @@ namespace ShipMonkTests\InputMapper\Compiler\Validator\Int\Data;
 use ShipMonk\InputMapper\Runtime\Exception\MappingFailedException;
 use ShipMonk\InputMapper\Runtime\Mapper;
 use ShipMonk\InputMapper\Runtime\MapperProvider;
+use function is_int;
 
 /**
  * Generated mapper. Do not edit directly.
  *
- * @implements Mapper<mixed>
+ * @implements Mapper<int>
  */
 class NoopIntRangeValidatorMapper implements Mapper
 {
@@ -21,8 +22,12 @@ class NoopIntRangeValidatorMapper implements Mapper
      * @param  list<string|int> $path
      * @throws MappingFailedException
      */
-    public function map(mixed $data, array $path = []): mixed
+    public function map(mixed $data, array $path = []): int
     {
+        if (!is_int($data)) {
+            throw MappingFailedException::incorrectType($data, $path, 'int');
+        }
+
         return $data;
     }
 }

--- a/tests/Compiler/Validator/Object/AssertDateTimeRangeTest.php
+++ b/tests/Compiler/Validator/Object/AssertDateTimeRangeTest.php
@@ -3,7 +3,9 @@
 namespace ShipMonkTests\InputMapper\Compiler\Validator\Object;
 
 use DateTimeImmutable;
-use DateTimeZone;
+use DateTimeInterface;
+use ShipMonk\InputMapper\Compiler\Mapper\Object\MapDate;
+use ShipMonk\InputMapper\Compiler\Mapper\Object\MapDateTimeImmutable;
 use ShipMonk\InputMapper\Compiler\Validator\Object\AssertDateTimeRange;
 use ShipMonk\InputMapper\Runtime\Exception\MappingFailedException;
 use ShipMonkTests\InputMapper\Compiler\Validator\ValidatorCompilerTestCase;
@@ -13,161 +15,152 @@ class AssertDateTimeRangeTest extends ValidatorCompilerTestCase
 
     public function testNoopDateTimeRangeValidator(): void
     {
+        $mapperCompiler = new MapDate();
         $validatorCompiler = new AssertDateTimeRange();
-        $validator = $this->compileValidator('NoopDateTimeRangeValidator', $validatorCompiler);
+        $validator = $this->compileValidator('NoopDateTimeRangeValidator', $mapperCompiler, $validatorCompiler);
 
-        $validator->map(123);
-        $validator->map(null);
-        $validator->map([]);
+        $validator->map('2000-01-05');
         self::assertTrue(true); // @phpstan-ignore-line always true
     }
 
     public function testDateTimeRangeValidatorWithInclusiveLowerBound(): void
     {
+        $mapperCompiler = new MapDate();
         $validatorCompiler = new AssertDateTimeRange(gte: '2000-01-05');
-        $validator = $this->compileValidator('DateTimeRangeValidatorWithInclusiveLowerBound', $validatorCompiler);
+        $validator = $this->compileValidator('DateTimeRangeValidatorWithInclusiveLowerBound', $mapperCompiler, $validatorCompiler);
 
-        $validator->map(new DateTimeImmutable('2000-01-05'));
-        $validator->map(new DateTimeImmutable('2000-01-06'));
-        $validator->map(null);
-        $validator->map([]);
+        $validator->map('2000-01-05');
+        $validator->map('2000-01-06');
 
         self::assertException(
             MappingFailedException::class,
             'Failed to map data at path /: Expected value greater than or equal to 2000-01-05, got 2000-01-04 (UTC)',
-            static fn() => $validator->map(new DateTimeImmutable('2000-01-04')),
+            static fn() => $validator->map('2000-01-04'),
         );
     }
 
     public function testDateTimeRangeValidatorWithExclusiveLowerBound(): void
     {
+        $mapperCompiler = new MapDate();
         $validatorCompiler = new AssertDateTimeRange(gt: '2000-01-05');
-        $validator = $this->compileValidator('DateTimeRangeValidatorWithExclusiveLowerBound', $validatorCompiler);
+        $validator = $this->compileValidator('DateTimeRangeValidatorWithExclusiveLowerBound', $mapperCompiler, $validatorCompiler);
 
-        $validator->map(new DateTimeImmutable('2000-01-06'));
-        $validator->map(null);
-        $validator->map([]);
+        $validator->map('2000-01-06');
 
         self::assertException(
             MappingFailedException::class,
             'Failed to map data at path /: Expected value greater than 2000-01-05, got 2000-01-05 (UTC)',
-            static fn() => $validator->map(new DateTimeImmutable('2000-01-05')),
+            static fn() => $validator->map('2000-01-05'),
         );
     }
 
     public function testDateTimeRangeValidatorWithInclusiveUpperBound(): void
     {
+        $mapperCompiler = new MapDate();
         $validatorCompiler = new AssertDateTimeRange(lte: '2000-01-05');
-        $validator = $this->compileValidator('DateTimeRangeValidatorWithInclusiveUpperBound', $validatorCompiler);
+        $validator = $this->compileValidator('DateTimeRangeValidatorWithInclusiveUpperBound', $mapperCompiler, $validatorCompiler);
 
-        $validator->map(new DateTimeImmutable('2000-01-05'));
-        $validator->map(new DateTimeImmutable('2000-01-04'));
-        $validator->map(null);
-        $validator->map([]);
+        $validator->map('2000-01-05');
+        $validator->map('2000-01-04');
 
         self::assertException(
             MappingFailedException::class,
             'Failed to map data at path /: Expected value less than or equal to 2000-01-05, got 2000-01-06 (UTC)',
-            static fn() => $validator->map(new DateTimeImmutable('2000-01-06')),
+            static fn() => $validator->map('2000-01-06'),
         );
     }
 
     public function testDateTimeRangeValidatorWithExclusiveUpperBound(): void
     {
+        $mapperCompiler = new MapDate();
         $validatorCompiler = new AssertDateTimeRange(lt: '2000-01-05');
-        $validator = $this->compileValidator('DateTimeRangeValidatorWithExclusiveUpperBound', $validatorCompiler);
+        $validator = $this->compileValidator('DateTimeRangeValidatorWithExclusiveUpperBound', $mapperCompiler, $validatorCompiler);
 
-        $validator->map(new DateTimeImmutable('2000-01-04'));
-        $validator->map(null);
-        $validator->map([]);
+        $validator->map('2000-01-04');
 
         self::assertException(
             MappingFailedException::class,
             'Failed to map data at path /: Expected value less than 2000-01-05, got 2000-01-05 (UTC)',
-            static fn() => $validator->map(new DateTimeImmutable('2000-01-05')),
+            static fn() => $validator->map('2000-01-05'),
         );
     }
 
     public function testDateTimeRangeValidatorWithInclusiveLowerAndUpperBound(): void
     {
+        $mapperCompiler = new MapDate();
         $validatorCompiler = new AssertDateTimeRange(gte: '2000-01-05', lte: '2000-01-10');
-        $validator = $this->compileValidator('DateTimeRangeValidatorWithInclusiveLowerAndUpperBound', $validatorCompiler);
+        $validator = $this->compileValidator('DateTimeRangeValidatorWithInclusiveLowerAndUpperBound', $mapperCompiler, $validatorCompiler);
 
-        $validator->map(new DateTimeImmutable('2000-01-05'));
-        $validator->map(new DateTimeImmutable('2000-01-06'));
-        $validator->map(new DateTimeImmutable('2000-01-10'));
-        $validator->map(null);
-        $validator->map([]);
+        $validator->map('2000-01-05');
+        $validator->map('2000-01-06');
+        $validator->map('2000-01-10');
 
         self::assertException(
             MappingFailedException::class,
             'Failed to map data at path /: Expected value greater than or equal to 2000-01-05, got 2000-01-04 (UTC)',
-            static fn() => $validator->map(new DateTimeImmutable('2000-01-04')),
+            static fn() => $validator->map('2000-01-04'),
         );
 
         self::assertException(
             MappingFailedException::class,
             'Failed to map data at path /: Expected value less than or equal to 2000-01-10, got 2000-01-11 (UTC)',
-            static fn() => $validator->map(new DateTimeImmutable('2000-01-11')),
+            static fn() => $validator->map('2000-01-11'),
         );
     }
 
     public function testDateTimeRangeValidatorWithBothDateAndTime(): void
     {
+        $mapperCompiler = new MapDateTimeImmutable(format: DateTimeInterface::RFC3339);
         $validatorCompiler = new AssertDateTimeRange(gte: '2000-01-01T00:00:05Z');
-        $validator = $this->compileValidator('DateTimeRangeValidatorWithBothDateAndTime', $validatorCompiler);
+        $validator = $this->compileValidator('DateTimeRangeValidatorWithBothDateAndTime', $mapperCompiler, $validatorCompiler);
 
-        $validator->map(new DateTimeImmutable('2000-01-01T00:00:05Z'));
-        $validator->map(new DateTimeImmutable('2000-01-01T02:00:05+02:00'));
-        $validator->map(new DateTimeImmutable('1999-12-31T19:00:05-05:00'));
-        $validator->map(new DateTimeImmutable('2000-01-01T00:00:06Z'));
-        $validator->map(null);
-        $validator->map([]);
+        $validator->map('2000-01-01T00:00:05Z');
+        $validator->map('2000-01-01T02:00:05+02:00');
+        $validator->map('1999-12-31T19:00:05-05:00');
+        $validator->map('2000-01-01T00:00:06Z');
 
         self::assertException(
             MappingFailedException::class,
             'Failed to map data at path /: Expected value greater than or equal to 2000-01-01T00:00:05Z, got 2000-01-01T00:00:04+00:00',
-            static fn() => $validator->map(new DateTimeImmutable('2000-01-01T00:00:04Z')),
+            static fn() => $validator->map('2000-01-01T00:00:04Z'),
         );
 
         self::assertException(
             MappingFailedException::class,
             'Failed to map data at path /: Expected value greater than or equal to 2000-01-01T00:00:05Z, got 2000-01-01T02:00:04+02:00',
-            static fn() => $validator->map(new DateTimeImmutable('2000-01-01T02:00:04+02:00')),
+            static fn() => $validator->map('2000-01-01T02:00:04+02:00'),
         );
     }
 
     public function testDateTimeRangeValidatorWithRelativeBound(): void
     {
+        $mapperCompiler = new MapDateTimeImmutable(format: DateTimeInterface::RFC3339);
         $validatorCompiler = new AssertDateTimeRange(gte: 'now');
-        $validator = $this->compileValidator('DateTimeRangeValidatorWithRelativeBound', $validatorCompiler);
+        $validator = $this->compileValidator('DateTimeRangeValidatorWithRelativeBound', $mapperCompiler, $validatorCompiler);
 
-        $validator->map(new DateTimeImmutable('+1 day'));
-        $validator->map(new DateTimeImmutable('+1 hour'));
-        $validator->map(null);
-        $validator->map([]);
+        $validator->map((new DateTimeImmutable('+1 day'))->format(DateTimeInterface::RFC3339));
+        $validator->map((new DateTimeImmutable('+1 hour'))->format(DateTimeInterface::RFC3339));
 
         self::assertException(
             MappingFailedException::class,
             'Failed to map data at path /: Expected value greater than or equal to now, got %s',
-            static fn() => $validator->map(new DateTimeImmutable('-1 minute')),
+            static fn() => $validator->map((new DateTimeImmutable('-1 minute'))->format(DateTimeInterface::RFC3339)),
         );
     }
 
     public function testDateTimeRangeValidatorWithTimezone(): void
     {
+        $mapperCompiler = new MapDateTimeImmutable(format: '!Y-m-d', defaultTimezone: 'America/New_York');
         $validatorCompiler = new AssertDateTimeRange(gte: '2000-01-05', timezone: 'America/New_York');
-        $validator = $this->compileValidator('DateTimeRangeValidatorWithTimezone', $validatorCompiler);
+        $validator = $this->compileValidator('DateTimeRangeValidatorWithTimezone', $mapperCompiler, $validatorCompiler);
 
-        $validator->map(new DateTimeImmutable('2000-01-05', new DateTimeZone('America/New_York')));
-        $validator->map(new DateTimeImmutable('2000-01-06', new DateTimeZone('America/New_York')));
-        $validator->map(null);
-        $validator->map([]);
+        $validator->map('2000-01-05');
+        $validator->map('2000-01-06');
 
         self::assertException(
             MappingFailedException::class,
             'Failed to map data at path /: Expected value greater than or equal to 2000-01-05 (in America/New_York timezone), got 2000-01-04 (America/New_York)',
-            static fn() => $validator->map(new DateTimeImmutable('2000-01-04', new DateTimeZone('America/New_York'))),
+            static fn() => $validator->map('2000-01-04'),
         );
     }
 

--- a/tests/Compiler/Validator/Object/Data/DateTimeRangeValidatorWithBothDateAndTimeMapper.php
+++ b/tests/Compiler/Validator/Object/Data/DateTimeRangeValidatorWithBothDateAndTimeMapper.php
@@ -3,7 +3,6 @@
 namespace ShipMonkTests\InputMapper\Compiler\Validator\Object\Data;
 
 use DateTimeImmutable;
-use DateTimeInterface;
 use ShipMonk\InputMapper\Runtime\Exception\MappingFailedException;
 use ShipMonk\InputMapper\Runtime\Mapper;
 use ShipMonk\InputMapper\Runtime\MapperProvider;
@@ -36,10 +35,8 @@ class DateTimeRangeValidatorWithBothDateAndTimeMapper implements Mapper
             throw MappingFailedException::incorrectValue($data, $path, 'date-time string in RFC 3339 format');
         }
 
-        if ($mapped instanceof DateTimeInterface) {
-            if ($mapped < new DateTimeImmutable('2000-01-01T00:00:05Z')) {
-                throw MappingFailedException::incorrectValue($mapped, $path, 'value greater than or equal to 2000-01-01T00:00:05Z');
-            }
+        if ($mapped < new DateTimeImmutable('2000-01-01T00:00:05Z')) {
+            throw MappingFailedException::incorrectValue($mapped, $path, 'value greater than or equal to 2000-01-01T00:00:05Z');
         }
 
         return $mapped;

--- a/tests/Compiler/Validator/Object/Data/DateTimeRangeValidatorWithBothDateAndTimeMapper.php
+++ b/tests/Compiler/Validator/Object/Data/DateTimeRangeValidatorWithBothDateAndTimeMapper.php
@@ -7,11 +7,12 @@ use DateTimeInterface;
 use ShipMonk\InputMapper\Runtime\Exception\MappingFailedException;
 use ShipMonk\InputMapper\Runtime\Mapper;
 use ShipMonk\InputMapper\Runtime\MapperProvider;
+use function is_string;
 
 /**
  * Generated mapper. Do not edit directly.
  *
- * @implements Mapper<mixed>
+ * @implements Mapper<DateTimeImmutable>
  */
 class DateTimeRangeValidatorWithBothDateAndTimeMapper implements Mapper
 {
@@ -23,14 +24,24 @@ class DateTimeRangeValidatorWithBothDateAndTimeMapper implements Mapper
      * @param  list<string|int> $path
      * @throws MappingFailedException
      */
-    public function map(mixed $data, array $path = []): mixed
+    public function map(mixed $data, array $path = []): DateTimeImmutable
     {
-        if ($data instanceof DateTimeInterface) {
-            if ($data < new DateTimeImmutable('2000-01-01T00:00:05Z')) {
-                throw MappingFailedException::incorrectValue($data, $path, 'value greater than or equal to 2000-01-01T00:00:05Z');
+        if (!is_string($data)) {
+            throw MappingFailedException::incorrectType($data, $path, 'string');
+        }
+
+        $mapped = DateTimeImmutable::createFromFormat('Y-m-d\\TH:i:sP', $data);
+
+        if ($mapped === false) {
+            throw MappingFailedException::incorrectValue($data, $path, 'date-time string in RFC 3339 format');
+        }
+
+        if ($mapped instanceof DateTimeInterface) {
+            if ($mapped < new DateTimeImmutable('2000-01-01T00:00:05Z')) {
+                throw MappingFailedException::incorrectValue($mapped, $path, 'value greater than or equal to 2000-01-01T00:00:05Z');
             }
         }
 
-        return $data;
+        return $mapped;
     }
 }

--- a/tests/Compiler/Validator/Object/Data/DateTimeRangeValidatorWithExclusiveLowerBoundMapper.php
+++ b/tests/Compiler/Validator/Object/Data/DateTimeRangeValidatorWithExclusiveLowerBoundMapper.php
@@ -7,11 +7,12 @@ use DateTimeInterface;
 use ShipMonk\InputMapper\Runtime\Exception\MappingFailedException;
 use ShipMonk\InputMapper\Runtime\Mapper;
 use ShipMonk\InputMapper\Runtime\MapperProvider;
+use function is_string;
 
 /**
  * Generated mapper. Do not edit directly.
  *
- * @implements Mapper<mixed>
+ * @implements Mapper<DateTimeImmutable>
  */
 class DateTimeRangeValidatorWithExclusiveLowerBoundMapper implements Mapper
 {
@@ -23,14 +24,24 @@ class DateTimeRangeValidatorWithExclusiveLowerBoundMapper implements Mapper
      * @param  list<string|int> $path
      * @throws MappingFailedException
      */
-    public function map(mixed $data, array $path = []): mixed
+    public function map(mixed $data, array $path = []): DateTimeImmutable
     {
-        if ($data instanceof DateTimeInterface) {
-            if ($data <= new DateTimeImmutable('2000-01-05')) {
-                throw MappingFailedException::incorrectValue($data, $path, 'value greater than 2000-01-05');
+        if (!is_string($data)) {
+            throw MappingFailedException::incorrectType($data, $path, 'string');
+        }
+
+        $mapped = DateTimeImmutable::createFromFormat('!Y-m-d', $data);
+
+        if ($mapped === false) {
+            throw MappingFailedException::incorrectValue($data, $path, 'date string in Y-m-d format');
+        }
+
+        if ($mapped instanceof DateTimeInterface) {
+            if ($mapped <= new DateTimeImmutable('2000-01-05')) {
+                throw MappingFailedException::incorrectValue($mapped, $path, 'value greater than 2000-01-05');
             }
         }
 
-        return $data;
+        return $mapped;
     }
 }

--- a/tests/Compiler/Validator/Object/Data/DateTimeRangeValidatorWithExclusiveLowerBoundMapper.php
+++ b/tests/Compiler/Validator/Object/Data/DateTimeRangeValidatorWithExclusiveLowerBoundMapper.php
@@ -3,7 +3,6 @@
 namespace ShipMonkTests\InputMapper\Compiler\Validator\Object\Data;
 
 use DateTimeImmutable;
-use DateTimeInterface;
 use ShipMonk\InputMapper\Runtime\Exception\MappingFailedException;
 use ShipMonk\InputMapper\Runtime\Mapper;
 use ShipMonk\InputMapper\Runtime\MapperProvider;
@@ -36,10 +35,8 @@ class DateTimeRangeValidatorWithExclusiveLowerBoundMapper implements Mapper
             throw MappingFailedException::incorrectValue($data, $path, 'date string in Y-m-d format');
         }
 
-        if ($mapped instanceof DateTimeInterface) {
-            if ($mapped <= new DateTimeImmutable('2000-01-05')) {
-                throw MappingFailedException::incorrectValue($mapped, $path, 'value greater than 2000-01-05');
-            }
+        if ($mapped <= new DateTimeImmutable('2000-01-05')) {
+            throw MappingFailedException::incorrectValue($mapped, $path, 'value greater than 2000-01-05');
         }
 
         return $mapped;

--- a/tests/Compiler/Validator/Object/Data/DateTimeRangeValidatorWithExclusiveUpperBoundMapper.php
+++ b/tests/Compiler/Validator/Object/Data/DateTimeRangeValidatorWithExclusiveUpperBoundMapper.php
@@ -7,11 +7,12 @@ use DateTimeInterface;
 use ShipMonk\InputMapper\Runtime\Exception\MappingFailedException;
 use ShipMonk\InputMapper\Runtime\Mapper;
 use ShipMonk\InputMapper\Runtime\MapperProvider;
+use function is_string;
 
 /**
  * Generated mapper. Do not edit directly.
  *
- * @implements Mapper<mixed>
+ * @implements Mapper<DateTimeImmutable>
  */
 class DateTimeRangeValidatorWithExclusiveUpperBoundMapper implements Mapper
 {
@@ -23,14 +24,24 @@ class DateTimeRangeValidatorWithExclusiveUpperBoundMapper implements Mapper
      * @param  list<string|int> $path
      * @throws MappingFailedException
      */
-    public function map(mixed $data, array $path = []): mixed
+    public function map(mixed $data, array $path = []): DateTimeImmutable
     {
-        if ($data instanceof DateTimeInterface) {
-            if ($data >= new DateTimeImmutable('2000-01-05')) {
-                throw MappingFailedException::incorrectValue($data, $path, 'value less than 2000-01-05');
+        if (!is_string($data)) {
+            throw MappingFailedException::incorrectType($data, $path, 'string');
+        }
+
+        $mapped = DateTimeImmutable::createFromFormat('!Y-m-d', $data);
+
+        if ($mapped === false) {
+            throw MappingFailedException::incorrectValue($data, $path, 'date string in Y-m-d format');
+        }
+
+        if ($mapped instanceof DateTimeInterface) {
+            if ($mapped >= new DateTimeImmutable('2000-01-05')) {
+                throw MappingFailedException::incorrectValue($mapped, $path, 'value less than 2000-01-05');
             }
         }
 
-        return $data;
+        return $mapped;
     }
 }

--- a/tests/Compiler/Validator/Object/Data/DateTimeRangeValidatorWithExclusiveUpperBoundMapper.php
+++ b/tests/Compiler/Validator/Object/Data/DateTimeRangeValidatorWithExclusiveUpperBoundMapper.php
@@ -3,7 +3,6 @@
 namespace ShipMonkTests\InputMapper\Compiler\Validator\Object\Data;
 
 use DateTimeImmutable;
-use DateTimeInterface;
 use ShipMonk\InputMapper\Runtime\Exception\MappingFailedException;
 use ShipMonk\InputMapper\Runtime\Mapper;
 use ShipMonk\InputMapper\Runtime\MapperProvider;
@@ -36,10 +35,8 @@ class DateTimeRangeValidatorWithExclusiveUpperBoundMapper implements Mapper
             throw MappingFailedException::incorrectValue($data, $path, 'date string in Y-m-d format');
         }
 
-        if ($mapped instanceof DateTimeInterface) {
-            if ($mapped >= new DateTimeImmutable('2000-01-05')) {
-                throw MappingFailedException::incorrectValue($mapped, $path, 'value less than 2000-01-05');
-            }
+        if ($mapped >= new DateTimeImmutable('2000-01-05')) {
+            throw MappingFailedException::incorrectValue($mapped, $path, 'value less than 2000-01-05');
         }
 
         return $mapped;

--- a/tests/Compiler/Validator/Object/Data/DateTimeRangeValidatorWithInclusiveLowerAndUpperBoundMapper.php
+++ b/tests/Compiler/Validator/Object/Data/DateTimeRangeValidatorWithInclusiveLowerAndUpperBoundMapper.php
@@ -7,11 +7,12 @@ use DateTimeInterface;
 use ShipMonk\InputMapper\Runtime\Exception\MappingFailedException;
 use ShipMonk\InputMapper\Runtime\Mapper;
 use ShipMonk\InputMapper\Runtime\MapperProvider;
+use function is_string;
 
 /**
  * Generated mapper. Do not edit directly.
  *
- * @implements Mapper<mixed>
+ * @implements Mapper<DateTimeImmutable>
  */
 class DateTimeRangeValidatorWithInclusiveLowerAndUpperBoundMapper implements Mapper
 {
@@ -23,18 +24,28 @@ class DateTimeRangeValidatorWithInclusiveLowerAndUpperBoundMapper implements Map
      * @param  list<string|int> $path
      * @throws MappingFailedException
      */
-    public function map(mixed $data, array $path = []): mixed
+    public function map(mixed $data, array $path = []): DateTimeImmutable
     {
-        if ($data instanceof DateTimeInterface) {
-            if ($data < new DateTimeImmutable('2000-01-05')) {
-                throw MappingFailedException::incorrectValue($data, $path, 'value greater than or equal to 2000-01-05');
+        if (!is_string($data)) {
+            throw MappingFailedException::incorrectType($data, $path, 'string');
+        }
+
+        $mapped = DateTimeImmutable::createFromFormat('!Y-m-d', $data);
+
+        if ($mapped === false) {
+            throw MappingFailedException::incorrectValue($data, $path, 'date string in Y-m-d format');
+        }
+
+        if ($mapped instanceof DateTimeInterface) {
+            if ($mapped < new DateTimeImmutable('2000-01-05')) {
+                throw MappingFailedException::incorrectValue($mapped, $path, 'value greater than or equal to 2000-01-05');
             }
 
-            if ($data > new DateTimeImmutable('2000-01-10')) {
-                throw MappingFailedException::incorrectValue($data, $path, 'value less than or equal to 2000-01-10');
+            if ($mapped > new DateTimeImmutable('2000-01-10')) {
+                throw MappingFailedException::incorrectValue($mapped, $path, 'value less than or equal to 2000-01-10');
             }
         }
 
-        return $data;
+        return $mapped;
     }
 }

--- a/tests/Compiler/Validator/Object/Data/DateTimeRangeValidatorWithInclusiveLowerAndUpperBoundMapper.php
+++ b/tests/Compiler/Validator/Object/Data/DateTimeRangeValidatorWithInclusiveLowerAndUpperBoundMapper.php
@@ -3,7 +3,6 @@
 namespace ShipMonkTests\InputMapper\Compiler\Validator\Object\Data;
 
 use DateTimeImmutable;
-use DateTimeInterface;
 use ShipMonk\InputMapper\Runtime\Exception\MappingFailedException;
 use ShipMonk\InputMapper\Runtime\Mapper;
 use ShipMonk\InputMapper\Runtime\MapperProvider;
@@ -36,14 +35,12 @@ class DateTimeRangeValidatorWithInclusiveLowerAndUpperBoundMapper implements Map
             throw MappingFailedException::incorrectValue($data, $path, 'date string in Y-m-d format');
         }
 
-        if ($mapped instanceof DateTimeInterface) {
-            if ($mapped < new DateTimeImmutable('2000-01-05')) {
-                throw MappingFailedException::incorrectValue($mapped, $path, 'value greater than or equal to 2000-01-05');
-            }
+        if ($mapped < new DateTimeImmutable('2000-01-05')) {
+            throw MappingFailedException::incorrectValue($mapped, $path, 'value greater than or equal to 2000-01-05');
+        }
 
-            if ($mapped > new DateTimeImmutable('2000-01-10')) {
-                throw MappingFailedException::incorrectValue($mapped, $path, 'value less than or equal to 2000-01-10');
-            }
+        if ($mapped > new DateTimeImmutable('2000-01-10')) {
+            throw MappingFailedException::incorrectValue($mapped, $path, 'value less than or equal to 2000-01-10');
         }
 
         return $mapped;

--- a/tests/Compiler/Validator/Object/Data/DateTimeRangeValidatorWithInclusiveLowerBoundMapper.php
+++ b/tests/Compiler/Validator/Object/Data/DateTimeRangeValidatorWithInclusiveLowerBoundMapper.php
@@ -3,7 +3,6 @@
 namespace ShipMonkTests\InputMapper\Compiler\Validator\Object\Data;
 
 use DateTimeImmutable;
-use DateTimeInterface;
 use ShipMonk\InputMapper\Runtime\Exception\MappingFailedException;
 use ShipMonk\InputMapper\Runtime\Mapper;
 use ShipMonk\InputMapper\Runtime\MapperProvider;
@@ -36,10 +35,8 @@ class DateTimeRangeValidatorWithInclusiveLowerBoundMapper implements Mapper
             throw MappingFailedException::incorrectValue($data, $path, 'date string in Y-m-d format');
         }
 
-        if ($mapped instanceof DateTimeInterface) {
-            if ($mapped < new DateTimeImmutable('2000-01-05')) {
-                throw MappingFailedException::incorrectValue($mapped, $path, 'value greater than or equal to 2000-01-05');
-            }
+        if ($mapped < new DateTimeImmutable('2000-01-05')) {
+            throw MappingFailedException::incorrectValue($mapped, $path, 'value greater than or equal to 2000-01-05');
         }
 
         return $mapped;

--- a/tests/Compiler/Validator/Object/Data/DateTimeRangeValidatorWithInclusiveLowerBoundMapper.php
+++ b/tests/Compiler/Validator/Object/Data/DateTimeRangeValidatorWithInclusiveLowerBoundMapper.php
@@ -7,11 +7,12 @@ use DateTimeInterface;
 use ShipMonk\InputMapper\Runtime\Exception\MappingFailedException;
 use ShipMonk\InputMapper\Runtime\Mapper;
 use ShipMonk\InputMapper\Runtime\MapperProvider;
+use function is_string;
 
 /**
  * Generated mapper. Do not edit directly.
  *
- * @implements Mapper<mixed>
+ * @implements Mapper<DateTimeImmutable>
  */
 class DateTimeRangeValidatorWithInclusiveLowerBoundMapper implements Mapper
 {
@@ -23,14 +24,24 @@ class DateTimeRangeValidatorWithInclusiveLowerBoundMapper implements Mapper
      * @param  list<string|int> $path
      * @throws MappingFailedException
      */
-    public function map(mixed $data, array $path = []): mixed
+    public function map(mixed $data, array $path = []): DateTimeImmutable
     {
-        if ($data instanceof DateTimeInterface) {
-            if ($data < new DateTimeImmutable('2000-01-05')) {
-                throw MappingFailedException::incorrectValue($data, $path, 'value greater than or equal to 2000-01-05');
+        if (!is_string($data)) {
+            throw MappingFailedException::incorrectType($data, $path, 'string');
+        }
+
+        $mapped = DateTimeImmutable::createFromFormat('!Y-m-d', $data);
+
+        if ($mapped === false) {
+            throw MappingFailedException::incorrectValue($data, $path, 'date string in Y-m-d format');
+        }
+
+        if ($mapped instanceof DateTimeInterface) {
+            if ($mapped < new DateTimeImmutable('2000-01-05')) {
+                throw MappingFailedException::incorrectValue($mapped, $path, 'value greater than or equal to 2000-01-05');
             }
         }
 
-        return $data;
+        return $mapped;
     }
 }

--- a/tests/Compiler/Validator/Object/Data/DateTimeRangeValidatorWithInclusiveUpperBoundMapper.php
+++ b/tests/Compiler/Validator/Object/Data/DateTimeRangeValidatorWithInclusiveUpperBoundMapper.php
@@ -3,7 +3,6 @@
 namespace ShipMonkTests\InputMapper\Compiler\Validator\Object\Data;
 
 use DateTimeImmutable;
-use DateTimeInterface;
 use ShipMonk\InputMapper\Runtime\Exception\MappingFailedException;
 use ShipMonk\InputMapper\Runtime\Mapper;
 use ShipMonk\InputMapper\Runtime\MapperProvider;
@@ -36,10 +35,8 @@ class DateTimeRangeValidatorWithInclusiveUpperBoundMapper implements Mapper
             throw MappingFailedException::incorrectValue($data, $path, 'date string in Y-m-d format');
         }
 
-        if ($mapped instanceof DateTimeInterface) {
-            if ($mapped > new DateTimeImmutable('2000-01-05')) {
-                throw MappingFailedException::incorrectValue($mapped, $path, 'value less than or equal to 2000-01-05');
-            }
+        if ($mapped > new DateTimeImmutable('2000-01-05')) {
+            throw MappingFailedException::incorrectValue($mapped, $path, 'value less than or equal to 2000-01-05');
         }
 
         return $mapped;

--- a/tests/Compiler/Validator/Object/Data/DateTimeRangeValidatorWithInclusiveUpperBoundMapper.php
+++ b/tests/Compiler/Validator/Object/Data/DateTimeRangeValidatorWithInclusiveUpperBoundMapper.php
@@ -7,11 +7,12 @@ use DateTimeInterface;
 use ShipMonk\InputMapper\Runtime\Exception\MappingFailedException;
 use ShipMonk\InputMapper\Runtime\Mapper;
 use ShipMonk\InputMapper\Runtime\MapperProvider;
+use function is_string;
 
 /**
  * Generated mapper. Do not edit directly.
  *
- * @implements Mapper<mixed>
+ * @implements Mapper<DateTimeImmutable>
  */
 class DateTimeRangeValidatorWithInclusiveUpperBoundMapper implements Mapper
 {
@@ -23,14 +24,24 @@ class DateTimeRangeValidatorWithInclusiveUpperBoundMapper implements Mapper
      * @param  list<string|int> $path
      * @throws MappingFailedException
      */
-    public function map(mixed $data, array $path = []): mixed
+    public function map(mixed $data, array $path = []): DateTimeImmutable
     {
-        if ($data instanceof DateTimeInterface) {
-            if ($data > new DateTimeImmutable('2000-01-05')) {
-                throw MappingFailedException::incorrectValue($data, $path, 'value less than or equal to 2000-01-05');
+        if (!is_string($data)) {
+            throw MappingFailedException::incorrectType($data, $path, 'string');
+        }
+
+        $mapped = DateTimeImmutable::createFromFormat('!Y-m-d', $data);
+
+        if ($mapped === false) {
+            throw MappingFailedException::incorrectValue($data, $path, 'date string in Y-m-d format');
+        }
+
+        if ($mapped instanceof DateTimeInterface) {
+            if ($mapped > new DateTimeImmutable('2000-01-05')) {
+                throw MappingFailedException::incorrectValue($mapped, $path, 'value less than or equal to 2000-01-05');
             }
         }
 
-        return $data;
+        return $mapped;
     }
 }

--- a/tests/Compiler/Validator/Object/Data/DateTimeRangeValidatorWithRelativeBoundMapper.php
+++ b/tests/Compiler/Validator/Object/Data/DateTimeRangeValidatorWithRelativeBoundMapper.php
@@ -7,11 +7,12 @@ use DateTimeInterface;
 use ShipMonk\InputMapper\Runtime\Exception\MappingFailedException;
 use ShipMonk\InputMapper\Runtime\Mapper;
 use ShipMonk\InputMapper\Runtime\MapperProvider;
+use function is_string;
 
 /**
  * Generated mapper. Do not edit directly.
  *
- * @implements Mapper<mixed>
+ * @implements Mapper<DateTimeImmutable>
  */
 class DateTimeRangeValidatorWithRelativeBoundMapper implements Mapper
 {
@@ -23,14 +24,24 @@ class DateTimeRangeValidatorWithRelativeBoundMapper implements Mapper
      * @param  list<string|int> $path
      * @throws MappingFailedException
      */
-    public function map(mixed $data, array $path = []): mixed
+    public function map(mixed $data, array $path = []): DateTimeImmutable
     {
-        if ($data instanceof DateTimeInterface) {
-            if ($data < new DateTimeImmutable('now')) {
-                throw MappingFailedException::incorrectValue($data, $path, 'value greater than or equal to now');
+        if (!is_string($data)) {
+            throw MappingFailedException::incorrectType($data, $path, 'string');
+        }
+
+        $mapped = DateTimeImmutable::createFromFormat('Y-m-d\\TH:i:sP', $data);
+
+        if ($mapped === false) {
+            throw MappingFailedException::incorrectValue($data, $path, 'date-time string in RFC 3339 format');
+        }
+
+        if ($mapped instanceof DateTimeInterface) {
+            if ($mapped < new DateTimeImmutable('now')) {
+                throw MappingFailedException::incorrectValue($mapped, $path, 'value greater than or equal to now');
             }
         }
 
-        return $data;
+        return $mapped;
     }
 }

--- a/tests/Compiler/Validator/Object/Data/DateTimeRangeValidatorWithRelativeBoundMapper.php
+++ b/tests/Compiler/Validator/Object/Data/DateTimeRangeValidatorWithRelativeBoundMapper.php
@@ -3,7 +3,6 @@
 namespace ShipMonkTests\InputMapper\Compiler\Validator\Object\Data;
 
 use DateTimeImmutable;
-use DateTimeInterface;
 use ShipMonk\InputMapper\Runtime\Exception\MappingFailedException;
 use ShipMonk\InputMapper\Runtime\Mapper;
 use ShipMonk\InputMapper\Runtime\MapperProvider;
@@ -36,10 +35,8 @@ class DateTimeRangeValidatorWithRelativeBoundMapper implements Mapper
             throw MappingFailedException::incorrectValue($data, $path, 'date-time string in RFC 3339 format');
         }
 
-        if ($mapped instanceof DateTimeInterface) {
-            if ($mapped < new DateTimeImmutable('now')) {
-                throw MappingFailedException::incorrectValue($mapped, $path, 'value greater than or equal to now');
-            }
+        if ($mapped < new DateTimeImmutable('now')) {
+            throw MappingFailedException::incorrectValue($mapped, $path, 'value greater than or equal to now');
         }
 
         return $mapped;

--- a/tests/Compiler/Validator/Object/Data/DateTimeRangeValidatorWithTimezoneMapper.php
+++ b/tests/Compiler/Validator/Object/Data/DateTimeRangeValidatorWithTimezoneMapper.php
@@ -3,7 +3,6 @@
 namespace ShipMonkTests\InputMapper\Compiler\Validator\Object\Data;
 
 use DateTimeImmutable;
-use DateTimeInterface;
 use DateTimeZone;
 use ShipMonk\InputMapper\Runtime\Exception\MappingFailedException;
 use ShipMonk\InputMapper\Runtime\Mapper;
@@ -38,15 +37,13 @@ class DateTimeRangeValidatorWithTimezoneMapper implements Mapper
             throw MappingFailedException::incorrectValue($data, $path, 'date-time string in RFC 3339 format');
         }
 
-        if ($mapped instanceof DateTimeInterface) {
-            $timezone2 = new DateTimeZone('America/New_York');
+        $timezone2 = new DateTimeZone('America/New_York');
 
-            if ($mapped < new DateTimeImmutable(
-                '2000-01-05',
-                $timezone2,
-            )) {
-                throw MappingFailedException::incorrectValue($mapped, $path, 'value greater than or equal to 2000-01-05 (in America/New_York timezone)');
-            }
+        if ($mapped < new DateTimeImmutable(
+            '2000-01-05',
+            $timezone2,
+        )) {
+            throw MappingFailedException::incorrectValue($mapped, $path, 'value greater than or equal to 2000-01-05 (in America/New_York timezone)');
         }
 
         return $mapped;

--- a/tests/Compiler/Validator/Object/Data/DateTimeRangeValidatorWithTimezoneMapper.php
+++ b/tests/Compiler/Validator/Object/Data/DateTimeRangeValidatorWithTimezoneMapper.php
@@ -8,11 +8,12 @@ use DateTimeZone;
 use ShipMonk\InputMapper\Runtime\Exception\MappingFailedException;
 use ShipMonk\InputMapper\Runtime\Mapper;
 use ShipMonk\InputMapper\Runtime\MapperProvider;
+use function is_string;
 
 /**
  * Generated mapper. Do not edit directly.
  *
- * @implements Mapper<mixed>
+ * @implements Mapper<DateTimeImmutable>
  */
 class DateTimeRangeValidatorWithTimezoneMapper implements Mapper
 {
@@ -24,19 +25,30 @@ class DateTimeRangeValidatorWithTimezoneMapper implements Mapper
      * @param  list<string|int> $path
      * @throws MappingFailedException
      */
-    public function map(mixed $data, array $path = []): mixed
+    public function map(mixed $data, array $path = []): DateTimeImmutable
     {
-        if ($data instanceof DateTimeInterface) {
-            $timezone = new DateTimeZone('America/New_York');
+        if (!is_string($data)) {
+            throw MappingFailedException::incorrectType($data, $path, 'string');
+        }
 
-            if ($data < new DateTimeImmutable(
+        $timezone = new DateTimeZone('America/New_York');
+        $mapped = DateTimeImmutable::createFromFormat('!Y-m-d', $data, $timezone);
+
+        if ($mapped === false) {
+            throw MappingFailedException::incorrectValue($data, $path, 'date-time string in RFC 3339 format');
+        }
+
+        if ($mapped instanceof DateTimeInterface) {
+            $timezone2 = new DateTimeZone('America/New_York');
+
+            if ($mapped < new DateTimeImmutable(
                 '2000-01-05',
-                $timezone,
+                $timezone2,
             )) {
-                throw MappingFailedException::incorrectValue($data, $path, 'value greater than or equal to 2000-01-05 (in America/New_York timezone)');
+                throw MappingFailedException::incorrectValue($mapped, $path, 'value greater than or equal to 2000-01-05 (in America/New_York timezone)');
             }
         }
 
-        return $data;
+        return $mapped;
     }
 }

--- a/tests/Compiler/Validator/Object/Data/NoopDateTimeRangeValidatorMapper.php
+++ b/tests/Compiler/Validator/Object/Data/NoopDateTimeRangeValidatorMapper.php
@@ -2,14 +2,16 @@
 
 namespace ShipMonkTests\InputMapper\Compiler\Validator\Object\Data;
 
+use DateTimeImmutable;
 use ShipMonk\InputMapper\Runtime\Exception\MappingFailedException;
 use ShipMonk\InputMapper\Runtime\Mapper;
 use ShipMonk\InputMapper\Runtime\MapperProvider;
+use function is_string;
 
 /**
  * Generated mapper. Do not edit directly.
  *
- * @implements Mapper<mixed>
+ * @implements Mapper<DateTimeImmutable>
  */
 class NoopDateTimeRangeValidatorMapper implements Mapper
 {
@@ -21,8 +23,18 @@ class NoopDateTimeRangeValidatorMapper implements Mapper
      * @param  list<string|int> $path
      * @throws MappingFailedException
      */
-    public function map(mixed $data, array $path = []): mixed
+    public function map(mixed $data, array $path = []): DateTimeImmutable
     {
-        return $data;
+        if (!is_string($data)) {
+            throw MappingFailedException::incorrectType($data, $path, 'string');
+        }
+
+        $mapped = DateTimeImmutable::createFromFormat('!Y-m-d', $data);
+
+        if ($mapped === false) {
+            throw MappingFailedException::incorrectValue($data, $path, 'date string in Y-m-d format');
+        }
+
+        return $mapped;
     }
 }

--- a/tests/Compiler/Validator/String/AssertStringLengthTest.php
+++ b/tests/Compiler/Validator/String/AssertStringLengthTest.php
@@ -3,6 +3,7 @@
 namespace ShipMonkTests\InputMapper\Compiler\Validator\String;
 
 use LogicException;
+use ShipMonk\InputMapper\Compiler\Mapper\Scalar\MapString;
 use ShipMonk\InputMapper\Compiler\Validator\String\AssertStringLength;
 use ShipMonk\InputMapper\Runtime\Exception\MappingFailedException;
 use ShipMonkTests\InputMapper\Compiler\Validator\ValidatorCompilerTestCase;
@@ -12,25 +13,22 @@ class AssertStringLengthTest extends ValidatorCompilerTestCase
 
     public function testNoopStringLengthValidator(): void
     {
+        $mapperCompiler = new MapString();
         $validatorCompiler = new AssertStringLength();
-        $validator = $this->compileValidator('NoopStringLengthValidator', $validatorCompiler);
+        $validator = $this->compileValidator('NoopStringLengthValidator', $mapperCompiler, $validatorCompiler);
 
         $validator->map('abc');
-        $validator->map(123);
-        $validator->map(null);
-        $validator->map([]);
         self::assertTrue(true); // @phpstan-ignore-line always true
     }
 
     public function testStringLengthValidatorWithMin(): void
     {
+        $mapperCompiler = new MapString();
         $validatorCompiler = new AssertStringLength(min: 5);
-        $validator = $this->compileValidator('StringLengthValidatorWithMin', $validatorCompiler);
+        $validator = $this->compileValidator('StringLengthValidatorWithMin', $mapperCompiler, $validatorCompiler);
 
         $validator->map('hello');
         $validator->map('hello world');
-        $validator->map(null);
-        $validator->map([]);
 
         self::assertException(
             MappingFailedException::class,
@@ -41,13 +39,12 @@ class AssertStringLengthTest extends ValidatorCompilerTestCase
 
     public function testStringLengthValidatorWithMax(): void
     {
+        $mapperCompiler = new MapString();
         $validatorCompiler = new AssertStringLength(max: 5);
-        $validator = $this->compileValidator('StringLengthValidatorWithMax', $validatorCompiler);
+        $validator = $this->compileValidator('StringLengthValidatorWithMax', $mapperCompiler, $validatorCompiler);
 
         $validator->map('abc');
         $validator->map('hello');
-        $validator->map(null);
-        $validator->map([]);
 
         self::assertException(
             MappingFailedException::class,
@@ -58,14 +55,13 @@ class AssertStringLengthTest extends ValidatorCompilerTestCase
 
     public function testStringLengthValidatorWithMinAndMax(): void
     {
+        $mapperCompiler = new MapString();
         $validatorCompiler = new AssertStringLength(min: 1, max: 5);
-        $validator = $this->compileValidator('StringLengthValidatorWithMinAndMax', $validatorCompiler);
+        $validator = $this->compileValidator('StringLengthValidatorWithMinAndMax', $mapperCompiler, $validatorCompiler);
 
         $validator->map('a');
         $validator->map('abc');
         $validator->map('hello');
-        $validator->map(null);
-        $validator->map([]);
 
         self::assertException(
             MappingFailedException::class,
@@ -82,12 +78,11 @@ class AssertStringLengthTest extends ValidatorCompilerTestCase
 
     public function testStringLengthValidatorWithExact(): void
     {
+        $mapperCompiler = new MapString();
         $validatorCompiler = new AssertStringLength(exact: 5);
-        $validator = $this->compileValidator('StringLengthValidatorWithExact', $validatorCompiler);
+        $validator = $this->compileValidator('StringLengthValidatorWithExact', $mapperCompiler, $validatorCompiler);
 
         $validator->map('hello');
-        $validator->map(null);
-        $validator->map([]);
 
         self::assertException(
             MappingFailedException::class,

--- a/tests/Compiler/Validator/String/AssertStringMatchesTest.php
+++ b/tests/Compiler/Validator/String/AssertStringMatchesTest.php
@@ -2,6 +2,7 @@
 
 namespace ShipMonkTests\InputMapper\Compiler\Validator\String;
 
+use ShipMonk\InputMapper\Compiler\Mapper\Scalar\MapString;
 use ShipMonk\InputMapper\Compiler\Validator\String\AssertStringMatches;
 use ShipMonk\InputMapper\Runtime\Exception\MappingFailedException;
 use ShipMonkTests\InputMapper\Compiler\Validator\ValidatorCompilerTestCase;
@@ -11,13 +12,11 @@ class AssertStringMatchesTest extends ValidatorCompilerTestCase
 
     public function testUrlValidator(): void
     {
+        $mapperCompiler = new MapString();
         $validatorCompiler = new AssertStringMatches('#^\d+\z#');
-        $validator = $this->compileValidator('PatternValidator', $validatorCompiler);
+        $validator = $this->compileValidator('PatternValidator', $mapperCompiler, $validatorCompiler);
 
         self::assertSame('123', $validator->map('123'));
-        self::assertSame(123, $validator->map(123));
-        self::assertNull($validator->map(null));
-        self::assertSame([], $validator->map([]));
 
         self::assertException(
             MappingFailedException::class,
@@ -28,8 +27,9 @@ class AssertStringMatchesTest extends ValidatorCompilerTestCase
 
     public function testUrlValidatorWithCustomPatternDescription(): void
     {
+        $mapperCompiler = new MapString();
         $validatorCompiler = new AssertStringMatches('#^\d+\z#', 'numeric string');
-        $validator = $this->compileValidator('PatternValidatorWithCustomPatternDescription', $validatorCompiler);
+        $validator = $this->compileValidator('PatternValidatorWithCustomPatternDescription', $mapperCompiler, $validatorCompiler);
 
         self::assertException(
             MappingFailedException::class,

--- a/tests/Compiler/Validator/String/AssertUrlTest.php
+++ b/tests/Compiler/Validator/String/AssertUrlTest.php
@@ -2,6 +2,8 @@
 
 namespace ShipMonkTests\InputMapper\Compiler\Validator\String;
 
+use ShipMonk\InputMapper\Compiler\Exception\CannotCompileMapperException;
+use ShipMonk\InputMapper\Compiler\Mapper\Scalar\MapInt;
 use ShipMonk\InputMapper\Compiler\Mapper\Scalar\MapString;
 use ShipMonk\InputMapper\Compiler\Validator\String\AssertUrl;
 use ShipMonk\InputMapper\Runtime\Exception\MappingFailedException;
@@ -9,6 +11,18 @@ use ShipMonkTests\InputMapper\Compiler\Validator\ValidatorCompilerTestCase;
 
 class AssertUrlTest extends ValidatorCompilerTestCase
 {
+
+    public function testUrlValidatorWithIncompatibleMapperType(): void
+    {
+        $mapperCompiler = new MapInt();
+        $validatorCompiler = new AssertUrl();
+
+        self::assertException(
+            CannotCompileMapperException::class,
+            'Cannot compile mapper with validator ShipMonk\InputMapper\Compiler\Validator\String\AssertUrl, because mapper output type \'int\' is not compatible with validator input type \'string\'',
+            fn() => $this->compileValidator('UrlValidatorWithIncompatibleMapperType', $mapperCompiler, $validatorCompiler),
+        );
+    }
 
     public function testUrlValidator(): void
     {

--- a/tests/Compiler/Validator/String/AssertUrlTest.php
+++ b/tests/Compiler/Validator/String/AssertUrlTest.php
@@ -2,6 +2,7 @@
 
 namespace ShipMonkTests\InputMapper\Compiler\Validator\String;
 
+use ShipMonk\InputMapper\Compiler\Mapper\Scalar\MapString;
 use ShipMonk\InputMapper\Compiler\Validator\String\AssertUrl;
 use ShipMonk\InputMapper\Runtime\Exception\MappingFailedException;
 use ShipMonkTests\InputMapper\Compiler\Validator\ValidatorCompilerTestCase;
@@ -11,13 +12,11 @@ class AssertUrlTest extends ValidatorCompilerTestCase
 
     public function testUrlValidator(): void
     {
+        $mapperCompiler = new MapString();
         $validatorCompiler = new AssertUrl();
-        $validator = $this->compileValidator('UrlValidator', $validatorCompiler);
+        $validator = $this->compileValidator('UrlValidator', $mapperCompiler, $validatorCompiler);
 
         $validator->map('https://example.com');
-        $validator->map(123);
-        $validator->map(null);
-        $validator->map([]);
 
         self::assertException(
             MappingFailedException::class,

--- a/tests/Compiler/Validator/String/Data/NoopStringLengthValidatorMapper.php
+++ b/tests/Compiler/Validator/String/Data/NoopStringLengthValidatorMapper.php
@@ -5,12 +5,13 @@ namespace ShipMonkTests\InputMapper\Compiler\Validator\String\Data;
 use ShipMonk\InputMapper\Runtime\Exception\MappingFailedException;
 use ShipMonk\InputMapper\Runtime\Mapper;
 use ShipMonk\InputMapper\Runtime\MapperProvider;
+use function is_string;
 use function strlen;
 
 /**
  * Generated mapper. Do not edit directly.
  *
- * @implements Mapper<mixed>
+ * @implements Mapper<string>
  */
 class NoopStringLengthValidatorMapper implements Mapper
 {
@@ -22,8 +23,12 @@ class NoopStringLengthValidatorMapper implements Mapper
      * @param  list<string|int> $path
      * @throws MappingFailedException
      */
-    public function map(mixed $data, array $path = []): mixed
+    public function map(mixed $data, array $path = []): string
     {
+        if (!is_string($data)) {
+            throw MappingFailedException::incorrectType($data, $path, 'string');
+        }
+
         return $data;
     }
 }

--- a/tests/Compiler/Validator/String/Data/PatternValidatorMapper.php
+++ b/tests/Compiler/Validator/String/Data/PatternValidatorMapper.php
@@ -29,7 +29,7 @@ class PatternValidatorMapper implements Mapper
             throw MappingFailedException::incorrectType($data, $path, 'string');
         }
 
-        if (is_string($data) && preg_match('#^\\d+\\z#', $data) !== 1) {
+        if (preg_match('#^\\d+\\z#', $data) !== 1) {
             throw MappingFailedException::incorrectValue($data, $path, 'string matching pattern #^\\d+\\z#');
         }
 

--- a/tests/Compiler/Validator/String/Data/PatternValidatorMapper.php
+++ b/tests/Compiler/Validator/String/Data/PatternValidatorMapper.php
@@ -11,7 +11,7 @@ use function preg_match;
 /**
  * Generated mapper. Do not edit directly.
  *
- * @implements Mapper<mixed>
+ * @implements Mapper<string>
  */
 class PatternValidatorMapper implements Mapper
 {
@@ -23,8 +23,12 @@ class PatternValidatorMapper implements Mapper
      * @param  list<string|int> $path
      * @throws MappingFailedException
      */
-    public function map(mixed $data, array $path = []): mixed
+    public function map(mixed $data, array $path = []): string
     {
+        if (!is_string($data)) {
+            throw MappingFailedException::incorrectType($data, $path, 'string');
+        }
+
         if (is_string($data) && preg_match('#^\\d+\\z#', $data) !== 1) {
             throw MappingFailedException::incorrectValue($data, $path, 'string matching pattern #^\\d+\\z#');
         }

--- a/tests/Compiler/Validator/String/Data/PatternValidatorWithCustomPatternDescriptionMapper.php
+++ b/tests/Compiler/Validator/String/Data/PatternValidatorWithCustomPatternDescriptionMapper.php
@@ -29,7 +29,7 @@ class PatternValidatorWithCustomPatternDescriptionMapper implements Mapper
             throw MappingFailedException::incorrectType($data, $path, 'string');
         }
 
-        if (is_string($data) && preg_match('#^\\d+\\z#', $data) !== 1) {
+        if (preg_match('#^\\d+\\z#', $data) !== 1) {
             throw MappingFailedException::incorrectValue($data, $path, 'numeric string');
         }
 

--- a/tests/Compiler/Validator/String/Data/PatternValidatorWithCustomPatternDescriptionMapper.php
+++ b/tests/Compiler/Validator/String/Data/PatternValidatorWithCustomPatternDescriptionMapper.php
@@ -11,7 +11,7 @@ use function preg_match;
 /**
  * Generated mapper. Do not edit directly.
  *
- * @implements Mapper<mixed>
+ * @implements Mapper<string>
  */
 class PatternValidatorWithCustomPatternDescriptionMapper implements Mapper
 {
@@ -23,8 +23,12 @@ class PatternValidatorWithCustomPatternDescriptionMapper implements Mapper
      * @param  list<string|int> $path
      * @throws MappingFailedException
      */
-    public function map(mixed $data, array $path = []): mixed
+    public function map(mixed $data, array $path = []): string
     {
+        if (!is_string($data)) {
+            throw MappingFailedException::incorrectType($data, $path, 'string');
+        }
+
         if (is_string($data) && preg_match('#^\\d+\\z#', $data) !== 1) {
             throw MappingFailedException::incorrectValue($data, $path, 'numeric string');
         }

--- a/tests/Compiler/Validator/String/Data/StringLengthValidatorWithExactMapper.php
+++ b/tests/Compiler/Validator/String/Data/StringLengthValidatorWithExactMapper.php
@@ -29,10 +29,8 @@ class StringLengthValidatorWithExactMapper implements Mapper
             throw MappingFailedException::incorrectType($data, $path, 'string');
         }
 
-        if (is_string($data)) {
-            if (strlen($data) !== 5) {
-                throw MappingFailedException::incorrectValue($data, $path, 'string with exactly 5 characters');
-            }
+        if (strlen($data) !== 5) {
+            throw MappingFailedException::incorrectValue($data, $path, 'string with exactly 5 characters');
         }
 
         return $data;

--- a/tests/Compiler/Validator/String/Data/StringLengthValidatorWithExactMapper.php
+++ b/tests/Compiler/Validator/String/Data/StringLengthValidatorWithExactMapper.php
@@ -11,7 +11,7 @@ use function strlen;
 /**
  * Generated mapper. Do not edit directly.
  *
- * @implements Mapper<mixed>
+ * @implements Mapper<string>
  */
 class StringLengthValidatorWithExactMapper implements Mapper
 {
@@ -23,8 +23,12 @@ class StringLengthValidatorWithExactMapper implements Mapper
      * @param  list<string|int> $path
      * @throws MappingFailedException
      */
-    public function map(mixed $data, array $path = []): mixed
+    public function map(mixed $data, array $path = []): string
     {
+        if (!is_string($data)) {
+            throw MappingFailedException::incorrectType($data, $path, 'string');
+        }
+
         if (is_string($data)) {
             if (strlen($data) !== 5) {
                 throw MappingFailedException::incorrectValue($data, $path, 'string with exactly 5 characters');

--- a/tests/Compiler/Validator/String/Data/StringLengthValidatorWithMaxMapper.php
+++ b/tests/Compiler/Validator/String/Data/StringLengthValidatorWithMaxMapper.php
@@ -29,10 +29,8 @@ class StringLengthValidatorWithMaxMapper implements Mapper
             throw MappingFailedException::incorrectType($data, $path, 'string');
         }
 
-        if (is_string($data)) {
-            if (strlen($data) > 5) {
-                throw MappingFailedException::incorrectValue($data, $path, 'string with at most 5 characters');
-            }
+        if (strlen($data) > 5) {
+            throw MappingFailedException::incorrectValue($data, $path, 'string with at most 5 characters');
         }
 
         return $data;

--- a/tests/Compiler/Validator/String/Data/StringLengthValidatorWithMaxMapper.php
+++ b/tests/Compiler/Validator/String/Data/StringLengthValidatorWithMaxMapper.php
@@ -11,7 +11,7 @@ use function strlen;
 /**
  * Generated mapper. Do not edit directly.
  *
- * @implements Mapper<mixed>
+ * @implements Mapper<string>
  */
 class StringLengthValidatorWithMaxMapper implements Mapper
 {
@@ -23,8 +23,12 @@ class StringLengthValidatorWithMaxMapper implements Mapper
      * @param  list<string|int> $path
      * @throws MappingFailedException
      */
-    public function map(mixed $data, array $path = []): mixed
+    public function map(mixed $data, array $path = []): string
     {
+        if (!is_string($data)) {
+            throw MappingFailedException::incorrectType($data, $path, 'string');
+        }
+
         if (is_string($data)) {
             if (strlen($data) > 5) {
                 throw MappingFailedException::incorrectValue($data, $path, 'string with at most 5 characters');

--- a/tests/Compiler/Validator/String/Data/StringLengthValidatorWithMinAndMaxMapper.php
+++ b/tests/Compiler/Validator/String/Data/StringLengthValidatorWithMinAndMaxMapper.php
@@ -11,7 +11,7 @@ use function strlen;
 /**
  * Generated mapper. Do not edit directly.
  *
- * @implements Mapper<mixed>
+ * @implements Mapper<string>
  */
 class StringLengthValidatorWithMinAndMaxMapper implements Mapper
 {
@@ -23,8 +23,12 @@ class StringLengthValidatorWithMinAndMaxMapper implements Mapper
      * @param  list<string|int> $path
      * @throws MappingFailedException
      */
-    public function map(mixed $data, array $path = []): mixed
+    public function map(mixed $data, array $path = []): string
     {
+        if (!is_string($data)) {
+            throw MappingFailedException::incorrectType($data, $path, 'string');
+        }
+
         if (is_string($data)) {
             if (strlen($data) < 1) {
                 throw MappingFailedException::incorrectValue($data, $path, 'string with at least 1 characters');

--- a/tests/Compiler/Validator/String/Data/StringLengthValidatorWithMinAndMaxMapper.php
+++ b/tests/Compiler/Validator/String/Data/StringLengthValidatorWithMinAndMaxMapper.php
@@ -29,14 +29,12 @@ class StringLengthValidatorWithMinAndMaxMapper implements Mapper
             throw MappingFailedException::incorrectType($data, $path, 'string');
         }
 
-        if (is_string($data)) {
-            if (strlen($data) < 1) {
-                throw MappingFailedException::incorrectValue($data, $path, 'string with at least 1 characters');
-            }
+        if (strlen($data) < 1) {
+            throw MappingFailedException::incorrectValue($data, $path, 'string with at least 1 characters');
+        }
 
-            if (strlen($data) > 5) {
-                throw MappingFailedException::incorrectValue($data, $path, 'string with at most 5 characters');
-            }
+        if (strlen($data) > 5) {
+            throw MappingFailedException::incorrectValue($data, $path, 'string with at most 5 characters');
         }
 
         return $data;

--- a/tests/Compiler/Validator/String/Data/StringLengthValidatorWithMinMapper.php
+++ b/tests/Compiler/Validator/String/Data/StringLengthValidatorWithMinMapper.php
@@ -29,10 +29,8 @@ class StringLengthValidatorWithMinMapper implements Mapper
             throw MappingFailedException::incorrectType($data, $path, 'string');
         }
 
-        if (is_string($data)) {
-            if (strlen($data) < 5) {
-                throw MappingFailedException::incorrectValue($data, $path, 'string with at least 5 characters');
-            }
+        if (strlen($data) < 5) {
+            throw MappingFailedException::incorrectValue($data, $path, 'string with at least 5 characters');
         }
 
         return $data;

--- a/tests/Compiler/Validator/String/Data/StringLengthValidatorWithMinMapper.php
+++ b/tests/Compiler/Validator/String/Data/StringLengthValidatorWithMinMapper.php
@@ -11,7 +11,7 @@ use function strlen;
 /**
  * Generated mapper. Do not edit directly.
  *
- * @implements Mapper<mixed>
+ * @implements Mapper<string>
  */
 class StringLengthValidatorWithMinMapper implements Mapper
 {
@@ -23,8 +23,12 @@ class StringLengthValidatorWithMinMapper implements Mapper
      * @param  list<string|int> $path
      * @throws MappingFailedException
      */
-    public function map(mixed $data, array $path = []): mixed
+    public function map(mixed $data, array $path = []): string
     {
+        if (!is_string($data)) {
+            throw MappingFailedException::incorrectType($data, $path, 'string');
+        }
+
         if (is_string($data)) {
             if (strlen($data) < 5) {
                 throw MappingFailedException::incorrectValue($data, $path, 'string with at least 5 characters');

--- a/tests/Compiler/Validator/String/Data/UrlValidatorMapper.php
+++ b/tests/Compiler/Validator/String/Data/UrlValidatorMapper.php
@@ -29,7 +29,7 @@ class UrlValidatorMapper implements Mapper
             throw MappingFailedException::incorrectType($data, $path, 'string');
         }
 
-        if (is_string($data) && !Validators::isUrl($data)) {
+        if (!Validators::isUrl($data)) {
             throw MappingFailedException::incorrectValue($data, $path, 'valid URL');
         }
 

--- a/tests/Compiler/Validator/String/Data/UrlValidatorMapper.php
+++ b/tests/Compiler/Validator/String/Data/UrlValidatorMapper.php
@@ -11,7 +11,7 @@ use function is_string;
 /**
  * Generated mapper. Do not edit directly.
  *
- * @implements Mapper<mixed>
+ * @implements Mapper<string>
  */
 class UrlValidatorMapper implements Mapper
 {
@@ -23,8 +23,12 @@ class UrlValidatorMapper implements Mapper
      * @param  list<string|int> $path
      * @throws MappingFailedException
      */
-    public function map(mixed $data, array $path = []): mixed
+    public function map(mixed $data, array $path = []): string
     {
+        if (!is_string($data)) {
+            throw MappingFailedException::incorrectType($data, $path, 'string');
+        }
+
         if (is_string($data) && !Validators::isUrl($data)) {
             throw MappingFailedException::incorrectValue($data, $path, 'valid URL');
         }

--- a/tests/Compiler/Validator/ValidatorCompilerTestCase.php
+++ b/tests/Compiler/Validator/ValidatorCompilerTestCase.php
@@ -2,7 +2,7 @@
 
 namespace ShipMonkTests\InputMapper\Compiler\Validator;
 
-use ShipMonk\InputMapper\Compiler\Mapper\Mixed\MapMixed;
+use ShipMonk\InputMapper\Compiler\Mapper\MapperCompiler;
 use ShipMonk\InputMapper\Compiler\Mapper\Wrapper\ValidatedMapperCompiler;
 use ShipMonk\InputMapper\Compiler\Validator\ValidatorCompiler;
 use ShipMonk\InputMapper\Runtime\Mapper;
@@ -14,9 +14,13 @@ abstract class ValidatorCompilerTestCase extends MapperCompilerTestCase
     /**
      * @return Mapper<mixed>
      */
-    protected function compileValidator(string $name, ValidatorCompiler $validatorCompiler): Mapper
+    protected function compileValidator(
+        string $name,
+        MapperCompiler $mapperCompiler,
+        ValidatorCompiler $validatorCompiler
+    ): Mapper
     {
-        $mapperCompiler = new ValidatedMapperCompiler(new MapMixed(), [$validatorCompiler]);
+        $mapperCompiler = new ValidatedMapperCompiler($mapperCompiler, [$validatorCompiler]);
         return $this->compileMapper($name, $mapperCompiler);
     }
 

--- a/tests/Runtime/Data/Optional/OptionalNotNullInput.php
+++ b/tests/Runtime/Data/Optional/OptionalNotNullInput.php
@@ -2,6 +2,7 @@
 
 namespace ShipMonkTests\InputMapper\Runtime\Data\Optional;
 
+use ShipMonk\InputMapper\Compiler\Validator\Int\AssertPositiveInt;
 use ShipMonk\InputMapper\Runtime\Optional;
 
 class OptionalNotNullInput
@@ -11,6 +12,7 @@ class OptionalNotNullInput
      * @param Optional<int> $number
      */
     public function __construct(
+        #[AssertPositiveInt]
         public readonly Optional $number,
     )
     {

--- a/tests/Runtime/Data/Optional/OptionalNullableInput.php
+++ b/tests/Runtime/Data/Optional/OptionalNullableInput.php
@@ -2,6 +2,7 @@
 
 namespace ShipMonkTests\InputMapper\Runtime\Data\Optional;
 
+use ShipMonk\InputMapper\Compiler\Validator\Int\AssertPositiveInt;
 use ShipMonk\InputMapper\Runtime\Optional;
 
 class OptionalNullableInput
@@ -11,6 +12,7 @@ class OptionalNullableInput
      * @param Optional<?int> $number
      */
     public function __construct(
+        #[AssertPositiveInt]
         public readonly Optional $number,
     )
     {

--- a/tests/Runtime/MapperProviderTest.php
+++ b/tests/Runtime/MapperProviderTest.php
@@ -77,6 +77,14 @@ class MapperProviderTest extends InputMapperTestCase
                 $mapper->map(['number' => null]);
             },
         );
+
+        self::assertException(
+            MappingFailedException::class,
+            'Failed to map data at path /number: Expected value greater than 0, got -1',
+            static function () use ($mapper): void {
+                $mapper->map(['number' => -1]);
+            },
+        );
     }
 
     public function testMapperForOptionalNullableInput(): void
@@ -86,6 +94,14 @@ class MapperProviderTest extends InputMapperTestCase
         self::assertEquals(new OptionalNullableInput(Optional::of(123)), $mapper->map(['number' => 123]));
         self::assertEquals(new OptionalNullableInput(Optional::of(null)), $mapper->map(['number' => null]));
         self::assertEquals(new OptionalNullableInput(Optional::none([], 'number')), $mapper->map([]));
+
+        self::assertException(
+            MappingFailedException::class,
+            'Failed to map data at path /number: Expected value greater than 0, got -1',
+            static function () use ($mapper): void {
+                $mapper->map(['number' => -1]);
+            },
+        );
     }
 
     private function createMapperProvider(): MapperProvider


### PR DESCRIPTION
Makes validator explicitly declare their expected input type. This makes it possible to ensure that they are correctly placed in the mapping tree. It also allows us to emit exception when validator is used with incompatible mapper.

Note: it's probably easier to review the code commit by commit.