### PR TITLE
Add coverage-guard with tests to meet coverage threshold

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /.idea
 /phpstan.neon
 /composer.lock
+/coverage.xml

--- a/composer.json
+++ b/composer.json
@@ -48,7 +48,6 @@
             "@check:ec",
             "@check:cs",
             "@check:types",
-            "@check:tests",
             "@check:coverage",
             "@check:dependencies"
         ],

--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,7 @@
         "phpunit/phpunit": "^10.5.63",
         "shipmonk/coding-standard": "^0.2.1",
         "shipmonk/composer-dependency-analyser": "^1.8.4",
+        "shipmonk/coverage-guard": "^1.0",
         "shipmonk/dead-code-detector": "^0.15.0",
         "shipmonk/name-collision-detector": "^2.1.1",
         "shipmonk/phpstan-rules": "^4.3.5"
@@ -48,9 +49,14 @@
             "@check:cs",
             "@check:types",
             "@check:tests",
+            "@check:coverage",
             "@check:dependencies"
         ],
         "check:composer": "composer normalize --dry-run --no-check-lock --no-update-lock",
+        "check:coverage": [
+            "XDEBUG_MODE=coverage phpunit tests --coverage-clover=coverage.xml",
+            "coverage-guard check coverage.xml --config coverage-guard.php"
+        ],
         "check:cs": "phpcs",
         "check:dependencies": "composer-dependency-analyser",
         "check:ec": "ec src tests",

--- a/coverage-guard.php
+++ b/coverage-guard.php
@@ -5,7 +5,7 @@ use ShipMonk\CoverageGuard\Rule\EnforceCoverageForMethodsRule;
 
 $config = new Config();
 $config->addRule(new EnforceCoverageForMethodsRule(
-    requiredCoveragePercentage: 50,
+    requiredCoveragePercentage: 70,
     minExecutableLines: 5,
 ));
 

--- a/coverage-guard.php
+++ b/coverage-guard.php
@@ -1,0 +1,12 @@
+<?php
+
+use ShipMonk\CoverageGuard\Config;
+use ShipMonk\CoverageGuard\Rule\EnforceCoverageForMethodsRule;
+
+$config = new Config();
+$config->addRule(new EnforceCoverageForMethodsRule(
+    requiredCoveragePercentage: 50,
+    minExecutableLines: 5,
+));
+
+return $config;

--- a/tests/Compiler/Attribute/MapChainTest.php
+++ b/tests/Compiler/Attribute/MapChainTest.php
@@ -1,0 +1,45 @@
+<?php declare(strict_types = 1);
+
+namespace ShipMonk\InputMapperTests\Compiler\Attribute;
+
+use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
+use ShipMonk\InputMapper\Compiler\Attribute\MapChain;
+use ShipMonk\InputMapper\Compiler\Attribute\MapInt;
+use ShipMonk\InputMapper\Compiler\Attribute\MapString;
+use ShipMonk\InputMapper\Compiler\Mapper\Input\ChainMapperCompiler;
+use ShipMonk\InputMapper\Compiler\Mapper\Input\IntInputMapperCompiler;
+use ShipMonk\InputMapper\Compiler\Mapper\Input\StringInputMapperCompiler;
+use ShipMonk\InputMapper\Compiler\Mapper\PassthroughMapperCompiler;
+use ShipMonk\InputMapperTests\InputMapperTestCase;
+
+class MapChainTest extends InputMapperTestCase
+{
+
+    public function testGetInputMapperCompiler(): void
+    {
+        $mapChain = new MapChain([new MapString(), new MapInt()]);
+
+        $result = $mapChain->getInputMapperCompiler();
+
+        self::assertEquals(
+            new ChainMapperCompiler([new StringInputMapperCompiler(), new IntInputMapperCompiler()]),
+            $result,
+        );
+    }
+
+    public function testGetOutputMapperCompiler(): void
+    {
+        $mapChain = new MapChain([new MapString(), new MapInt()]);
+
+        $result = $mapChain->getOutputMapperCompiler();
+
+        self::assertEquals(
+            new ChainMapperCompiler([
+                new PassthroughMapperCompiler(new IdentifierTypeNode('int')),
+                new PassthroughMapperCompiler(new IdentifierTypeNode('string')),
+            ]),
+            $result,
+        );
+    }
+
+}

