### PR TITLE
Add support for non-empty-string PHPDoc type

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ composer require shipmonk/input-mapper
 Input Mapper comes with built-in mappers for the following types:
 
 * `array`, `bool`, `float`, `int`, `mixed`, `string`, `list`
-* `positive-int`, `negative-int`, `int<TMin, TMax>`, `non-empty-list`
+* `positive-int`, `negative-int`, `int<TMin, TMax>`, `non-empty-string`, `non-empty-list`
 * `array<V>`, `array<K, V>`, `list<V>`, `non-empty-list<V>`
 * `array{K1: V1, ...}`
 * `?T`, `Optional<T>`

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -48,6 +48,10 @@ parameters:
             message: "#^Method ShipMonk\\\\InputMapperTests\\\\Compiler\\\\Validator\\\\Array\\\\Data\\\\ListItemValidatorWithMultipleValidatorsMapper\\:\\:map\\(\\) should return list\\<int\\<1, max\\>\\> but returns list\\<int\\>\\.$#"
             count: 1
             path: tests/Compiler/Validator/Array/Data/ListItemValidatorWithMultipleValidatorsMapper.php
+        -
+            message: "#^Method ShipMonk\\\\InputMapperTests\\\\Compiler\\\\Validator\\\\String\\\\Data\\\\StringNonEmptyValidatorMapper\\:\\:map\\(\\) should return non\\-empty\\-string but returns string\\.$#"
+            count: 1
+            path: tests/Compiler/Validator/String/Data/StringNonEmptyValidatorMapper.php
 
         -
             identifier: method.internalClass

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -49,11 +49,6 @@ parameters:
             count: 1
             path: tests/Compiler/Validator/Array/Data/ListItemValidatorWithMultipleValidatorsMapper.php
         -
