### PR TITLE
Add narrowing validators

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -45,3 +45,11 @@ parameters:
         -
             message: '#throws checked exception ShipMonk\\InputMapper\\Runtime\\Exception\\MappingFailedException but it''s missing from the PHPDoc @throws tag\.#'
             paths: [tests/**/*Test.php]
+        -
+            message: "#^Method ShipMonkTests\\\\InputMapper\\\\Compiler\\\\Validator\\\\Array\\\\Data\\\\ListItemValidatorMapper\\:\\:map\\(\\) should return list\\<int\\<1, max\\>\\> but returns list\\<int\\>\\.$#"
+            count: 1
+            path: tests/Compiler/Validator/Array/Data/ListItemValidatorMapper.php
+        -
+            message: "#^Method ShipMonkTests\\\\InputMapper\\\\Compiler\\\\Validator\\\\Array\\\\Data\\\\ListItemValidatorWithMultipleValidatorsMapper\\:\\:map\\(\\) should return list\\<int\\<1, max\\>\\> but returns list\\<int\\>\\.$#"
+            count: 1
+            path: tests/Compiler/Validator/Array/Data/ListItemValidatorWithMultipleValidatorsMapper.php

--- a/src/Compiler/Mapper/Wrapper/ValidatedMapperCompiler.php
+++ b/src/Compiler/Mapper/Wrapper/ValidatedMapperCompiler.php
@@ -10,6 +10,7 @@ use ShipMonk\InputMapper\Compiler\Exception\CannotCompileMapperException;
 use ShipMonk\InputMapper\Compiler\Mapper\MapperCompiler;
 use ShipMonk\InputMapper\Compiler\Php\PhpCodeBuilder;
 use ShipMonk\InputMapper\Compiler\Type\PhpDocTypeUtils;
+use ShipMonk\InputMapper\Compiler\Validator\NarrowingValidatorCompiler;
 use ShipMonk\InputMapper\Compiler\Validator\ValidatorCompiler;
 
 class ValidatedMapperCompiler implements MapperCompiler
@@ -65,7 +66,15 @@ class ValidatedMapperCompiler implements MapperCompiler
 
     public function getOutputType(): TypeNode
     {
-        return $this->mapperCompiler->getOutputType();
+        $outputTypes = [$this->mapperCompiler->getOutputType()];
+
+        foreach ($this->validatorCompilers as $validatorCompiler) {
+            if ($validatorCompiler instanceof NarrowingValidatorCompiler) {
+                $outputTypes[] = $validatorCompiler->getNarrowedInputType();
+            }
+        }
+
+        return PhpDocTypeUtils::intersect(...$outputTypes);
     }
 
 }

--- a/src/Compiler/MapperFactory/DefaultMapperCompilerFactory.php
+++ b/src/Compiler/MapperFactory/DefaultMapperCompilerFactory.php
@@ -50,6 +50,10 @@ use ShipMonk\InputMapper\Compiler\Mapper\Wrapper\MapOptional;
 use ShipMonk\InputMapper\Compiler\Mapper\Wrapper\ValidatedMapperCompiler;
 use ShipMonk\InputMapper\Compiler\Type\PhpDocTypeUtils;
 use ShipMonk\InputMapper\Compiler\Validator\Int\AssertIntRange;
+use ShipMonk\InputMapper\Compiler\Validator\Int\AssertNegativeInt;
+use ShipMonk\InputMapper\Compiler\Validator\Int\AssertNonNegativeInt;
+use ShipMonk\InputMapper\Compiler\Validator\Int\AssertNonPositiveInt;
+use ShipMonk\InputMapper\Compiler\Validator\Int\AssertPositiveInt;
 use ShipMonk\InputMapper\Compiler\Validator\ValidatorCompiler;
 use ShipMonk\InputMapper\Runtime\Optional;
 use function class_exists;
@@ -116,8 +120,10 @@ class DefaultMapperCompilerFactory implements MapperCompilerFactory
 
                 default => match ($type->name) {
                     'list' => new MapList(new MapMixed()),
-                    'negative-int' => new ValidatedMapperCompiler(new MapInt(), [new AssertIntRange(lt: 0)]),
-                    'positive-int' => new ValidatedMapperCompiler(new MapInt(), [new AssertIntRange(gt: 0)]),
+                    'negative-int' => new ValidatedMapperCompiler(new MapInt(), [new AssertNegativeInt()]),
+                    'non-negative-int' => new ValidatedMapperCompiler(new MapInt(), [new AssertNonNegativeInt()]),
+                    'non-positive-int' => new ValidatedMapperCompiler(new MapInt(), [new AssertNonPositiveInt()]),
+                    'positive-int' => new ValidatedMapperCompiler(new MapInt(), [new AssertPositiveInt()]),
                     default => throw CannotCreateMapperCompilerException::fromType($type),
                 },
             };

--- a/src/Compiler/Type/PhpDocTypeUtils.php
+++ b/src/Compiler/Type/PhpDocTypeUtils.php
@@ -38,6 +38,7 @@ use ShipMonk\InputMapper\Runtime\OptionalNone;
 use ShipMonk\InputMapper\Runtime\OptionalSome;
 use Traversable;
 use function array_map;
+use function array_splice;
 use function constant;
 use function count;
 use function get_object_vars;