--- a/tests/Compiler/Mapper/Array/ArrayShapeOutputMapperCompilerTest.php
+++ b/tests/Compiler/Mapper/Array/ArrayShapeOutputMapperCompilerTest.php
@@ -5,6 +5,7 @@ namespace ShipMonk\InputMapperTests\Compiler\Mapper\Array;
 use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
 use ShipMonk\InputMapper\Compiler\Mapper\Output\ArrayShapeOutputMapperCompiler;
 use ShipMonk\InputMapper\Compiler\Mapper\Output\EnumOutputMapperCompiler;
+use ShipMonk\InputMapper\Compiler\Mapper\Output\ListOutputMapperCompiler;
 use ShipMonk\InputMapper\Compiler\Mapper\PassthroughMapperCompiler;
 use ShipMonk\InputMapperTests\Compiler\Mapper\MapperCompilerTestCase;
 use ShipMonk\InputMapperTests\Compiler\Mapper\Object\Data\SuitEnum;
@@ -66,6 +67,22 @@ class ArrayShapeOutputMapperCompilerTest extends MapperCompilerTestCase
         $mapper = $this->compileOutputMapper('ArrayShapeWithInlinedExpression', $mapperCompiler);
 
         self::assertSame(['name' => 'test', 'suit' => 'H'], $mapper->map(['name' => 'test', 'suit' => SuitEnum::Hearts]));
+    }
+
+    public function testCompileWithItemMapperThatHasStatements(): void
+    {
+        $items = [
+            ['key' => 'name', 'mapper' => new PassthroughMapperCompiler(new IdentifierTypeNode('string')), 'optional' => false],
+            ['key' => 'suits', 'mapper' => new ListOutputMapperCompiler(new EnumOutputMapperCompiler(SuitEnum::class)), 'optional' => false],
+        ];
+
+        $mapperCompiler = new ArrayShapeOutputMapperCompiler($items, sealed: true);
+        $mapper = $this->compileOutputMapper('ArrayShapeWithStatements', $mapperCompiler);
+
+        self::assertSame(
+            ['name' => 'test', 'suits' => ['H', 'D']],
+            $mapper->map(['name' => 'test', 'suits' => [SuitEnum::Hearts, SuitEnum::Diamonds]]),
+        );
     }
 
 }

--- a/tests/Compiler/Mapper/Array/Data/ArrayShapeWithStatementsOutputMapper.php
+++ b/tests/Compiler/Mapper/Array/Data/ArrayShapeWithStatementsOutputMapper.php
@@ -1,0 +1,49 @@
+<?php declare (strict_types=1);
+
+namespace ShipMonk\InputMapperTests\Compiler\Mapper\Array\Data;
+
+use ShipMonk\InputMapperTests\Compiler\Mapper\Object\Data\SuitEnum;
+use ShipMonk\InputMapper\Compiler\Mapper\Output\ArrayShapeOutputMapperCompiler;
+use ShipMonk\InputMapper\Runtime\Exception\MappingFailedException;
+use ShipMonk\InputMapper\Runtime\Mapper;
+use ShipMonk\InputMapper\Runtime\MapperProvider;
+
+/**
+ * Generated mapper by {@see ArrayShapeOutputMapperCompiler}. Do not edit directly.
+ *
+ * @implements Mapper<array{name: string, suits: list<SuitEnum>}, mixed>
+ */
+class ArrayShapeWithStatementsOutputMapper implements Mapper
+{
+    public function __construct(private readonly MapperProvider $provider)
+    {
+    }
+
+    /**
+     * @param  array{name: string, suits: list<SuitEnum>} $data
+     * @param  list<string|int> $path
+     * @return array{name: string, suits: list<string>}
+     * @throws MappingFailedException
+     */
+    public function map(mixed $data, array $path = []): mixed
+    {
+        return ['name' => $data['name'], 'suits' => $this->mapSuits($data['suits'], [...$path, 'suits'])];
+    }
+
+    /**
+     * @param  list<SuitEnum> $data
+     * @param  list<string|int> $path
+     * @return list<string>
+     * @throws MappingFailedException
+     */
+    private function mapSuits(mixed $data, array $path = []): mixed
+    {
+        $mapped = [];
+
+        foreach ($data as $index => $item) {
+            $mapped[] = $item->value;
+        }
+
+        return $mapped;
+    }
+}

