### PR TITLE
 add Optional attribute that allows specifying default value 

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,10 +66,11 @@ You can write your own validators if you need more.
 
 To use Input Mapper, write a class with a public constructor and add either native or PHPDoc types to all constructor parameters.
 
-Optional fields need to be wrapped with the Optional class, which allows distinguishing between null and missing values.
+Optional fields can either be marked with `#[Optional]` attribute (allowing you to specify a default value),
+or if you need to distinguish between default and missing values, you can wrap the type with `ShipMonk\InputMapper\Runtime\Optional` class.
 
 ```php
-use ShipMonk\InputMapper\Runtime\Optional;
+use ShipMonk\InputMapper\Compiler\Mapper\Optional;
 
 class Person
 {
@@ -78,14 +79,15 @@ class Person
 
         public readonly int $age,
 
-        /** @var Optional<string> */
-        public readonly Optional $email,
+        #[Optional]
+        public readonly ?string $email,
 
         /** @var list<string> */
         public readonly array $hobbies,
 
-        /** @var Optional<list<self>> */
-        public readonly Optional $friends,
+        /** @var list<self> */
+        #[Optional(default: [])]
+        public readonly array $friends,
     ) {}
 }
 ```

--- a/src/Compiler/Exception/CannotCreateMapperCompilerException.php
+++ b/src/Compiler/Exception/CannotCreateMapperCompilerException.php
@@ -6,6 +6,7 @@ use LogicException;
 use PHPStan\PhpDocParser\Ast\Type\TypeNode;
 use ReflectionParameter;
 use ShipMonk\InputMapper\Compiler\Mapper\MapperCompiler;
+use ShipMonk\InputMapper\Compiler\Mapper\UndefinedAwareMapperCompiler;
 use ShipMonk\InputMapper\Compiler\Validator\ValidatorCompiler;
 use Throwable;
 
@@ -34,6 +35,25 @@ class CannotCreateMapperCompilerException extends LogicException
         $methodFullName = $className !== null ? "{$className}::{$methodName}" : $methodName;
 
         $reason = "mapper output type '{$mapperOutputType}' is not compatible with parameter type '{$parameterType}'";
+        return new self("Cannot use mapper {$mapperCompilerClass} for parameter \${$parameterName} of method {$methodFullName}, because {$reason}", 0, $previous);
+    }
+
+    public static function withIncompatibleDefaultValueParameter(
+        UndefinedAwareMapperCompiler $mapperCompiler,
+        ReflectionParameter $parameter,
+        TypeNode $parameterType,
+        ?Throwable $previous = null
+    ): self
+    {
+        $mapperCompilerClass = $mapperCompiler::class;
+        $defaultValueType = $mapperCompiler->getDefaultValueType();
+
+        $parameterName = $parameter->getName();
+        $className = $parameter->getDeclaringClass()?->getName();
+        $methodName = $parameter->getDeclaringFunction()->getName();
+        $methodFullName = $className !== null ? "{$className}::{$methodName}" : $methodName;
+
+        $reason = "default value of type '{$defaultValueType}' is not compatible with parameter type '{$parameterType}'";
         return new self("Cannot use mapper {$mapperCompilerClass} for parameter \${$parameterName} of method {$methodFullName}, because {$reason}", 0, $previous);
     }
 

--- a/src/Compiler/Mapper/Optional.php
+++ b/src/Compiler/Mapper/Optional.php
@@ -1,0 +1,17 @@
+<?php declare(strict_types = 1);
+
+namespace ShipMonk\InputMapper\Compiler\Mapper;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_PARAMETER | Attribute::TARGET_PROPERTY)]
+class Optional
+{
+
+    public function __construct(
+        public readonly mixed $default = null,
+    )
+    {
+    }
+
+}

--- a/src/Compiler/Mapper/UndefinedAwareMapperCompiler.php
+++ b/src/Compiler/Mapper/UndefinedAwareMapperCompiler.php
@@ -3,6 +3,7 @@
 namespace ShipMonk\InputMapper\Compiler\Mapper;
 
 use PhpParser\Node\Expr;
+use PHPStan\PhpDocParser\Ast\Type\TypeNode;
 use ShipMonk\InputMapper\Compiler\CompiledExpr;
 use ShipMonk\InputMapper\Compiler\Php\PhpCodeBuilder;
 