@@ -253,6 +254,20 @@ class PhpDocTypeUtils
 
     public static function union(TypeNode ...$types): TypeNode
     {
+        for ($i = 0; $i < count($types); $i++) {
+            for ($j = $i + 1; $j < count($types); $j++) {
+                if (self::isSubTypeOf($types[$i], $types[$j])) {
+                    array_splice($types, $i--, 1);
+                    continue 2;
+                }
+
+                if (self::isSubTypeOf($types[$j], $types[$i])) {
+                    array_splice($types, $j--, 1);
+                    continue;
+                }
+            }
+        }
+
         return match (count($types)) {
             0 => new IdentifierTypeNode('never'),
             1 => $types[0],
@@ -262,6 +277,20 @@ class PhpDocTypeUtils
 
     public static function intersect(TypeNode ...$types): TypeNode
     {
+        for ($i = 0; $i < count($types); $i++) {
+            for ($j = $i + 1; $j < count($types); $j++) {
+                if (self::isSubTypeOf($types[$i], $types[$j])) {
+                    array_splice($types, $j--, 1);
+                    continue;
+                }
+
+                if (self::isSubTypeOf($types[$j], $types[$i])) {
+                    array_splice($types, $i--, 1);
+                    continue 2;
+                }
+            }
+        }
+
         return match (count($types)) {
             0 => new IdentifierTypeNode('mixed'),
             1 => $types[0],

--- a/src/Compiler/Validator/Int/AssertIntRange.php
+++ b/src/Compiler/Validator/Int/AssertIntRange.php
@@ -5,14 +5,21 @@ namespace ShipMonk\InputMapper\Compiler\Validator\Int;
 use Attribute;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Stmt;
+use PHPStan\PhpDocParser\Ast\ConstExpr\ConstExprIntegerNode;
+use PHPStan\PhpDocParser\Ast\Type\ConstTypeNode;
+use PHPStan\PhpDocParser\Ast\Type\GenericTypeNode;
 use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
 use PHPStan\PhpDocParser\Ast\Type\TypeNode;
 use ShipMonk\InputMapper\Compiler\Php\PhpCodeBuilder;
-use ShipMonk\InputMapper\Compiler\Validator\ValidatorCompiler;
+use ShipMonk\InputMapper\Compiler\Validator\NarrowingValidatorCompiler;
 use ShipMonk\InputMapper\Runtime\Exception\MappingFailedException;
+use function max;
+use function min;
+use const PHP_INT_MAX;
+use const PHP_INT_MIN;
 
 #[Attribute(Attribute::TARGET_PARAMETER | Attribute::TARGET_PROPERTY)]
-class AssertIntRange implements ValidatorCompiler
+class AssertIntRange implements NarrowingValidatorCompiler
 {
 
     public function __construct(
@@ -90,6 +97,48 @@ class AssertIntRange implements ValidatorCompiler
     public function getInputType(): TypeNode
     {
         return new IdentifierTypeNode('int');
+    }
+
+    public function getNarrowedInputType(): TypeNode
+    {
+        $inclusiveLowerBounds = [PHP_INT_MIN];
+        $inclusiveUpperBounds = [PHP_INT_MAX];
+
+        if ($this->gte !== null) {
+            $inclusiveLowerBounds[] = $this->gte;
+        }
+
+        if ($this->gt !== null) {
+            $inclusiveLowerBounds[] = $this->gt + 1;
+        }
+
+        if ($this->lt !== null) {
+            $inclusiveUpperBounds[] = $this->lt - 1;
+        }
+
+        if ($this->lte !== null) {
+            $inclusiveUpperBounds[] = $this->lte;
+        }
+
+        $inclusiveLowerBound = max($inclusiveLowerBounds);
+        $inclusiveUpperBound = min($inclusiveUpperBounds);
+
+        if ($inclusiveLowerBound === PHP_INT_MIN && $inclusiveUpperBound === PHP_INT_MAX) {
+            return new IdentifierTypeNode('int');
+        }
+
+        $inclusiveLowerBoundType = $inclusiveLowerBound !== PHP_INT_MIN
+            ? new ConstTypeNode(new ConstExprIntegerNode((string) $inclusiveLowerBound))
+            : new IdentifierTypeNode('min');
+
+        $inclusiveUpperBoundType = $inclusiveUpperBound !== PHP_INT_MAX
+            ? new ConstTypeNode(new ConstExprIntegerNode((string) $inclusiveUpperBound))
+            : new IdentifierTypeNode('max');
+
+        return new GenericTypeNode(new IdentifierTypeNode('int'), [
+            $inclusiveLowerBoundType,
+            $inclusiveUpperBoundType,
+        ]);
     }
 
 }

--- a/src/Compiler/Validator/Int/AssertNegativeInt.php
+++ b/src/Compiler/Validator/Int/AssertNegativeInt.php
@@ -3,6 +3,8 @@
 namespace ShipMonk\InputMapper\Compiler\Validator\Int;
 
 use Attribute;
+use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
+use PHPStan\PhpDocParser\Ast\Type\TypeNode;
 
 #[Attribute(Attribute::TARGET_PARAMETER | Attribute::TARGET_PROPERTY)]
 class AssertNegativeInt extends AssertIntRange
@@ -13,6 +15,11 @@ class AssertNegativeInt extends AssertIntRange
         parent::__construct(
             lt: 0,
         );
+    }
+
+    public function getNarrowedInputType(): TypeNode
+    {
+        return new IdentifierTypeNode('negative-int');
     }
 
 }

--- a/src/Compiler/Validator/Int/AssertPositiveInt.php
+++ b/src/Compiler/Validator/Int/AssertPositiveInt.php
@@ -3,6 +3,8 @@
 namespace ShipMonk\InputMapper\Compiler\Validator\Int;
 
 use Attribute;
+use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
+use PHPStan\PhpDocParser\Ast\Type\TypeNode;
 
 #[Attribute(Attribute::TARGET_PARAMETER | Attribute::TARGET_PROPERTY)]
 class AssertPositiveInt extends AssertIntRange
@@ -13,6 +15,11 @@ class AssertPositiveInt extends AssertIntRange
         parent::__construct(
             gt: 0,
         );
+    }
+
+    public function getNarrowedInputType(): TypeNode
+    {
+        return new IdentifierTypeNode('positive-int');
     }
 
 }

--- a/src/Compiler/Validator/NarrowingValidatorCompiler.php
+++ b/src/Compiler/Validator/NarrowingValidatorCompiler.php
@@ -1,0 +1,15 @@
+<?php declare(strict_types = 1);
+
+namespace ShipMonk\InputMapper\Compiler\Validator;
+
+use PHPStan\PhpDocParser\Ast\Type\TypeNode;
+
+interface NarrowingValidatorCompiler extends ValidatorCompiler
+{
+
+    /**
+     * Must return subtype of input type returned by {@link self::getInputType()}.
+     */
+    public function getNarrowedInputType(): TypeNode;
+
+}

--- a/tests/Compiler/Mapper/Wrapper/Data/NotValidatedIntMapperMapper.php
+++ b/tests/Compiler/Mapper/Wrapper/Data/NotValidatedIntMapperMapper.php
@@ -1,0 +1,34 @@
+<?php declare (strict_types=1);
+
+namespace ShipMonkTests\InputMapper\Compiler\Mapper\Wrapper\Data;
+
+use ShipMonk\InputMapper\Compiler\Mapper\Wrapper\ValidatedMapperCompiler;
+use ShipMonk\InputMapper\Runtime\Exception\MappingFailedException;
+use ShipMonk\InputMapper\Runtime\Mapper;
+use ShipMonk\InputMapper\Runtime\MapperProvider;
+use function is_int;
+
+/**
+ * Generated mapper by {@see ValidatedMapperCompiler}. Do not edit directly.
+ *
+ * @implements Mapper<int>
+ */
+class NotValidatedIntMapperMapper implements Mapper
+{
+    public function __construct(private readonly MapperProvider $provider)
+    {
+    }
+
+    /**
+     * @param  list<string|int> $path
+     * @throws MappingFailedException
+     */
+    public function map(mixed $data, array $path = []): int
+    {
+        if (!is_int($data)) {
+            throw MappingFailedException::incorrectType($data, $path, 'int');
+        }
+
+        return $data;
+    }
+}

--- a/tests/Compiler/Mapper/Wrapper/Data/PositiveIntMapperMapper.php
+++ b/tests/Compiler/Mapper/Wrapper/Data/PositiveIntMapperMapper.php
@@ -1,0 +1,39 @@
+<?php declare (strict_types=1);
+
+namespace ShipMonkTests\InputMapper\Compiler\Mapper\Wrapper\Data;
+
+use ShipMonk\InputMapper\Compiler\Mapper\Wrapper\ValidatedMapperCompiler;
+use ShipMonk\InputMapper\Runtime\Exception\MappingFailedException;
+use ShipMonk\InputMapper\Runtime\Mapper;
+use ShipMonk\InputMapper\Runtime\MapperProvider;
+use function is_int;
+
+/**
+ * Generated mapper by {@see ValidatedMapperCompiler}. Do not edit directly.
+ *
+ * @implements Mapper<positive-int>
+ */
+class PositiveIntMapperMapper implements Mapper
+{
+    public function __construct(private readonly MapperProvider $provider)
+    {
+    }
+
+    /**
+     * @param  list<string|int> $path
+     * @return positive-int
+     * @throws MappingFailedException
+     */
+    public function map(mixed $data, array $path = []): int
+    {
+        if (!is_int($data)) {
+            throw MappingFailedException::incorrectType($data, $path, 'int');
+        }
+
+        if ($data <= 0) {
+            throw MappingFailedException::incorrectValue($data, $path, 'value greater than 0');
+        }
+
+        return $data;
+    }
+}

--- a/tests/Compiler/Mapper/Wrapper/ValidatedMapperCompilerTest.php
+++ b/tests/Compiler/Mapper/Wrapper/ValidatedMapperCompilerTest.php
@@ -1,0 +1,48 @@
+<?php declare(strict_types = 1);
+
+namespace ShipMonkTests\InputMapper\Compiler\Mapper\Wrapper;
+
+use ShipMonk\InputMapper\Compiler\Exception\CannotCompileMapperException;
+use ShipMonk\InputMapper\Compiler\Mapper\Scalar\MapInt;
+use ShipMonk\InputMapper\Compiler\Mapper\Wrapper\ValidatedMapperCompiler;
+use ShipMonk\InputMapper\Compiler\Validator\Int\AssertPositiveInt;
+use ShipMonk\InputMapper\Compiler\Validator\String\AssertUrl;
+use ShipMonk\InputMapper\Runtime\Exception\MappingFailedException;
+use ShipMonkTests\InputMapper\Compiler\Mapper\MapperCompilerTestCase;
+
+class ValidatedMapperCompilerTest extends MapperCompilerTestCase
+{
+
+    public function testCompileWithEmptyValidatorList(): void
+    {
+        $mapperCompiler = new ValidatedMapperCompiler(new MapInt(), []);
+        $mapper = $this->compileMapper('NotValidatedIntMapper', $mapperCompiler);
+        self::assertSame(1, $mapper->map(1));
+    }
+
+    public function testCompile(): void
+    {
+        $mapperCompiler = new ValidatedMapperCompiler(new MapInt(), [new AssertPositiveInt()]);
+        $mapper = $this->compileMapper('PositiveIntMapper', $mapperCompiler);
+
+        self::assertSame(1, $mapper->map(1));
+
+        self::assertException(
+            MappingFailedException::class,
+            'Failed to map data at path /: Expected value greater than 0, got 0',
+            static fn() => $mapper->map(0),
+        );
+    }
+
+    public function testCompileWithIncompatibleValidator(): void
+    {
+        $mapperCompiler = new ValidatedMapperCompiler(new MapInt(), [new AssertUrl()]);
+
+        self::assertException(
+            CannotCompileMapperException::class,
+            'Cannot compile mapper with validator ShipMonk\InputMapper\Compiler\Validator\String\AssertUrl, because mapper output type \'int\' is not compatible with validator input type \'string\'',
+            fn() => $this->compileMapper('IntMapperWithIncompatibleValidator', $mapperCompiler),
+        );
+    }
+
+}

--- a/tests/Compiler/MapperFactory/Data/BrandInput.php
+++ b/tests/Compiler/MapperFactory/Data/BrandInput.php
@@ -8,8 +8,12 @@ use ShipMonk\InputMapper\Compiler\Mapper\Object\AllowExtraKeys;
 class BrandInput
 {
 
+    /**
+     * @param int<1900, 2100> $foundedIn
+     */
     public function __construct(
         public readonly string $name,
+        public readonly int $foundedIn,
     )
     {
     }

--- a/tests/Compiler/MapperFactory/DefaultMapperCompilerFactoryTest.php
+++ b/tests/Compiler/MapperFactory/DefaultMapperCompilerFactoryTest.php
@@ -32,6 +32,9 @@ use ShipMonk\InputMapper\Compiler\Mapper\Wrapper\MapOptional;
 use ShipMonk\InputMapper\Compiler\Mapper\Wrapper\ValidatedMapperCompiler;
 use ShipMonk\InputMapper\Compiler\MapperFactory\DefaultMapperCompilerFactory;
 use ShipMonk\InputMapper\Compiler\Validator\Int\AssertIntRange;
+use ShipMonk\InputMapper\Compiler\Validator\Int\AssertNegativeInt;
+use ShipMonk\InputMapper\Compiler\Validator\Int\AssertNonNegativeInt;
+use ShipMonk\InputMapper\Compiler\Validator\Int\AssertNonPositiveInt;
 use ShipMonk\InputMapper\Compiler\Validator\Int\AssertPositiveInt;
 use ShipMonk\InputMapper\Compiler\Validator\String\AssertStringLength;
 use ShipMonk\InputMapper\Compiler\Validator\String\AssertUrl;
@@ -106,7 +109,13 @@ class DefaultMapperCompilerFactoryTest extends InputMapperTestCase
             [],
             new MapObject(
                 BrandInput::class,
-                ['name' => new MapString()],
+                [
+                    'name' => new MapString(),
+                    'foundedIn' => new ValidatedMapperCompiler(
+                        new MapInt(),
+                        [new AssertIntRange(gte: 1_900, lte: 2_100)],
+                    ),
+                ],
                 allowExtraKeys: true,
             ),
         ];
@@ -237,6 +246,38 @@ class DefaultMapperCompilerFactoryTest extends InputMapperTestCase
             [],
             new ValidatedMapperCompiler(new MapInt(), [
                 new AssertIntRange(gte: 0),
+            ]),
+        ];
+
+        yield 'positive-int' => [
+            'positive-int',
+            [],
+            new ValidatedMapperCompiler(new MapInt(), [
+                new AssertPositiveInt(),
+            ]),
+        ];
+
+        yield 'negative-int' => [
+            'negative-int',
+            [],
+            new ValidatedMapperCompiler(new MapInt(), [
+                new AssertNegativeInt(),
+            ]),
+        ];
+
+        yield 'non-positive-int' => [
+            'non-positive-int',
+            [],
+            new ValidatedMapperCompiler(new MapInt(), [
+                new AssertNonPositiveInt(),
+            ]),
+        ];
+
+        yield 'non-negative-int' => [
+            'non-negative-int',
+            [],
+            new ValidatedMapperCompiler(new MapInt(), [
+                new AssertNonNegativeInt(),
             ]),
         ];
 