--- a/tests/Compiler/Mapper/Object/DiscriminatedObjectOutputMapperCompilerTest.php
+++ b/tests/Compiler/Mapper/Object/DiscriminatedObjectOutputMapperCompilerTest.php
@@ -2,12 +2,14 @@
 
 namespace ShipMonk\InputMapperTests\Compiler\Mapper\Object;
 
+use PHPStan\PhpDocParser\Ast\Type\GenericTypeNode;
 use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
 use ShipMonk\InputMapper\Compiler\Mapper\Output\DelegateOutputMapperCompiler;
 use ShipMonk\InputMapper\Compiler\Mapper\Output\DiscriminatedObjectOutputMapperCompiler;
 use ShipMonk\InputMapper\Compiler\Mapper\Output\ObjectOutputMapperCompiler;
 use ShipMonk\InputMapper\Compiler\Mapper\Output\OptionalOutputMapperCompiler;
 use ShipMonk\InputMapper\Compiler\Mapper\PassthroughMapperCompiler;
+use ShipMonk\InputMapper\Compiler\Type\GenericTypeParameter;
 use ShipMonk\InputMapper\Runtime\Exception\MappingFailedException;
 use ShipMonk\InputMapper\Runtime\Optional;
 use ShipMonk\InputMapperTests\Compiler\Mapper\MapperCompilerTestCase;
@@ -74,6 +76,27 @@ class DiscriminatedObjectOutputMapperCompilerTest extends MapperCompilerTestCase
         self::assertSame(
             ['id' => 2, 'name' => 'Bob', 'type' => 'childTwo', 'childTwoField' => 42],
             $mapper->map($childTwo),
+        );
+    }
+
+    public function testGetInputTypeWithGenericParameters(): void
+    {
+        $mapperCompiler = new DiscriminatedObjectOutputMapperCompiler(
+            HierarchicalParentInput::class,
+            [
+                'childOne' => new DelegateOutputMapperCompiler(HierarchicalChildOneInput::class),
+            ],
+            genericParameters: [
+                new GenericTypeParameter('T'),
+            ],
+        );
+
+        self::assertEquals(
+            new GenericTypeNode(
+                new IdentifierTypeNode(HierarchicalParentInput::class),
+                [new IdentifierTypeNode('T')],
+            ),
+            $mapperCompiler->getInputType(),
         );
     }
 

--- a/tests/Compiler/Mapper/Object/MapDiscriminatedObjectTest.php
+++ b/tests/Compiler/Mapper/Object/MapDiscriminatedObjectTest.php
@@ -2,6 +2,8 @@
 
 namespace ShipMonk\InputMapperTests\Compiler\Mapper\Object;
 
+use PHPStan\PhpDocParser\Ast\Type\GenericTypeNode;
+use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
 use ShipMonk\InputMapper\Compiler\Exception\CannotCompileMapperException;
 use ShipMonk\InputMapper\Compiler\Mapper\Input\DelegateInputMapperCompiler;
 use ShipMonk\InputMapper\Compiler\Mapper\Input\DiscriminatedObjectInputMapperCompiler;
@@ -11,6 +13,7 @@ use ShipMonk\InputMapper\Compiler\Mapper\Input\ObjectInputMapperCompiler;
 use ShipMonk\InputMapper\Compiler\Mapper\Input\OptionalInputMapperCompiler;
 use ShipMonk\InputMapper\Compiler\Mapper\Input\StringInputMapperCompiler;
 use ShipMonk\InputMapper\Compiler\Mapper\MapperCompiler;
+use ShipMonk\InputMapper\Compiler\Type\GenericTypeParameter;
 use ShipMonk\InputMapper\Runtime\Exception\MappingFailedException;
 use ShipMonk\InputMapper\Runtime\Mapper;
 use ShipMonk\InputMapper\Runtime\Optional;