-            message: "#^Method ShipMonk\\\\InputMapperTests\\\\Compiler\\\\Validator\\\\String\\\\Data\\\\StringNonEmptyValidatorMapper\\:\\:map\\(\\) should return non\\-empty\\-string but returns string\\.$#"
-            count: 1
-            path: tests/Compiler/Validator/String/Data/StringNonEmptyValidatorMapper.php
-
-        -
             identifier: method.internalClass
             path: tests/*
 

--- a/src/Compiler/MapperFactory/DefaultMapperCompilerFactory.php
+++ b/src/Compiler/MapperFactory/DefaultMapperCompilerFactory.php
@@ -61,6 +61,7 @@ use ShipMonk\InputMapper\Compiler\Validator\Int\AssertNegativeInt;
 use ShipMonk\InputMapper\Compiler\Validator\Int\AssertNonNegativeInt;
 use ShipMonk\InputMapper\Compiler\Validator\Int\AssertNonPositiveInt;
 use ShipMonk\InputMapper\Compiler\Validator\Int\AssertPositiveInt;
+use ShipMonk\InputMapper\Compiler\Validator\String\AssertStringNonEmpty;
 use ShipMonk\InputMapper\Compiler\Validator\ValidatorCompiler;
 use ShipMonk\InputMapper\Runtime\Optional;
 use function array_column;
@@ -147,6 +148,7 @@ class DefaultMapperCompilerFactory implements MapperCompilerFactory
                 default => match ($type->name) {
                     'list' => new MapList(new MapMixed()),
                     'non-empty-list' => new ValidatedMapperCompiler(new MapList(new MapMixed()), [new AssertListLength(min: 1)]),
+                    'non-empty-string' => new ValidatedMapperCompiler($this->createInner(new IdentifierTypeNode('string'), $options), [new AssertStringNonEmpty()]),
                     'negative-int' => new ValidatedMapperCompiler($this->createInner(new IdentifierTypeNode('int'), $options), [new AssertNegativeInt()]),
                     'non-negative-int' => new ValidatedMapperCompiler($this->createInner(new IdentifierTypeNode('int'), $options), [new AssertNonNegativeInt()]),
                     'non-positive-int' => new ValidatedMapperCompiler($this->createInner(new IdentifierTypeNode('int'), $options), [new AssertNonPositiveInt()]),

--- a/src/Compiler/Type/PhpDocTypeUtils.php
+++ b/src/Compiler/Type/PhpDocTypeUtils.php
@@ -227,6 +227,7 @@ class PhpDocTypeUtils
             return match ($type->name) {
                 'list',
                 'non-empty-list' => new Identifier('array'),
+                'non-empty-string' => new Identifier('string'),
                 'positive-int',
                 'negative-int',
                 'non-positive-int',
@@ -566,7 +567,7 @@ class PhpDocTypeUtils
                 'resource' => $a instanceof IdentifierTypeNode && $a->name === 'resource',
 
                 'string' => match (true) {
-                    $a instanceof IdentifierTypeNode => $a->name === 'string',
+                    $a instanceof IdentifierTypeNode => $a->name === 'string' || $a->name === 'non-empty-string',
                     $a instanceof ConstTypeNode => match (true) {
                         $a->constExpr instanceof ConstExprStringNode => true,
                         $a->constExpr instanceof ConstFetchNode => is_string(constant((string) $a->constExpr)),

--- a/src/Compiler/Validator/String/AssertStringNonEmpty.php
+++ b/src/Compiler/Validator/String/AssertStringNonEmpty.php
@@ -3,9 +3,13 @@
 namespace ShipMonk\InputMapper\Compiler\Validator\String;
 
 use Attribute;
+use PhpParser\Node\Expr;
+use PhpParser\Node\Stmt;
 use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
 use PHPStan\PhpDocParser\Ast\Type\TypeNode;
+use ShipMonk\InputMapper\Compiler\Php\PhpCodeBuilder;
 use ShipMonk\InputMapper\Compiler\Validator\NarrowingValidatorCompiler;
+use ShipMonk\InputMapper\Runtime\Exception\MappingFailedException;
 
 #[Attribute(Attribute::TARGET_PARAMETER | Attribute::TARGET_PROPERTY)]
 class AssertStringNonEmpty extends AssertStringMatches implements NarrowingValidatorCompiler
@@ -17,6 +21,33 @@ class AssertStringNonEmpty extends AssertStringMatches implements NarrowingValid
             pattern: '#\S#',
             expectedDescription: 'non-empty string',
         );
+    }
+
+    /**
+     * @return list<Stmt>
+     */
+    public function compile(
+        Expr $value,
+        TypeNode $type,
+        Expr $path,
+        PhpCodeBuilder $builder,
+    ): array
+    {
+        $isEmpty = $builder->same($value, $builder->val(''));
+        $matchCount = $builder->funcCall($builder->importFunction('preg_match'), [$builder->val($this->pattern), $value]);
+        $noMatch = $builder->notSame($matchCount, $builder->val(1));
+
+        return [
+            $builder->if($builder->or($isEmpty, $noMatch), [
+                $builder->throw(
+                    $builder->staticCall(
+                        $builder->importClass(MappingFailedException::class),
+                        'incorrectValue',
+                        [$value, $path, $builder->val('non-empty string')],
+                    ),
+                ),
+            ]),
+        ];
     }
 
     public function getNarrowedInputType(): TypeNode

--- a/src/Compiler/Validator/String/AssertStringNonEmpty.php
+++ b/src/Compiler/Validator/String/AssertStringNonEmpty.php
@@ -3,9 +3,12 @@
 namespace ShipMonk\InputMapper\Compiler\Validator\String;
 
 use Attribute;
+use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
+use PHPStan\PhpDocParser\Ast\Type\TypeNode;
+use ShipMonk\InputMapper\Compiler\Validator\NarrowingValidatorCompiler;
 
 #[Attribute(Attribute::TARGET_PARAMETER | Attribute::TARGET_PROPERTY)]
-class AssertStringNonEmpty extends AssertStringMatches
+class AssertStringNonEmpty extends AssertStringMatches implements NarrowingValidatorCompiler
 {
 
     public function __construct()
@@ -14,6 +17,11 @@ class AssertStringNonEmpty extends AssertStringMatches
             pattern: '#\S#',
             expectedDescription: 'non-empty string',
         );