@@ -10,5 +11,7 @@ interface UndefinedAwareMapperCompiler extends MapperCompiler
 {
 
     public function compileUndefined(Expr $path, Expr $key, PhpCodeBuilder $builder): CompiledExpr;
+
+    public function getDefaultValueType(): TypeNode;
 
 }

--- a/src/Compiler/Mapper/Wrapper/MapDefaultValue.php
+++ b/src/Compiler/Mapper/Wrapper/MapDefaultValue.php
@@ -35,7 +35,7 @@ class MapDefaultValue implements UndefinedAwareMapperCompiler
     public function compileUndefined(Expr $path, Expr $key, PhpCodeBuilder $builder): CompiledExpr
     {
         if ($this->defaultValue === null || is_scalar($this->defaultValue) || is_array($this->defaultValue)) {
-            return new CompiledExpr($builder->val(null));
+            return new CompiledExpr($builder->val($this->defaultValue));
         }
 
         if ($this->defaultValue instanceof BackedEnum) {

--- a/src/Compiler/Mapper/Wrapper/MapDefaultValue.php
+++ b/src/Compiler/Mapper/Wrapper/MapDefaultValue.php
@@ -1,0 +1,93 @@
+<?php declare(strict_types = 1);
+
+namespace ShipMonk\InputMapper\Compiler\Mapper\Wrapper;
+
+use Attribute;
+use BackedEnum;
+use LogicException;
+use PhpParser\Node\Expr;
+use PHPStan\PhpDocParser\Ast\Type\GenericTypeNode;
+use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
+use PHPStan\PhpDocParser\Ast\Type\TypeNode;
+use ShipMonk\InputMapper\Compiler\CompiledExpr;
+use ShipMonk\InputMapper\Compiler\Mapper\MapperCompiler;
+use ShipMonk\InputMapper\Compiler\Mapper\UndefinedAwareMapperCompiler;
+use ShipMonk\InputMapper\Compiler\Php\PhpCodeBuilder;
+use ShipMonk\InputMapper\Compiler\Type\PhpDocTypeUtils;
+use function array_is_list;
+use function array_keys;
+use function array_map;
+use function array_values;
+use function get_debug_type;
+use function is_array;
+use function is_scalar;
+
+#[Attribute(Attribute::TARGET_PARAMETER | Attribute::TARGET_PROPERTY)]
+class MapDefaultValue implements UndefinedAwareMapperCompiler
+{
+
+    public function __construct(
+        public readonly MapperCompiler $mapperCompiler,
+        public readonly mixed $defaultValue,
+    )
+    {
+    }
+
+    public function compile(Expr $value, Expr $path, PhpCodeBuilder $builder): CompiledExpr
+    {
+        return $this->mapperCompiler->compile($value, $path, $builder);
+    }
+
+    public function compileUndefined(Expr $path, Expr $key, PhpCodeBuilder $builder): CompiledExpr
+    {
+        if ($this->defaultValue === null || is_scalar($this->defaultValue) || is_array($this->defaultValue)) {
+            return new CompiledExpr($builder->val(null));
+        }
+
+        if ($this->defaultValue instanceof BackedEnum) {
+            return new CompiledExpr($builder->classConstFetch($builder->importClass($this->defaultValue::class), $this->defaultValue->name));
+        }
+
+        throw new LogicException('Unsupported default value type: ' . get_debug_type($this->defaultValue));
+    }
+
+    public function getInputType(): TypeNode
+    {
+        return $this->mapperCompiler->getInputType();
+    }
+
+    public function getOutputType(): TypeNode
+    {
+        return $this->mapperCompiler->getOutputType();
+    }
+
+    public function getDefaultValueType(): TypeNode
+    {
+        return $this->typeFromValue($this->defaultValue);
+    }
+
+    private function typeFromValue(mixed $value): TypeNode
+    {
+        if (is_scalar($value) || $value === null) {
+            return new IdentifierTypeNode(get_debug_type($value));
+        }
+
+        if (is_array($value)) {
+            if (array_is_list($value)) {
+                $valueType = PhpDocTypeUtils::union(...array_map($this->typeFromValue(...), $value));
+                return new GenericTypeNode(new IdentifierTypeNode('list'), [$valueType]);
+            }
+
+            $keyType = PhpDocTypeUtils::union(...array_map($this->typeFromValue(...), array_keys($value)));
+            $valueType = PhpDocTypeUtils::union(...array_map($this->typeFromValue(...), array_values($value)));
+            return new GenericTypeNode(new IdentifierTypeNode('array'), [$keyType, $valueType]);
+        }
+
+        if ($value instanceof BackedEnum) {
+            return new IdentifierTypeNode($value::class);
+        }
+
+        throw new LogicException('Unsupported default value type: ' . get_debug_type($value));
+    }
+
+}

--- a/src/Compiler/Mapper/Wrapper/MapDefaultValue.php
+++ b/src/Compiler/Mapper/Wrapper/MapDefaultValue.php
@@ -6,18 +6,12 @@ use Attribute;
 use BackedEnum;
 use LogicException;
 use PhpParser\Node\Expr;
-use PHPStan\PhpDocParser\Ast\Type\GenericTypeNode;
-use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
 use PHPStan\PhpDocParser\Ast\Type\TypeNode;
 use ShipMonk\InputMapper\Compiler\CompiledExpr;
 use ShipMonk\InputMapper\Compiler\Mapper\MapperCompiler;
 use ShipMonk\InputMapper\Compiler\Mapper\UndefinedAwareMapperCompiler;
 use ShipMonk\InputMapper\Compiler\Php\PhpCodeBuilder;
 use ShipMonk\InputMapper\Compiler\Type\PhpDocTypeUtils;
-use function array_is_list;
-use function array_keys;
-use function array_map;
-use function array_values;
 use function get_debug_type;
 use function is_array;
 use function is_scalar;
@@ -63,31 +57,7 @@ class MapDefaultValue implements UndefinedAwareMapperCompiler
 
     public function getDefaultValueType(): TypeNode
     {
-        return $this->typeFromValue($this->defaultValue);
-    }
-
-    private function typeFromValue(mixed $value): TypeNode
-    {
-        if (is_scalar($value) || $value === null) {
-            return new IdentifierTypeNode(get_debug_type($value));
-        }
-
-        if (is_array($value)) {
-            if (array_is_list($value)) {
-                $valueType = PhpDocTypeUtils::union(...array_map($this->typeFromValue(...), $value));
-                return new GenericTypeNode(new IdentifierTypeNode('list'), [$valueType]);
-            }
-
-            $keyType = PhpDocTypeUtils::union(...array_map($this->typeFromValue(...), array_keys($value)));
-            $valueType = PhpDocTypeUtils::union(...array_map($this->typeFromValue(...), array_values($value)));
-            return new GenericTypeNode(new IdentifierTypeNode('array'), [$keyType, $valueType]);
-        }
-
-        if ($value instanceof BackedEnum) {
-            return new IdentifierTypeNode($value::class);
-        }
-
-        throw new LogicException('Unsupported default value type: ' . get_debug_type($value));
+        return PhpDocTypeUtils::fromValue($this->defaultValue);
     }
 
 }

--- a/src/Compiler/Mapper/Wrapper/MapOptional.php
+++ b/src/Compiler/Mapper/Wrapper/MapOptional.php
@@ -12,6 +12,8 @@ use ShipMonk\InputMapper\Compiler\Mapper\MapperCompiler;
 use ShipMonk\InputMapper\Compiler\Mapper\UndefinedAwareMapperCompiler;
 use ShipMonk\InputMapper\Compiler\Php\PhpCodeBuilder;
 use ShipMonk\InputMapper\Runtime\Optional;
+use ShipMonk\InputMapper\Runtime\OptionalNone;
+use ShipMonk\InputMapper\Runtime\OptionalSome;
 
 #[Attribute(Attribute::TARGET_PARAMETER | Attribute::TARGET_PROPERTY)]
 class MapOptional implements UndefinedAwareMapperCompiler
@@ -44,9 +46,14 @@ class MapOptional implements UndefinedAwareMapperCompiler
     public function getOutputType(): TypeNode
     {
         return new GenericTypeNode(
-            new IdentifierTypeNode(Optional::class),
+            new IdentifierTypeNode(OptionalSome::class),
             [$this->mapperCompiler->getOutputType()],
         );
+    }
+
+    public function getDefaultValueType(): TypeNode
+    {
+        return new IdentifierTypeNode(OptionalNone::class);
     }
 
 }