@@ -171,6 +174,28 @@ class MapDiscriminatedObjectTest extends MapperCompilerTestCase
             MappingFailedException::class,
             'Failed to map data at path /$type: Expected one of childOne, got "c"',
             static fn () => $parentInputMapper->map([...$childOneInputArray, '$type' => 'c']),
+        );
+    }
+
+    public function testGetOutputTypeWithGenericParameters(): void
+    {
+        $mapperCompiler = new DiscriminatedObjectInputMapperCompiler(
+            HierarchicalParentInput::class,
+            'type',
+            [
+                'childOne' => new DelegateInputMapperCompiler(HierarchicalChildOneInput::class),
+            ],
+            genericParameters: [
+                new GenericTypeParameter('T'),
+            ],
+        );
+
+        self::assertEquals(
+            new GenericTypeNode(
+                new IdentifierTypeNode(HierarchicalParentInput::class),
+                [new IdentifierTypeNode('T')],
+            ),
+            $mapperCompiler->getOutputType(),
         );
     }
 

--- a/tests/Compiler/Mapper/Wrapper/Data/NullableEnumListOutputMapper.php
+++ b/tests/Compiler/Mapper/Wrapper/Data/NullableEnumListOutputMapper.php
@@ -1,0 +1,44 @@
+<?php declare (strict_types=1);
+
+namespace ShipMonk\InputMapperTests\Compiler\Mapper\Wrapper\Data;
+
+use ShipMonk\InputMapperTests\Compiler\Mapper\Object\Data\SuitEnum;
+use ShipMonk\InputMapper\Compiler\Mapper\Output\NullableOutputMapperCompiler;
+use ShipMonk\InputMapper\Runtime\Exception\MappingFailedException;
+use ShipMonk\InputMapper\Runtime\Mapper;
+use ShipMonk\InputMapper\Runtime\MapperProvider;
+
+/**
+ * Generated mapper by {@see NullableOutputMapperCompiler}. Do not edit directly.
+ *
+ * @implements Mapper<?list<SuitEnum>, mixed>
+ */
+class NullableEnumListOutputMapper implements Mapper
+{
+    public function __construct(private readonly MapperProvider $provider)
+    {
+    }
+
+    /**
+     * @param  ?list<SuitEnum> $data
+     * @param  list<string|int> $path
+     * @return ?list<string>
+     * @throws MappingFailedException
+     */
+    public function map(mixed $data, array $path = []): mixed
+    {
+        if ($data === null) {
+            $mapped2 = null;
+        } else {
+            $mapped = [];
+
+            foreach ($data as $index => $item) {
+                $mapped[] = $item->value;
+            }
+
+            $mapped2 = $mapped;
+        }
+
+        return $mapped2;
+    }
+}

--- a/tests/Compiler/Mapper/Wrapper/NullableOutputMapperCompilerTest.php
+++ b/tests/Compiler/Mapper/Wrapper/NullableOutputMapperCompilerTest.php
@@ -4,6 +4,7 @@ namespace ShipMonk\InputMapperTests\Compiler\Mapper\Wrapper;
 
 use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
 use ShipMonk\InputMapper\Compiler\Mapper\Output\EnumOutputMapperCompiler;
+use ShipMonk\InputMapper\Compiler\Mapper\Output\ListOutputMapperCompiler;
 use ShipMonk\InputMapper\Compiler\Mapper\Output\NullableOutputMapperCompiler;
 use ShipMonk\InputMapper\Compiler\Mapper\PassthroughMapperCompiler;
 use ShipMonk\InputMapperTests\Compiler\Mapper\MapperCompilerTestCase;
@@ -40,6 +41,18 @@ class NullableOutputMapperCompilerTest extends MapperCompilerTestCase
         self::assertNull($mapper->map(null));
         self::assertSame('H', $mapper->map(SuitEnum::Hearts));
         self::assertSame('S', $mapper->map(SuitEnum::Spades));