--- a/tests/Compiler/Type/PhpDocTypeUtilsTest.php
+++ b/tests/Compiler/Type/PhpDocTypeUtilsTest.php
@@ -422,6 +422,120 @@ class PhpDocTypeUtilsTest extends InputMapperTestCase
         self::assertSame(self::class, $identifier->name);
     }
 
+    /**
+     * @param list<string> $types
+     */
+    #[DataProvider('provideUnionData')]
+    public function testUnion(array $types, string $expected): void
+    {
+        $typesNodes = [];
+
+        foreach ($types as $type) {
+            $typesNodes[] = $this->parseType($type);
+        }
+
+        $expectedTypeNode = $this->parseType($expected);
+        self::assertEquals($expectedTypeNode, PhpDocTypeUtils::union(...$typesNodes));
+    }
+
+    /**
+     * @return iterable<string, array{0: list<string>, 1: string}>
+     */
+    public static function provideUnionData(): iterable
+    {
+        yield 'empty' => [
+            [],
+            'never',
+        ];
+
+        yield 'int' => [
+            ['int'],
+            'int',
+        ];
+
+        yield 'int | int' => [
+            ['int', 'int'],
+            'int',
+        ];
+
+        yield 'int | number' => [
+            ['int', 'number'],
+            'number',
+        ];
+
+        yield 'number | int' => [
+            ['number', 'int'],
+            'number',
+        ];
+
+        yield 'int | string | never' => [
+            ['int', 'string', 'never'],
+            'int | string',
+        ];
+
+        yield 'int | string | mixed' => [
+            ['int', 'string', 'mixed'],
+            'mixed',
+        ];
+    }
+
+    /**
+     * @param list<string> $types
+     */
+    #[DataProvider('provideIntersectData')]
+    public function testIntersect(array $types, string $expected): void
+    {
+        $typesNodes = [];
+
+        foreach ($types as $type) {
+            $typesNodes[] = $this->parseType($type);
+        }
+
+        $expectedTypeNode = $this->parseType($expected);
+        self::assertEquals($expectedTypeNode, PhpDocTypeUtils::intersect(...$typesNodes));
+    }
+
+    /**
+     * @return iterable<string, array{0: list<string>, 1: string}>
+     */
+    public static function provideIntersectData(): iterable
+    {
+        yield 'empty' => [
+            [],
+            'mixed',
+        ];
+
+        yield 'int' => [
+            ['int'],
+            'int',
+        ];
+
+        yield 'int & int' => [
+            ['int', 'int'],
+            'int',
+        ];
+
+        yield 'int & number' => [
+            ['int', 'number'],
+            'int',
+        ];
+
+        yield 'number & int' => [
+            ['number', 'int'],
+            'int',
+        ];
+
+        yield 'Countable & Traversable & mixed' => [
+            ['Countable', 'Traversable', 'mixed'],
+            'Countable & Traversable',
+        ];
+
+        yield 'Countable & Traversable & never' => [
+            ['Countable', 'Traversable', 'never'],
+            'never',
+        ];
+    }
+
     #[DataProvider('provideIsSubTypeOfData')]
     public function testIsSubTypeOf(string $a, string $b, bool $expected): void
     {

--- a/tests/Compiler/Type/PhpDocTypeUtilsTest.php
+++ b/tests/Compiler/Type/PhpDocTypeUtilsTest.php
@@ -170,7 +170,25 @@ class PhpDocTypeUtilsTest extends InputMapperTestCase
 
         yield 'positive-int' => [
             new IdentifierTypeNode('positive-int'),
-            new Identifier('mixed'),
+            new Identifier('int'),
+            true,
+        ];
+
+        yield 'negative-int' => [
+            new IdentifierTypeNode('negative-int'),
+            new Identifier('int'),
+            true,
+        ];
+
+        yield 'non-positive-int' => [
+            new IdentifierTypeNode('non-positive-int'),
+            new Identifier('int'),
+            true,
+        ];
+
+        yield 'non-negative-int' => [
+            new IdentifierTypeNode('non-negative-int'),
+            new Identifier('int'),
             true,
         ];
 
@@ -795,12 +813,112 @@ class PhpDocTypeUtilsTest extends InputMapperTestCase
             'true' => [
                 'int',
                 'integer',
+                'int<1, 10>',
+                'int<min, max>',
+                'int<min, 10>',
+                'int<1, max>',
+                'positive-int',
+                'negative-int',
                 '1',
             ],
 
             'false' => [
                 'string',
                 'float',
+            ],
+        ];
+
+        yield 'int<3, 5>' => [
+            'true' => [
+                'int<3, 5>',
+                'int<3, 4>',
+                'int<4, 5>',
+                '3',
+                '4',
+                '5',
+            ],
+
+            'false' => [
+                'int',
+                'int<1, 2>',
+                'int<6, 10>',
+                'int<min, 4>',
+                'int<4, max>',
+                'positive-int',
+                'negative-int',
+                '2',
+                '6',
+            ],
+        ];
+
+        yield 'int<min, 5>' => [
+            'true' => [
+                'int<min, 4>',
+                'int<min, 5>',
+                'int<-7, 5>',
+                'int<0, 5>',
+                'int<5, 5>',
+                'negative-int',
+                '-7',
+                '0',
+                '5',
+            ],
+
+            'false' => [
+                'int',
+                'int<0, 10>',
+                'int<0, max>',
+                'int<min, 6>',
+                'positive-int',
+                '6',
+            ],
+        ];
+
+        yield 'int<3, max>' => [
+            'true' => [
+                'int<3, 3>',
+                'int<3, 4>',
+                'int<3, 5>',
+                'int<3, max>',
+                'int<4, 4>',
+                'int<4, 5>',
+                'int<4, max>',
+                '3',
+                '4',
+                '5',
+                '6',
+            ],
+
+            'false' => [
+                'int',
+                'int<0, 5>',
+                'int<2, max>',
+                'int<min, max>',
+                'positive-int',
+                'negative-int',
+                '-2',
+                '0',
+                '2',
+            ],
+        ];
+
+        yield 'int<min, max>' => [
+            'true' => [
+                'int',
+                'int<min, max>',
+                'int<min, 3>',
+                'int<3, max>',
+                'positive-int',
+                'negative-int',
+                '-3',
+                '0',
+                '3',
+            ],
+
+            'false' => [
+                'string',
+                'array',
+                'null',
             ],
         ];
 