--- a/src/Compiler/MapperFactory/DefaultMapperCompilerFactory.php
+++ b/src/Compiler/MapperFactory/DefaultMapperCompilerFactory.php
@@ -400,6 +400,12 @@ class DefaultMapperCompilerFactory implements MapperCompilerFactory
             throw CannotCreateMapperCompilerException::withIncompatibleMapperForMethodParameter($mapper, $parameterReflection, $type);
         }
 
+        if ($mapper instanceof UndefinedAwareMapperCompiler) {
+            if (!PhpDocTypeUtils::isSubTypeOf($mapper->getDefaultValueType(), $type)) {
+                throw CannotCreateMapperCompilerException::withIncompatibleDefaultValueParameter($mapper, $parameterReflection, $type);
+            }
+        }
+
         foreach ($validators as $validator) {
             $mapper = $this->addValidator($mapper, $validator);
         }

--- a/tests/Compiler/Mapper/Object/Data/DelegateToPerson__PersonInputMapper.php
+++ b/tests/Compiler/Mapper/Object/Data/DelegateToPerson__PersonInputMapper.php
@@ -7,6 +7,7 @@ use ShipMonk\InputMapper\Runtime\Exception\MappingFailedException;
 use ShipMonk\InputMapper\Runtime\Mapper;
 use ShipMonk\InputMapper\Runtime\MapperProvider;
 use ShipMonk\InputMapper\Runtime\Optional;
