### PR TITLE
dependabot: update non-major dev deps only

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,4 +5,10 @@ updates:
         directory: "/"
         schedule:
             interval: monthly
-        versioning-strategy: lockfile-only
+        allow:
+            - dependency-type: development
+        versioning-strategy: increase
+        ignore:
+            -
+                dependency-name: "*"
+                update-types: ["version-update:semver-major"] # never update major versions


### PR DESCRIPTION
Lockfile is not committed here, so the config was broken.