@@ -895,6 +1013,24 @@ class PhpDocTypeUtilsTest extends InputMapperTestCase
             'false' => [],
         ];
 
+        yield 'negative-int' => [
+            'true' => [
+                'negative-int',
+                'int<min, -1>',
+                '-1',
+                '-2',
+            ],
+
+            'false' => [
+                'int',
+                'int<0, max>',
+                'int<min, max>',
+                'int<min, 0>',
+                '0',
+                '1',
+            ],
+        ];
+
         yield 'never' => [
             'true' => [
                 'never',
@@ -945,6 +1081,26 @@ class PhpDocTypeUtilsTest extends InputMapperTestCase
                 'string',
                 'array',
                 'array<int>',
+            ],
+        ];
+
+        yield 'positive-int' => [
+            'true' => [
+                'positive-int',
+                'int<1, max>',
+                'int<1, 10>',
+                'int<1, 1>',
+                '1',
+                '10',
+            ],
+
+            'false' => [
+                'int',
+                'int<0, max>',
+                'int<min, max>',
+                'int<min, 1>',
+                '0',
+                '-1',
             ],
         ];
 

--- a/tests/Compiler/Validator/Array/AssertListItemTest.php
+++ b/tests/Compiler/Validator/Array/AssertListItemTest.php
@@ -68,7 +68,7 @@ class AssertListItemTest extends ValidatorCompilerTestCase
                 self::isInstanceOf(PhpCodeBuilder::class),
             );
 