+use ShipMonk\InputMapper\Runtime\OptionalSome;
 use function array_diff_key;
 use function array_key_exists;
 use function array_keys;
@@ -86,10 +87,10 @@ class DelegateToPerson__PersonInputMapper implements Mapper
 
     /**
      * @param  list<string|int> $path
-     * @return Optional<int>
+     * @return OptionalSome<int>
      * @throws MappingFailedException
      */
-    private function mapAge(mixed $data, array $path = []): Optional
+    private function mapAge(mixed $data, array $path = []): OptionalSome
     {
         if (!is_int($data)) {
             throw MappingFailedException::incorrectType($data, $path, 'int');

--- a/tests/Compiler/Mapper/Object/Data/MovieMapper.php
+++ b/tests/Compiler/Mapper/Object/Data/MovieMapper.php
@@ -7,6 +7,7 @@ use ShipMonk\InputMapper\Runtime\Exception\MappingFailedException;
 use ShipMonk\InputMapper\Runtime\Mapper;
 use ShipMonk\InputMapper\Runtime\MapperProvider;
 use ShipMonk\InputMapper\Runtime\Optional;
+use ShipMonk\InputMapper\Runtime\OptionalSome;
 use function array_diff_key;
 use function array_is_list;
 use function array_key_exists;
@@ -107,10 +108,10 @@ class MovieMapper implements Mapper
 
     /**
      * @param  list<string|int> $path
-     * @return Optional<string>
+     * @return OptionalSome<string>
      * @throws MappingFailedException
      */
-    private function mapDescription(mixed $data, array $path = []): Optional
+    private function mapDescription(mixed $data, array $path = []): OptionalSome
     {
         if (!is_string($data)) {
             throw MappingFailedException::incorrectType($data, $path, 'string');

--- a/tests/Compiler/Mapper/Object/Data/Movie__PersonInputMapper.php
+++ b/tests/Compiler/Mapper/Object/Data/Movie__PersonInputMapper.php
@@ -7,6 +7,7 @@ use ShipMonk\InputMapper\Runtime\Exception\MappingFailedException;
 use ShipMonk\InputMapper\Runtime\Mapper;
 use ShipMonk\InputMapper\Runtime\MapperProvider;
 use ShipMonk\InputMapper\Runtime\Optional;
+use ShipMonk\InputMapper\Runtime\OptionalSome;
 use function array_diff_key;
 use function array_key_exists;
 use function array_keys;
@@ -86,10 +87,10 @@ class Movie__PersonInputMapper implements Mapper
 
     /**
      * @param  list<string|int> $path
-     * @return Optional<int>
+     * @return OptionalSome<int>
      * @throws MappingFailedException
      */
-    private function mapAge(mixed $data, array $path = []): Optional
+    private function mapAge(mixed $data, array $path = []): OptionalSome
     {
         if (!is_int($data)) {
             throw MappingFailedException::incorrectType($data, $path, 'int');

--- a/tests/Compiler/Mapper/Object/Data/PersonWithAllowedExtraPropertiesMapper.php
+++ b/tests/Compiler/Mapper/Object/Data/PersonWithAllowedExtraPropertiesMapper.php
@@ -7,6 +7,7 @@ use ShipMonk\InputMapper\Runtime\Exception\MappingFailedException;
 use ShipMonk\InputMapper\Runtime\Mapper;
 use ShipMonk\InputMapper\Runtime\MapperProvider;
 use ShipMonk\InputMapper\Runtime\Optional;
+use ShipMonk\InputMapper\Runtime\OptionalSome;
 use function array_key_exists;
 use function is_array;
 use function is_int;
@@ -76,10 +77,10 @@ class PersonWithAllowedExtraPropertiesMapper implements Mapper
 
     /**
      * @param  list<string|int> $path
-     * @return Optional<int>
+     * @return OptionalSome<int>
      * @throws MappingFailedException
      */
-    private function mapAge(mixed $data, array $path = []): Optional
+    private function mapAge(mixed $data, array $path = []): OptionalSome
     {
         if (!is_int($data)) {
             throw MappingFailedException::incorrectType($data, $path, 'int');

--- a/tests/Compiler/Mapper/Wrapper/Data/IntWithDefaultValueMapper.php
+++ b/tests/Compiler/Mapper/Wrapper/Data/IntWithDefaultValueMapper.php
@@ -1,0 +1,34 @@
+<?php declare (strict_types=1);
+
+namespace ShipMonkTests\InputMapper\Compiler\Mapper\Wrapper\Data;
+
+use ShipMonk\InputMapper\Compiler\Mapper\Wrapper\MapDefaultValue;
+use ShipMonk\InputMapper\Runtime\Exception\MappingFailedException;
+use ShipMonk\InputMapper\Runtime\Mapper;
+use ShipMonk\InputMapper\Runtime\MapperProvider;
+use function is_int;
+
+/**
+ * Generated mapper by {@see MapDefaultValue}. Do not edit directly.
+ *
+ * @implements Mapper<int>
+ */
+class IntWithDefaultValueMapper implements Mapper
+{
+    public function __construct(private readonly MapperProvider $provider)
+    {
+    }
+
+    /**
+     * @param  list<string|int> $path
+     * @throws MappingFailedException
+     */
+    public function map(mixed $data, array $path = []): int
+    {
+        if (!is_int($data)) {
+            throw MappingFailedException::incorrectType($data, $path, 'int');
+        }
+
+        return $data;
+    }
+}

--- a/tests/Compiler/Mapper/Wrapper/Data/OptionalIntMapper.php
+++ b/tests/Compiler/Mapper/Wrapper/Data/OptionalIntMapper.php
@@ -7,12 +7,13 @@ use ShipMonk\InputMapper\Runtime\Exception\MappingFailedException;
 use ShipMonk\InputMapper\Runtime\Mapper;
 use ShipMonk\InputMapper\Runtime\MapperProvider;
 use ShipMonk\InputMapper\Runtime\Optional;
+use ShipMonk\InputMapper\Runtime\OptionalSome;
 use function is_int;
 
 /**
  * Generated mapper by {@see MapOptional}. Do not edit directly.
  *
- * @implements Mapper<Optional<int>>
+ * @implements Mapper<OptionalSome<int>>
  */
 class OptionalIntMapper implements Mapper
 {
@@ -22,10 +23,10 @@ class OptionalIntMapper implements Mapper
 
     /**
      * @param  list<string|int> $path
-     * @return Optional<int>
+     * @return OptionalSome<int>
      * @throws MappingFailedException
      */
-    public function map(mixed $data, array $path = []): Optional
+    public function map(mixed $data, array $path = []): OptionalSome
     {
         if (!is_int($data)) {
             throw MappingFailedException::incorrectType($data, $path, 'int');

--- a/tests/Compiler/Mapper/Wrapper/Data/Semaphore.php
+++ b/tests/Compiler/Mapper/Wrapper/Data/Semaphore.php
@@ -1,0 +1,20 @@
+<?php declare (strict_types = 1);
+
+namespace ShipMonkTests\InputMapper\Compiler\Mapper\Wrapper\Data;
+
+use ShipMonk\InputMapper\Compiler\Mapper\Optional;
+
+class Semaphore
+{
+
+    public function __construct(
+        #[Optional(default: SemaphoreColorEnum::Red)]
+        public readonly SemaphoreColorEnum $color,
+
+        #[Optional]
+        public readonly ?string $manufacturer,
+    )
+    {
+    }
+
+}

--- a/tests/Compiler/Mapper/Wrapper/Data/SemaphoreColorEnum.php
+++ b/tests/Compiler/Mapper/Wrapper/Data/SemaphoreColorEnum.php
@@ -1,0 +1,12 @@
+<?php declare (strict_types = 1);
+
+namespace ShipMonkTests\InputMapper\Compiler\Mapper\Wrapper\Data;
+
+enum SemaphoreColorEnum: string
+{
+
+    case Red = 'red';
+    case Yellow = 'yellow';
+    case Green = 'green';
+
+}

--- a/tests/Compiler/Mapper/Wrapper/Data/SemaphoreMapper.php
+++ b/tests/Compiler/Mapper/Wrapper/Data/SemaphoreMapper.php
@@ -1,0 +1,89 @@
+<?php declare (strict_types=1);
+
+namespace ShipMonkTests\InputMapper\Compiler\Mapper\Wrapper\Data;
+
+use ShipMonk\InputMapper\Compiler\Mapper\Object\MapObject;
+use ShipMonk\InputMapper\Runtime\Exception\MappingFailedException;
+use ShipMonk\InputMapper\Runtime\Mapper;
+use ShipMonk\InputMapper\Runtime\MapperProvider;
+use function array_column;
+use function array_diff_key;
+use function array_key_exists;
+use function array_keys;
+use function count;
+use function implode;
+use function is_array;
+use function is_string;
+
+/**
+ * Generated mapper by {@see MapObject}. Do not edit directly.
+ *
+ * @implements Mapper<Semaphore>
+ */
+class SemaphoreMapper implements Mapper
+{
+    public function __construct(private readonly MapperProvider $provider)
+    {
+    }
+
+    /**
+     * @param  list<string|int> $path
+     * @throws MappingFailedException
+     */
+    public function map(mixed $data, array $path = []): Semaphore
+    {
+        if (!is_array($data)) {
+            throw MappingFailedException::incorrectType($data, $path, 'array');
+        }
+
+        $knownKeys = ['color' => true, 'manufacturer' => true];
+        $extraKeys = array_diff_key($data, $knownKeys);
+
+        if (count($extraKeys) > 0) {
+            throw MappingFailedException::extraKeys($path, array_keys($extraKeys));
+        }
+
+        return new Semaphore(
+            array_key_exists('color', $data) ? $this->mapColor($data['color'], [...$path, 'color']) : SemaphoreColorEnum::Green,
+            array_key_exists('manufacturer', $data) ? $this->mapManufacturer($data['manufacturer'], [...$path, 'manufacturer']) : null,
+        );
+    }
+
+    /**
+     * @param  list<string|int> $path
+     * @throws MappingFailedException
+     */
+    private function mapColor(mixed $data, array $path = []): SemaphoreColorEnum
+    {
+        if (!is_string($data)) {
+            throw MappingFailedException::incorrectType($data, $path, 'string');
+        }
+
+        $enum = SemaphoreColorEnum::tryFrom($data);
+
+        if ($enum === null) {
+            throw MappingFailedException::incorrectValue($data, $path, 'one of ' . implode(', ', array_column(SemaphoreColorEnum::cases(), 'value')));
+        }
+
+        return $enum;
+    }
+
+    /**
+     * @param  list<string|int> $path
+     * @throws MappingFailedException
+     */
+    private function mapManufacturer(mixed $data, array $path = []): ?string
+    {
+        if ($data === null) {
+            $mapped = null;
+        } else {
+            if (!is_string($data)) {
+                throw MappingFailedException::incorrectType($data, $path, 'string');
+            }
+
+            $mapped = $data;
+        }
+
+        return $mapped;
+    }
+}

--- a/tests/Compiler/Mapper/Wrapper/MapDefaultValueTest.php
+++ b/tests/Compiler/Mapper/Wrapper/MapDefaultValueTest.php
@@ -1,0 +1,48 @@
+<?php declare(strict_types = 1);
+
+namespace ShipMonkTests\InputMapper\Compiler\Mapper\Wrapper;
+
+use ShipMonk\InputMapper\Compiler\Mapper\Object\MapEnum;
+use ShipMonk\InputMapper\Compiler\Mapper\Object\MapObject;
+use ShipMonk\InputMapper\Compiler\Mapper\Scalar\MapInt;
+use ShipMonk\InputMapper\Compiler\Mapper\Scalar\MapString;
+use ShipMonk\InputMapper\Compiler\Mapper\Wrapper\MapDefaultValue;
+use ShipMonk\InputMapper\Compiler\Mapper\Wrapper\MapNullable;
+use ShipMonk\InputMapper\Runtime\Exception\MappingFailedException;
+use ShipMonkTests\InputMapper\Compiler\Mapper\MapperCompilerTestCase;
+use ShipMonkTests\InputMapper\Compiler\Mapper\Wrapper\Data\Semaphore;
+use ShipMonkTests\InputMapper\Compiler\Mapper\Wrapper\Data\SemaphoreColorEnum;
+
+class MapDefaultValueTest extends MapperCompilerTestCase
+{
+
+    public function testCompile(): void
+    {
+        $mapperCompiler = new MapDefaultValue(new MapInt(), null);
+        $mapper = $this->compileMapper('IntWithDefaultValue', $mapperCompiler);
+
+        self::assertSame(1, $mapper->map(1));
+        self::assertSame(2, $mapper->map(2));
+
+        self::assertException(
+            MappingFailedException::class,
+            'Failed to map data at path /: Expected int, got "1"',
+            static fn() => $mapper->map('1'),
+        );
+    }
+
+    public function testCompileUndefined(): void
+    {
+        $mapperCompiler = new MapObject(Semaphore::class, [
+            'color' => new MapDefaultValue(new MapEnum(SemaphoreColorEnum::class, new MapString()), SemaphoreColorEnum::Green),
+            'manufacturer' => new MapDefaultValue(new MapNullable(new MapString()), null),
+        ]);
+
+        $mapper = $this->compileMapper('Semaphore', $mapperCompiler);
+
+        self::assertEquals(new Semaphore(SemaphoreColorEnum::Green, null), $mapper->map([]));
+        self::assertEquals(new Semaphore(SemaphoreColorEnum::Red, null), $mapper->map(['color' => 'red']));
+        self::assertEquals(new Semaphore(SemaphoreColorEnum::Red, 'Siemens'), $mapper->map(['color' => 'red', 'manufacturer' => 'Siemens']));
+    }
+
+}

--- a/tests/Compiler/MapperFactory/Data/BrandInputWithDefaultValues.php
+++ b/tests/Compiler/MapperFactory/Data/BrandInputWithDefaultValues.php
@@ -1,0 +1,26 @@
+<?php declare(strict_types = 1);
+
+namespace ShipMonkTests\InputMapper\Compiler\MapperFactory\Data;
+
+use ShipMonk\InputMapper\Compiler\Mapper\Optional;
+
+class BrandInputWithDefaultValues
+{
+
+    /**
+     * @param list<string> $founders
+     */
+    public function __construct(
+        #[Optional(default: 'ShipMonk')]
+        public readonly string $name,
+
+        #[Optional]
+        public readonly ?int $foundedIn,
+
+        #[Optional(default: ['Jan Bednář'])]
+        public readonly array $founders,
+    )
+    {
+    }
+
+}

--- a/tests/Compiler/MapperFactory/DefaultMapperCompilerFactoryTest.php
+++ b/tests/Compiler/MapperFactory/DefaultMapperCompilerFactoryTest.php
@@ -27,6 +27,7 @@ use ShipMonk\InputMapper\Compiler\Mapper\Scalar\MapBool;
 use ShipMonk\InputMapper\Compiler\Mapper\Scalar\MapFloat;
 use ShipMonk\InputMapper\Compiler\Mapper\Scalar\MapInt;
 use ShipMonk\InputMapper\Compiler\Mapper\Scalar\MapString;
+use ShipMonk\InputMapper\Compiler\Mapper\Wrapper\MapDefaultValue;
 use ShipMonk\InputMapper\Compiler\Mapper\Wrapper\MapNullable;
 use ShipMonk\InputMapper\Compiler\Mapper\Wrapper\MapOptional;
 use ShipMonk\InputMapper\Compiler\Mapper\Wrapper\ValidatedMapperCompiler;
@@ -41,6 +42,7 @@ use ShipMonk\InputMapper\Compiler\Validator\Int\AssertPositiveInt;
 use ShipMonk\InputMapper\Compiler\Validator\String\AssertStringLength;
 use ShipMonk\InputMapper\Compiler\Validator\String\AssertUrl;
 use ShipMonkTests\InputMapper\Compiler\MapperFactory\Data\BrandInput;
+use ShipMonkTests\InputMapper\Compiler\MapperFactory\Data\BrandInputWithDefaultValues;
 use ShipMonkTests\InputMapper\Compiler\MapperFactory\Data\CarFilterInput;
 use ShipMonkTests\InputMapper\Compiler\MapperFactory\Data\CarInput;
 use ShipMonkTests\InputMapper\Compiler\MapperFactory\Data\CarInputWithVarTags;
@@ -127,6 +129,28 @@ class DefaultMapperCompilerFactoryTest extends InputMapperTestCase
                     ),
                 ],
                 allowExtraKeys: true,
+            ),
+        ];
+
+        yield 'BrandInputWithDefaultValues' => [
+            BrandInputWithDefaultValues::class,
+            [],
+            new MapObject(
+                BrandInputWithDefaultValues::class,
+                [
+                    'name' => new MapDefaultValue(
+                        new MapString(),
+                        'ShipMonk',
+                    ),
+                    'foundedIn' => new MapDefaultValue(
+                        new MapNullable(new MapInt()),
+                        null,
+                    ),
+                    'founders' => new MapDefaultValue(
+                        new MapList(new MapString()),
+                        ['Jan Bednář'],
+                    ),
+                ],
             ),
         ];
 

--- a/tests/Compiler/Type/PhpDocTypeUtilsTest.php
+++ b/tests/Compiler/Type/PhpDocTypeUtilsTest.php
@@ -141,6 +141,33 @@ class PhpDocTypeUtilsTest extends InputMapperTestCase
         );
     }
 
+    #[DataProvider('provideFromValueData')]
+    public function testFromValue(mixed $value, string $expectedType): void
+    {
+        self::assertEquals(
+            $this->parseType($expectedType),
+            PhpDocTypeUtils::fromValue($value),
+        );
+    }
+
+    /**
+     * @return iterable<array{mixed, string}>
+     */
+    public static function provideFromValueData(): iterable
+    {
+        yield [null, 'null'];
+        yield [true, 'bool'];
+        yield [false, 'bool'];
+        yield [1, 'int'];
+        yield [1.1, 'float'];
+        yield ['abc', 'string'];
+        yield [[], 'array{}'];
+        yield [[1, 2, 'abc'], 'array{int, int, string}'];
+        yield [['key' => 'value'], 'array{key: string}'];
+        yield [['foo' => 'abc', 'bar' => null], 'array{foo: string, bar: null}'];
+        yield [new DateTimeImmutable(), DateTimeImmutable::class];
+    }
+
     /**
      * @param  list<GenericTypeParameter> $genericParameters
      */


### PR DESCRIPTION
Resolves #59.

Add alternative approach to dealing with undefined values, that does not require wrapping values with generic `Optional`. This makes it impossible to distinguish between undefined and default value (usually `null`), but is overall simpler to deal with.

```php
readonly class Semaphore
{
    public function __construct(
        #[Optional(default: SemaphoreColorEnum::Red)]
        public SemaphoreColorEnum $color,

        #[Optional]
        public ?string $manufacturer,
    ) {
    }
}
```