+    }
+
+    public function testCompileWithInnerMapperThatHasStatements(): void
+    {
+        $mapperCompiler = new NullableOutputMapperCompiler(
+            new ListOutputMapperCompiler(new EnumOutputMapperCompiler(SuitEnum::class)),
+        );
+        $mapper = $this->compileOutputMapper('NullableEnumList', $mapperCompiler);
+
+        self::assertNull($mapper->map(null));
+        self::assertSame(['H', 'D'], $mapper->map([SuitEnum::Hearts, SuitEnum::Diamonds]));
+        self::assertSame([], $mapper->map([]));
     }
 
 }

--- a/tests/Compiler/MapperFactory/Data/InputWithIncompatibleDefaultValue.php
+++ b/tests/Compiler/MapperFactory/Data/InputWithIncompatibleDefaultValue.php
@@ -1,0 +1,17 @@
+<?php declare(strict_types = 1);
+
+namespace ShipMonk\InputMapperTests\Compiler\MapperFactory\Data;
+
+use ShipMonk\InputMapper\Compiler\Attribute\Optional;
+
+class InputWithIncompatibleDefaultValue
+{
+
+    public function __construct(
+        #[Optional(default: 'not_an_int')]
+        public readonly int $value,
+    )
+    {
+    }
+
+}

--- a/tests/Compiler/MapperFactory/Data/InputWithIncompatibleValidator.php
+++ b/tests/Compiler/MapperFactory/Data/InputWithIncompatibleValidator.php
@@ -1,0 +1,17 @@
+<?php declare(strict_types = 1);
+
+namespace ShipMonk\InputMapperTests\Compiler\MapperFactory\Data;
+
+use ShipMonk\InputMapper\Compiler\Validator\Int\AssertPositiveInt;
+
+class InputWithIncompatibleValidator
+{
+
+    public function __construct(
+        #[AssertPositiveInt]
+        public readonly string $value,
+    )
+    {
+    }
+
+}

--- a/tests/Compiler/MapperFactory/DefaultMapperCompilerFactoryTest.php
+++ b/tests/Compiler/MapperFactory/DefaultMapperCompilerFactoryTest.php
@@ -76,7 +76,9 @@ use ShipMonk\InputMapperTests\Compiler\MapperFactory\Data\EnumFilterInput;
 use ShipMonk\InputMapperTests\Compiler\MapperFactory\Data\EqualsFilterInput;
 use ShipMonk\InputMapperTests\Compiler\MapperFactory\Data\InFilterInput;
 use ShipMonk\InputMapperTests\Compiler\MapperFactory\Data\InputWithDate;
+use ShipMonk\InputMapperTests\Compiler\MapperFactory\Data\InputWithIncompatibleDefaultValue;
 use ShipMonk\InputMapperTests\Compiler\MapperFactory\Data\InputWithIncompatibleMapperCompiler;
+use ShipMonk\InputMapperTests\Compiler\MapperFactory\Data\InputWithIncompatibleValidator;
 use ShipMonk\InputMapperTests\Compiler\MapperFactory\Data\InputWithoutConstructor;
 use ShipMonk\InputMapperTests\Compiler\MapperFactory\Data\InputWithPrivateConstructor;
 use ShipMonk\InputMapperTests\Compiler\MapperFactory\Data\InputWithRenamedSourceKey;
@@ -712,6 +714,18 @@ class DefaultMapperCompilerFactoryTest extends InputMapperTestCase
             EnumFilterInput::class . '<int>',
             [],
             'Cannot create mapper for type ShipMonk\\InputMapperTests\\Compiler\\MapperFactory\\Data\\EnumFilterInput<int>, because type int is not a subtype of BackedEnum',
+        ];
+
+        yield 'InputWithIncompatibleDefaultValue' => [
+            InputWithIncompatibleDefaultValue::class,
+            [],
+            "Cannot use mapper %s for parameter \$value of method %s::__construct, because default value of type 'string' is not compatible with parameter type 'int'",
+        ];
+
+        yield 'InputWithIncompatibleValidator' => [
+            InputWithIncompatibleValidator::class,
+            [],
+            'Cannot create mapper with validator %s, because mapper output type %s is not compatible with validator input type %s',
         ];
     }
 

