### PR TITLE
fix ValidatedMapperCompiler running before UndefinedAwareMapperCompiler

### DIFF
--- a/src/Compiler/MapperFactory/DefaultMapperCompilerFactory.php
+++ b/src/Compiler/MapperFactory/DefaultMapperCompilerFactory.php
@@ -486,20 +486,20 @@ class DefaultMapperCompilerFactory implements MapperCompilerFactory
         $validatorInputType = $validatorCompiler->getInputType();
         $mapperOutputType = $mapperCompiler->getOutputType();
 
-        if (PhpDocTypeUtils::isSubTypeOf($mapperOutputType, $validatorInputType)) {
-            return new ValidatedMapperCompiler($mapperCompiler, [$validatorCompiler]);
-        }
-
         if ($mapperCompiler instanceof MapDefaultValue) {
             return new MapDefaultValue($this->addValidator($mapperCompiler->mapperCompiler, $validatorCompiler), $mapperCompiler->defaultValue);
+        }
+
+        if ($mapperCompiler instanceof MapOptional) {
+            return new MapOptional($this->addValidator($mapperCompiler->mapperCompiler, $validatorCompiler));
         }
 
         if ($mapperCompiler instanceof MapNullable) {
             return new MapNullable($this->addValidator($mapperCompiler->innerMapperCompiler, $validatorCompiler));
         }
 
-        if ($mapperCompiler instanceof MapOptional) {
-            return new MapOptional($this->addValidator($mapperCompiler->mapperCompiler, $validatorCompiler));
+        if (PhpDocTypeUtils::isSubTypeOf($mapperOutputType, $validatorInputType)) {
+            return new ValidatedMapperCompiler($mapperCompiler, [$validatorCompiler]);
         }
 
         throw CannotCreateMapperCompilerException::withIncompatibleValidator($validatorCompiler, $mapperCompiler);

--- a/tests/Compiler/MapperFactory/Data/BrandInputWithDefaultValues.php
+++ b/tests/Compiler/MapperFactory/Data/BrandInputWithDefaultValues.php
@@ -3,6 +3,8 @@
 namespace ShipMonkTests\InputMapper\Compiler\MapperFactory\Data;
 
 use ShipMonk\InputMapper\Compiler\Mapper\Optional;
+use ShipMonk\InputMapper\Compiler\Validator\Int\AssertInt32;
+use ShipMonk\InputMapper\Compiler\Validator\String\AssertStringLength;
 
 class BrandInputWithDefaultValues
 {
@@ -12,9 +14,11 @@ class BrandInputWithDefaultValues
      */
     public function __construct(
         #[Optional(default: 'ShipMonk')]
+        #[AssertStringLength(min: 5)]
         public readonly string $name,
 
         #[Optional]
+        #[AssertInt32]
         public readonly ?int $foundedIn,
 
         #[Optional(default: ['Jan Bednář'])]

--- a/tests/Compiler/MapperFactory/DefaultMapperCompilerFactoryTest.php
+++ b/tests/Compiler/MapperFactory/DefaultMapperCompilerFactoryTest.php
@@ -36,6 +36,7 @@ use ShipMonk\InputMapper\Compiler\Mapper\Wrapper\ValidatedMapperCompiler;
 use ShipMonk\InputMapper\Compiler\MapperFactory\DefaultMapperCompilerFactory;
 use ShipMonk\InputMapper\Compiler\Type\GenericTypeParameter;
 use ShipMonk\InputMapper\Compiler\Validator\Array\AssertListLength;
+use ShipMonk\InputMapper\Compiler\Validator\Int\AssertInt32;
 use ShipMonk\InputMapper\Compiler\Validator\Int\AssertIntRange;
 use ShipMonk\InputMapper\Compiler\Validator\Int\AssertNegativeInt;
 use ShipMonk\InputMapper\Compiler\Validator\Int\AssertNonNegativeInt;
@@ -151,11 +152,17 @@ class DefaultMapperCompilerFactoryTest extends InputMapperTestCase
                 BrandInputWithDefaultValues::class,
                 [
                     'name' => new MapDefaultValue(
-                        new MapString(),
+                        new ValidatedMapperCompiler(
+                            new MapString(),
+                            [new AssertStringLength(min: 5)],
+                        ),
                         'ShipMonk',
                     ),
                     'foundedIn' => new MapDefaultValue(
-                        new MapNullable(new MapInt()),
+                        new MapNullable(new ValidatedMapperCompiler(
+                            new MapInt(),
+                            [new AssertInt32()],
+                        )),
                         null,
                     ),
                     'founders' => new MapDefaultValue(


### PR DESCRIPTION
Resolves this not working correctly:

~~~php
#[Optional(default: 1)]
#[AssertIntRange(gte: 1)]
public int $page,
~~~

because the validation was done before the undefined handling.