-        $itemValidator->expects(self::once())
+        $itemValidator->expects(self::exactly(3))
             ->method('getInputType')
             ->willReturn(new IdentifierTypeNode('int'));
 

--- a/tests/Compiler/Validator/Array/Data/ListItemValidatorMapper.php
+++ b/tests/Compiler/Validator/Array/Data/ListItemValidatorMapper.php
@@ -13,7 +13,7 @@ use function is_int;
 /**
  * Generated mapper by {@see ValidatedMapperCompiler}. Do not edit directly.
  *
- * @implements Mapper<list<int>>
+ * @implements Mapper<list<positive-int>>
  */
 class ListItemValidatorMapper implements Mapper
 {
@@ -23,7 +23,7 @@ class ListItemValidatorMapper implements Mapper
 
     /**
      * @param  list<string|int> $path
-     * @return list<int>
+     * @return list<positive-int>
      * @throws MappingFailedException
      */
     public function map(mixed $data, array $path = []): array

--- a/tests/Compiler/Validator/Array/Data/ListItemValidatorWithMultipleValidatorsMapper.php
+++ b/tests/Compiler/Validator/Array/Data/ListItemValidatorWithMultipleValidatorsMapper.php
@@ -13,7 +13,7 @@ use function is_int;
 /**
  * Generated mapper by {@see ValidatedMapperCompiler}. Do not edit directly.
  *
- * @implements Mapper<list<int>>
+ * @implements Mapper<list<positive-int>>
  */
 class ListItemValidatorWithMultipleValidatorsMapper implements Mapper
 {
@@ -23,7 +23,7 @@ class ListItemValidatorWithMultipleValidatorsMapper implements Mapper
 
     /**
      * @param  list<string|int> $path
-     * @return list<int>
+     * @return list<positive-int>
      * @throws MappingFailedException
      */
     public function map(mixed $data, array $path = []): array

--- a/tests/Compiler/Validator/Int/AssertIntRangeTest.php
+++ b/tests/Compiler/Validator/Int/AssertIntRangeTest.php
@@ -2,10 +2,13 @@
 
 namespace ShipMonkTests\InputMapper\Compiler\Validator\Int;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use ShipMonk\InputMapper\Compiler\Mapper\Scalar\MapInt;
 use ShipMonk\InputMapper\Compiler\Validator\Int\AssertIntRange;
 use ShipMonk\InputMapper\Runtime\Exception\MappingFailedException;
 use ShipMonkTests\InputMapper\Compiler\Validator\ValidatorCompilerTestCase;
+use const PHP_INT_MAX;
+use const PHP_INT_MIN;
 
 class AssertIntRangeTest extends ValidatorCompilerTestCase
 {
@@ -103,6 +106,88 @@ class AssertIntRangeTest extends ValidatorCompilerTestCase
             'Failed to map data at path /: Expected value less than or equal to 10, got 11',
             static fn() => $validator->map(11),
         );
+    }
+
+    #[DataProvider('provideGetNarrowedInputTypeData')]
+    public function testGetNarrowedInputType(AssertIntRange $validatorCompiler, string $expectedNarrowedType): void
+    {
+        self::assertSame($expectedNarrowedType, $validatorCompiler->getNarrowedInputType()->__toString());
+    }
+
+    /**
+     * @return iterable<array{AssertIntRange, string}>
+     */
+    public static function provideGetNarrowedInputTypeData(): iterable
+    {
+        yield [
+            new AssertIntRange(),
+            'int',
+        ];
+
+        yield [
+            new AssertIntRange(gte: 5),
+            'int<5, max>',
+        ];
+
+        yield [
+            new AssertIntRange(gt: 5),
+            'int<6, max>',
+        ];
+
+        yield [
+            new AssertIntRange(lte: 5),
+            'int<min, 5>',
+        ];
+
+        yield [
+            new AssertIntRange(lt: 5),
+            'int<min, 4>',
+        ];
+
+        yield [
+            new AssertIntRange(gte: 5, lte: 10),
+            'int<5, 10>',
+        ];
+
+        yield [
+            new AssertIntRange(gt: 5, lte: 10),
+            'int<6, 10>',
+        ];
+
+        yield [
+            new AssertIntRange(gte: 5, lt: 10),
+            'int<5, 9>',
+        ];
+
+        yield [
+            new AssertIntRange(gt: 5, lt: 10),
+            'int<6, 9>',
+        ];
+
+        yield [
+            new AssertIntRange(gt: 0, gte: 5),
+            'int<5, max>',
+        ];
+
+        yield [
+            new AssertIntRange(lt: 0, lte: 5),
+            'int<min, -1>',
+        ];
+
+        yield [
+            new AssertIntRange(gt: 5, gte: 0),
+            'int<6, max>',
+        ];
+
+        yield [
+            new AssertIntRange(lt: 5, lte: 0),
+            'int<min, 0>',
+        ];
+
+        yield [
+            new AssertIntRange(gte: PHP_INT_MIN, lte: PHP_INT_MAX),
+            'int',
+        ];
     }
 
 }