--- a/tests/Compiler/Type/NativeTypeUtilsTest.php
+++ b/tests/Compiler/Type/NativeTypeUtilsTest.php
@@ -1,0 +1,140 @@
+<?php declare(strict_types = 1);
+
+namespace ShipMonk\InputMapperTests\Compiler\Type;
+
+use ArrayObject;
+use Countable;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\IntersectionType;
+use PhpParser\Node\Name;
+use PHPUnit\Framework\Attributes\DataProvider;
+use ShipMonk\InputMapper\Compiler\Type\NativeTypeUtils;
+use ShipMonk\InputMapperTests\InputMapperTestCase;
+use Traversable;
+
+class NativeTypeUtilsTest extends InputMapperTestCase
+{
+
+    #[DataProvider('provideIsSubTypeOfData')]
+    public function testIsSubTypeOf(
+        Identifier|Name $a,
+        Identifier|Name $b,
+        bool $expected,
+    ): void
+    {
+        self::assertSame($expected, NativeTypeUtils::isSubTypeOf($a, $b));
+    }
+
+    /**
+     * @return iterable<string, array{Identifier|Name, Identifier|Name, bool}>
+     */
+    public static function provideIsSubTypeOfData(): iterable
+    {
+        yield 'same identifiers' => [
+            new Identifier('int'),
+            new Identifier('int'),
+            true,
+        ];
+
+        yield 'case insensitive identifiers' => [
+            new Identifier('Int'),
+            new Identifier('int'),
+            true,
+        ];
+
+        yield 'different identifiers' => [
+            new Identifier('int'),
+            new Identifier('string'),
+            false,
+        ];
+
+        yield 'same names' => [
+            new Name(Countable::class),
+            new Name(Countable::class),
+            true,
+        ];
+
+        yield 'name is subtype via inheritance' => [
+            new Name(ArrayObject::class),
+            new Name(Countable::class),
+            true,
+        ];
+
+        yield 'name is not subtype' => [
+            new Name(Countable::class),
+            new Name(Traversable::class),
+            false,
+        ];
+
+        yield 'identifier vs name' => [
+            new Identifier('int'),
+            new Name(Countable::class),
+            false,
+        ];
+
+        yield 'name vs identifier' => [
+            new Name(Countable::class),
+            new Identifier('int'),
+            false,
+        ];
+    }
+
+    /**
+     * @param list<Identifier|Name|IntersectionType> $members
+     */
+    #[DataProvider('provideCreateIntersectionData')]
+    public function testCreateIntersection(
+        array $members,
+        Identifier|Name|IntersectionType $expected,
+    ): void
+    {
+        self::assertEquals($expected, NativeTypeUtils::createIntersection(...$members));
+    }
+
+    /**
+     * @return iterable<string, array{list<Identifier|Name|IntersectionType>, Identifier|Name|IntersectionType}>
+     */
+    public static function provideCreateIntersectionData(): iterable
+    {
+        yield 'empty returns mixed' => [
+            [],
+            new Identifier('mixed'),
+        ];
+
+        yield 'single identifier' => [
+            [new Identifier('int')],
+            new Identifier('int'),
+        ];
+
+        yield 'single name' => [
+            [new Name(Countable::class)],
+            new Name(Countable::class),
+        ];
+
+        yield 'two different names' => [
+            [new Name(Countable::class), new Name(Traversable::class)],
+            new IntersectionType([new Name(Countable::class), new Name(Traversable::class)]),
+        ];
+
+        yield 'duplicate identifiers are deduplicated' => [
+            [new Identifier('int'), new Identifier('int')],
+            new Identifier('int'),
+        ];
+
+        yield 'flattens nested intersection' => [
+            [new IntersectionType([new Name(Countable::class), new Name(Traversable::class)])],
+            new IntersectionType([new Name(Countable::class), new Name(Traversable::class)]),
+        ];
+
+        yield 'subtype eliminated: ArrayObject is subtype of Countable' => [
+            [new Name(ArrayObject::class), new Name(Countable::class)],
+            new Name(ArrayObject::class),
+        ];
+
+        yield 'subtype eliminated reversed: Countable and ArrayObject' => [
+            [new Name(Countable::class), new Name(ArrayObject::class)],
+            new Name(ArrayObject::class),
+        ];
+    }
+
+}

