### PR TITLE
Avoid `new $mixed` in tests

### DIFF
--- a/tests/Compiler/Mapper/MapperCompilerTestCase.php
+++ b/tests/Compiler/Mapper/MapperCompilerTestCase.php
@@ -11,6 +11,7 @@ use ShipMonk\InputMapper\Runtime\MapperProvider;
 use ShipMonkTests\InputMapper\InputMapperTestCase;
 use function assert;
 use function class_exists;
+use function is_a;
 use function str_replace;
 use function strrpos;
 use function strtr;
@@ -59,10 +60,8 @@ abstract class MapperCompilerTestCase extends InputMapperTestCase
             },
         );
 
-        $mapper = new $mapperClassName($mapperProvider, $innerMappers);
-        assert($mapper instanceof Mapper);
-
-        return $mapper;
+        assert(is_a($mapperClassName, Mapper::class, true));
+        return new $mapperClassName($mapperProvider, $innerMappers);
     }
 
     private function toShortClassName(string $className): string


### PR DESCRIPTION
- Allows better Dead Code analysis: https://github.com/shipmonk-rnd/dead-code-detector/actions/runs/13896594883/job/38878520327?pr=170#step:5:56