--- a/tests/Compiler/Validator/Int/AssertNonNegativeIntTest.php
+++ b/tests/Compiler/Validator/Int/AssertNonNegativeIntTest.php
@@ -2,6 +2,7 @@
 
 namespace ShipMonkTests\InputMapper\Compiler\Validator\Int;
 
+use ShipMonk\InputMapper\Compiler\Mapper\Scalar\MapInt;
 use ShipMonk\InputMapper\Compiler\Validator\Int\AssertNonNegativeInt;
 use ShipMonkTests\InputMapper\Compiler\Validator\ValidatorCompilerTestCase;
 
@@ -10,11 +11,17 @@ class AssertNonNegativeIntTest extends ValidatorCompilerTestCase
 
     public function testNonNegativeIntValidator(): void
     {
+        $mapperCompiler = new MapInt();
         $validatorCompiler = new AssertNonNegativeInt();
+
         self::assertSame(0, $validatorCompiler->gte);
         self::assertNull($validatorCompiler->gt);
         self::assertNull($validatorCompiler->lt);
         self::assertNull($validatorCompiler->lte);
+
+        $validator = $this->compileValidator('NonNegativeIntValidator', $mapperCompiler, $validatorCompiler);
+        $validator->map(0);
+        $validator->map(123);
     }
 
 }

