### PR TITLE
Fix PHPDoc annotation group ordering

### DIFF
--- a/src/Runtime/CallbackMapper.php
+++ b/src/Runtime/CallbackMapper.php
@@ -6,9 +6,8 @@ use Closure;
 use ShipMonk\InputMapper\Runtime\Exception\MappingFailedException;
 
 /**
- * @implements Mapper<T>
- *
  * @template-covariant T
+ * @implements Mapper<T>
  */
 class CallbackMapper implements Mapper
 {

--- a/src/Runtime/OptionalSome.php
+++ b/src/Runtime/OptionalSome.php
@@ -3,9 +3,8 @@
 namespace ShipMonk\InputMapper\Runtime;
 
 /**
- * @extends Optional<T>
- *
  * @template-covariant T
+ * @extends Optional<T>
  */
 final class OptionalSome extends Optional
 {


### PR DESCRIPTION
## Summary
- Fix `@template-covariant` being in a separate annotation group from `@implements`/`@extends` in `CallbackMapper` and `OptionalSome`

Co-Authored-By: Claude Code