--- a/tests/Compiler/Type/NativeTypeUtilsTest.php
+++ b/tests/Compiler/Type/NativeTypeUtilsTest.php
@@ -4,9 +4,12 @@ namespace ShipMonk\InputMapperTests\Compiler\Type;
 
 use ArrayObject;
 use Countable;
+use PhpParser\Node\ComplexType;
 use PhpParser\Node\Identifier;
 use PhpParser\Node\IntersectionType;
 use PhpParser\Node\Name;
+use PhpParser\Node\NullableType;
+use PhpParser\Node\UnionType;
 use PHPUnit\Framework\Attributes\DataProvider;
 use ShipMonk\InputMapper\Compiler\Type\NativeTypeUtils;
 use ShipMonk\InputMapperTests\InputMapperTestCase;
@@ -134,6 +137,49 @@ class NativeTypeUtilsTest extends InputMapperTestCase
         yield 'subtype eliminated reversed: Countable and ArrayObject' => [
             [new Name(Countable::class), new Name(ArrayObject::class)],
             new Name(ArrayObject::class),
+        ];
+    }
+
+    /**
+     * @param list<ComplexType|Identifier|Name> $members
+     */
+    #[DataProvider('provideCreateUnionData')]
+    public function testCreateUnion(
+        array $members,
+        ComplexType|Identifier|Name $expected,
+    ): void
+    {
+        self::assertEquals($expected, NativeTypeUtils::createUnion(...$members));
+    }
+
+    /**
+     * @return iterable<string, array{list<ComplexType|Identifier|Name>, ComplexType|Identifier|Name}>
+     */
+    public static function provideCreateUnionData(): iterable
+    {
+        yield 'empty returns never' => [
+            [],
+            new Identifier('never'),
+        ];
+
+        yield 'single identifier' => [
+            [new Identifier('int')],
+            new Identifier('int'),
+        ];
+
+        yield 'two identifiers' => [
+            [new Identifier('int'), new Identifier('string')],
+            new UnionType([new Identifier('int'), new Identifier('string')]),
+        ];
+
+        yield 'nullable type is flattened' => [
+            [new NullableType(new Identifier('int'))],
+            new UnionType([new Identifier('int'), new Identifier('null')]),
+        ];
+
+        yield 'nullable type combined with other' => [
+            [new NullableType(new Identifier('int')), new Identifier('string')],
+            new UnionType([new Identifier('int'), new Identifier('null'), new Identifier('string')]),
         ];
     }
 

--- a/tests/Runtime/Data/CacheTestInput.php
+++ b/tests/Runtime/Data/CacheTestInput.php
@@ -1,0 +1,12 @@
+<?php declare(strict_types = 1);
+
+namespace ShipMonk\InputMapperTests\Runtime\Data;
+
+class CacheTestInput
+{
+
+    public function __construct()
+    {
+    }
+
+}

--- a/tests/Runtime/Data/MkdirTestInput.php
+++ b/tests/Runtime/Data/MkdirTestInput.php
@@ -1,0 +1,12 @@
+<?php declare(strict_types = 1);
+
+namespace ShipMonk\InputMapperTests\Runtime\Data;
+
+class MkdirTestInput
+{
+
+    public function __construct()
+    {
+    }
+
+}

--- a/tests/Runtime/InputMapperProviderTest.php
+++ b/tests/Runtime/InputMapperProviderTest.php
@@ -2,17 +2,28 @@
 
 namespace ShipMonk\InputMapperTests\Runtime;
 
+use Nette\Utils\FileSystem;
+use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
+use ShipMonk\InputMapper\Compiler\MapperFactory\DefaultMapperCompilerFactoryProvider;
+use ShipMonk\InputMapper\Compiler\Php\PhpCodeBuilder;
+use ShipMonk\InputMapper\Compiler\Php\PhpCodePrinter;
 use ShipMonk\InputMapper\Runtime\Exception\MappingFailedException;
 use ShipMonk\InputMapper\Runtime\Mapper;
 use ShipMonk\InputMapper\Runtime\MapperProvider;
 use ShipMonk\InputMapper\Runtime\Optional;
 use ShipMonk\InputMapperTests\InputMapperTestCase;