--- a/tests/Compiler/Validator/Int/AssertPositiveIntTest.php
+++ b/tests/Compiler/Validator/Int/AssertPositiveIntTest.php
@@ -2,6 +2,7 @@
 
 namespace ShipMonkTests\InputMapper\Compiler\Validator\Int;
 
+use ShipMonk\InputMapper\Compiler\Mapper\Scalar\MapInt;
 use ShipMonk\InputMapper\Compiler\Validator\Int\AssertPositiveInt;
 use ShipMonkTests\InputMapper\Compiler\Validator\ValidatorCompilerTestCase;
 
@@ -10,11 +11,16 @@ class AssertPositiveIntTest extends ValidatorCompilerTestCase
 
     public function testPositiveIntValidator(): void
     {
+        $mapperCompiler = new MapInt();
         $validatorCompiler = new AssertPositiveInt();
+
         self::assertNull($validatorCompiler->gte);
         self::assertSame(0, $validatorCompiler->gt);
         self::assertNull($validatorCompiler->lt);
         self::assertNull($validatorCompiler->lte);
+
+        $validator = $this->compileValidator('PositiveIntValidator', $mapperCompiler, $validatorCompiler);
+        $validator->map(123);
     }
 
 }

--- a/tests/Compiler/Validator/Int/Data/IntRangeValidatorWithExclusiveUpperBoundMapper.php
+++ b/tests/Compiler/Validator/Int/Data/IntRangeValidatorWithExclusiveUpperBoundMapper.php
@@ -11,7 +11,7 @@ use function is_int;
 /**
  * Generated mapper by {@see ValidatedMapperCompiler}. Do not edit directly.
  *
- * @implements Mapper<int>
+ * @implements Mapper<int<min, 4>>
  */
 class IntRangeValidatorWithExclusiveUpperBoundMapper implements Mapper
 {
@@ -21,6 +21,7 @@ class IntRangeValidatorWithExclusiveUpperBoundMapper implements Mapper
 
     /**
      * @param  list<string|int> $path
+     * @return int<min, 4>
      * @throws MappingFailedException
      */
     public function map(mixed $data, array $path = []): int

--- a/tests/Compiler/Validator/Int/Data/IntRangeValidatorWithInclusiveLowerAndUpperBoundMapper.php
+++ b/tests/Compiler/Validator/Int/Data/IntRangeValidatorWithInclusiveLowerAndUpperBoundMapper.php
@@ -11,7 +11,7 @@ use function is_int;
 /**
  * Generated mapper by {@see ValidatedMapperCompiler}. Do not edit directly.
  *
- * @implements Mapper<int>
+ * @implements Mapper<int<5, 10>>
  */
 class IntRangeValidatorWithInclusiveLowerAndUpperBoundMapper implements Mapper
 {
@@ -21,6 +21,7 @@ class IntRangeValidatorWithInclusiveLowerAndUpperBoundMapper implements Mapper
 
     /**
      * @param  list<string|int> $path
+     * @return int<5, 10>
      * @throws MappingFailedException
      */
     public function map(mixed $data, array $path = []): int

--- a/tests/Compiler/Validator/Int/Data/IntRangeValidatorWithInclusiveLowerBoundMapper.php
+++ b/tests/Compiler/Validator/Int/Data/IntRangeValidatorWithInclusiveLowerBoundMapper.php
@@ -11,7 +11,7 @@ use function is_int;
 /**
  * Generated mapper by {@see ValidatedMapperCompiler}. Do not edit directly.
  *
- * @implements Mapper<int>
+ * @implements Mapper<int<5, max>>
  */
 class IntRangeValidatorWithInclusiveLowerBoundMapper implements Mapper
 {
@@ -21,6 +21,7 @@ class IntRangeValidatorWithInclusiveLowerBoundMapper implements Mapper
 
     /**
      * @param  list<string|int> $path
+     * @return int<5, max>
      * @throws MappingFailedException
      */
     public function map(mixed $data, array $path = []): int

--- a/tests/Compiler/Validator/Int/Data/IntRangeValidatorWithInclusiveUpperBoundMapper.php
+++ b/tests/Compiler/Validator/Int/Data/IntRangeValidatorWithInclusiveUpperBoundMapper.php
@@ -11,7 +11,7 @@ use function is_int;
 /**
  * Generated mapper by {@see ValidatedMapperCompiler}. Do not edit directly.
  *
- * @implements Mapper<int>
+ * @implements Mapper<int<min, 5>>
  */
 class IntRangeValidatorWithInclusiveUpperBoundMapper implements Mapper
 {
@@ -21,6 +21,7 @@ class IntRangeValidatorWithInclusiveUpperBoundMapper implements Mapper
 
     /**
      * @param  list<string|int> $path
+     * @return int<min, 5>
      * @throws MappingFailedException
      */
     public function map(mixed $data, array $path = []): int

--- a/tests/Compiler/Validator/Int/Data/NonNegativeIntValidatorMapper.php
+++ b/tests/Compiler/Validator/Int/Data/NonNegativeIntValidatorMapper.php
@@ -11,9 +11,9 @@ use function is_int;
 /**
  * Generated mapper by {@see ValidatedMapperCompiler}. Do not edit directly.
  *
- * @implements Mapper<int<6, max>>
+ * @implements Mapper<int<0, max>>
  */
-class IntRangeValidatorWithExclusiveLowerBoundMapper implements Mapper
+class NonNegativeIntValidatorMapper implements Mapper
 {
     public function __construct(private readonly MapperProvider $provider)
     {
@@ -21,7 +21,7 @@ class IntRangeValidatorWithExclusiveLowerBoundMapper implements Mapper
 
     /**
      * @param  list<string|int> $path
-     * @return int<6, max>
+     * @return int<0, max>
      * @throws MappingFailedException
      */
     public function map(mixed $data, array $path = []): int
@@ -30,8 +30,8 @@ class IntRangeValidatorWithExclusiveLowerBoundMapper implements Mapper
             throw MappingFailedException::incorrectType($data, $path, 'int');
         }
 
-        if ($data <= 5) {
-            throw MappingFailedException::incorrectValue($data, $path, 'value greater than 5');
+        if ($data < 0) {
+            throw MappingFailedException::incorrectValue($data, $path, 'value greater than or equal to 0');
         }
 
         return $data;

--- a/tests/Compiler/Validator/Int/Data/PositiveIntValidatorMapper.php
+++ b/tests/Compiler/Validator/Int/Data/PositiveIntValidatorMapper.php
@@ -11,9 +11,9 @@ use function is_int;
 /**
  * Generated mapper by {@see ValidatedMapperCompiler}. Do not edit directly.
  *
- * @implements Mapper<int<6, max>>
+ * @implements Mapper<positive-int>
  */
-class IntRangeValidatorWithExclusiveLowerBoundMapper implements Mapper
+class PositiveIntValidatorMapper implements Mapper
 {
     public function __construct(private readonly MapperProvider $provider)
     {
@@ -21,7 +21,7 @@ class IntRangeValidatorWithExclusiveLowerBoundMapper implements Mapper
 
     /**
      * @param  list<string|int> $path
-     * @return int<6, max>
+     * @return positive-int
      * @throws MappingFailedException
      */
     public function map(mixed $data, array $path = []): int
@@ -30,8 +30,8 @@ class IntRangeValidatorWithExclusiveLowerBoundMapper implements Mapper
             throw MappingFailedException::incorrectType($data, $path, 'int');
         }
 
-        if ($data <= 5) {
-            throw MappingFailedException::incorrectValue($data, $path, 'value greater than 5');
+        if ($data <= 0) {
+            throw MappingFailedException::incorrectValue($data, $path, 'value greater than 0');
         }
 
         return $data;


### PR DESCRIPTION
Allows validators to refine the input type. This is essential for supporting integer boundary types that have been broken since https://github.com/shipmonk-rnd/input-mapper/commit/dbac53ce43dc6fa5250326be7a93dd3b21837941