+    }
+
+    public function getNarrowedInputType(): TypeNode
+    {
+        return new IdentifierTypeNode('non-empty-string');
     }
 
 }

--- a/tests/Compiler/MapperFactory/DefaultMapperCompilerFactoryTest.php
+++ b/tests/Compiler/MapperFactory/DefaultMapperCompilerFactoryTest.php
@@ -43,6 +43,7 @@ use ShipMonk\InputMapper\Compiler\Validator\Int\AssertNonNegativeInt;
 use ShipMonk\InputMapper\Compiler\Validator\Int\AssertNonPositiveInt;
 use ShipMonk\InputMapper\Compiler\Validator\Int\AssertPositiveInt;
 use ShipMonk\InputMapper\Compiler\Validator\String\AssertStringLength;
+use ShipMonk\InputMapper\Compiler\Validator\String\AssertStringNonEmpty;
 use ShipMonk\InputMapper\Compiler\Validator\String\AssertUrl;
 use ShipMonk\InputMapperTests\Compiler\MapperFactory\Data\AnimalCatInput;
 use ShipMonk\InputMapperTests\Compiler\MapperFactory\Data\AnimalDogInput;
@@ -386,6 +387,14 @@ class DefaultMapperCompilerFactoryTest extends InputMapperTestCase
             [],
             new ValidatedMapperCompiler(new MapList(new MapInt()), [
                 new AssertListLength(min: 1),
+            ]),
+        ];
+
+        yield 'non-empty-string' => [
+            'non-empty-string',
+            [],
+            new ValidatedMapperCompiler(new MapString(), [
+                new AssertStringNonEmpty(),
             ]),
         ];
 

--- a/tests/Compiler/Type/PhpDocTypeUtilsTest.php
+++ b/tests/Compiler/Type/PhpDocTypeUtilsTest.php
@@ -1320,6 +1320,7 @@ class PhpDocTypeUtilsTest extends InputMapperTestCase
         yield 'string' => [
             'true' => [
                 'string',
+                'non-empty-string',
                 '"abc"',
                 'DateTimeImmutable::RFC3339',
             ],

--- a/tests/Compiler/Validator/String/Data/StringNonEmptyValidatorMapper.php
+++ b/tests/Compiler/Validator/String/Data/StringNonEmptyValidatorMapper.php
@@ -31,7 +31,7 @@ class StringNonEmptyValidatorMapper implements Mapper
             throw MappingFailedException::incorrectType($data, $path, 'string');
         }
 
-        if (preg_match('#\\S#', $data) !== 1) {
+        if ($data === '' || preg_match('#\\S#', $data) !== 1) {
             throw MappingFailedException::incorrectValue($data, $path, 'non-empty string');
         }
 

--- a/tests/Compiler/Validator/String/Data/StringNonEmptyValidatorMapper.php
+++ b/tests/Compiler/Validator/String/Data/StringNonEmptyValidatorMapper.php
@@ -12,7 +12,7 @@ use function preg_match;
 /**
  * Generated mapper by {@see ValidatedMapperCompiler}. Do not edit directly.
  *
- * @implements Mapper<string>
+ * @implements Mapper<non-empty-string>
  */
 class StringNonEmptyValidatorMapper implements Mapper
 {
@@ -22,6 +22,7 @@ class StringNonEmptyValidatorMapper implements Mapper
 
     /**
      * @param  list<string|int> $path
+     * @return non-empty-string
      * @throws MappingFailedException
      */
     public function map(mixed $data, array $path = []): string


### PR DESCRIPTION
## Summary
- Adds `non-empty-string` as a built-in mapped PHPDoc type, using the existing `AssertStringNonEmpty` validator
- Makes `AssertStringNonEmpty` implement `NarrowingValidatorCompiler` so the output type is properly narrowed to `non-empty-string`
- Registers `non-empty-string` as a subtype of `string` in `PhpDocTypeUtils::isSubTypeOf()` and maps it to native `string` in `toNativeType()`

Co-Authored-By: Claude Code