+use ShipMonk\InputMapperTests\Runtime\Data\CacheTestInput;
 use ShipMonk\InputMapperTests\Runtime\Data\DummyMapper;
 use ShipMonk\InputMapperTests\Runtime\Data\EmptyInput;
 use ShipMonk\InputMapperTests\Runtime\Data\InputInterface;
 use ShipMonk\InputMapperTests\Runtime\Data\InterfaceImplementationInput;
+use ShipMonk\InputMapperTests\Runtime\Data\MkdirTestInput;
 use ShipMonk\InputMapperTests\Runtime\Data\Optional\OptionalNotNullInput;
 use ShipMonk\InputMapperTests\Runtime\Data\Optional\OptionalNullableInput;
+use function getmypid;
+use function md5;
+use function mkdir;
+use function substr;
 use function sys_get_temp_dir;
 
 class InputMapperProviderTest extends InputMapperTestCase
@@ -102,6 +113,50 @@ class InputMapperProviderTest extends InputMapperTestCase
                 $mapper->map(['number' => -1]);
             },
         );
+    }
+
+    public function testLoadFromCachedFile(): void
+    {
+        $tempDir = sys_get_temp_dir() . '/input-mapper-test-cache-' . getmypid();
+        @mkdir($tempDir, recursive: true);
+
+        try {
+            // Pre-compile the mapper file to disk WITHOUT loading the class into PHP memory
+            $className = CacheTestInput::class;
+            $shortName = 'CacheTestInput';
+            $hash = substr(md5($className), 0, 8);
+            $mapperClassName = "ShipMonk\\InputMapper\\Runtime\\Generated\\{$shortName}Mapper_{$hash}";
+            $filePath = "{$tempDir}/{$shortName}Mapper_{$hash}.php";
+
+            $factoryProvider = new DefaultMapperCompilerFactoryProvider();
+            $factory = $factoryProvider->get();
+            $mapperCompiler = $factory->create(new IdentifierTypeNode($className))->getInputMapperCompiler();
+
+            $codeBuilder = new PhpCodeBuilder();
+            $codePrinter = new PhpCodePrinter();
+            $code = $codePrinter->prettyPrintFile($codeBuilder->inputMapperFile($mapperClassName, $mapperCompiler));
+            FileSystem::write($filePath, $code);
+
+            // Now load from cache with autoRefresh=false
+            $provider = new MapperProvider($tempDir, autoRefresh: false);
+            $mapper = $provider->getInputMapper(CacheTestInput::class);
+            self::assertInstanceOf(CacheTestInput::class, $mapper->map([])); // @phpstan-ignore-line always true
+        } finally {
+            FileSystem::delete($tempDir);
+        }
+    }
+
+    public function testLoadCreatesDirectoryWhenMissing(): void
+    {
+        $tempDir = sys_get_temp_dir() . '/input-mapper-test-mkdir-' . getmypid();
+
+        try {
+            $provider = new MapperProvider($tempDir, autoRefresh: true);
+            $mapper = $provider->getInputMapper(MkdirTestInput::class);
+            self::assertInstanceOf(MkdirTestInput::class, $mapper->map([])); // @phpstan-ignore-line always true
+        } finally {
+            FileSystem::delete($tempDir);
+        }
     }
 
     private function createMapperProvider(): MapperProvider


### PR DESCRIPTION
## Summary

- Install `shipmonk/coverage-guard` and add `check:coverage` to composer scripts (runs PHPUnit with Clover coverage + coverage-guard check)
- Add tests to cover all 9 methods that were below the 50% coverage threshold:
  - `NativeTypeUtils::createIntersection` and `isSubTypeOf` — new `NativeTypeUtilsTest`
  - `NullableOutputMapperCompiler::compile` — statements branch via `ListOutputMapperCompiler` inner mapper
  - `MapChain::getInputMapperCompiler` and `getOutputMapperCompiler` — new `MapChainTest`
  - `CannotCreateMapperCompilerException::withIncompatibleDefaultValueParameter` and `withIncompatibleValidator` — factory error test cases
  - `DiscriminatedObjectInputMapperCompiler::getOutputType` and `DiscriminatedObjectOutputMapperCompiler::getInputType` — generic parameter branch
- Add `coverage.xml` to `.gitignore`

Co-Authored-By: Claude Code