### PR TITLE
Unify input/output mapper code generation via GenericMapperParameter

### DIFF
--- a/src/Compiler/Mapper/GenericMapperCompiler.php
+++ b/src/Compiler/Mapper/GenericMapperCompiler.php
@@ -2,13 +2,11 @@
 
 namespace ShipMonk\InputMapper\Compiler\Mapper;
 
-use ShipMonk\InputMapper\Compiler\Type\GenericTypeParameter;
-
 interface GenericMapperCompiler extends MapperCompiler
 {
 
     /**
-     * @return list<GenericTypeParameter>
+     * @return list<GenericMapperParameter>
      */
     public function getGenericParameters(): array;
 

--- a/src/Compiler/Mapper/GenericMapperParameter.php
+++ b/src/Compiler/Mapper/GenericMapperParameter.php
@@ -1,0 +1,51 @@
+<?php declare(strict_types = 1);
+
+namespace ShipMonk\InputMapper\Compiler\Mapper;
+
+use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
+use PHPStan\PhpDocParser\Ast\Type\TypeNode;
+use ShipMonk\InputMapper\Compiler\Type\GenericTypeParameter;
+use ShipMonk\InputMapper\Compiler\Type\GenericTypeVariance;
+
+class GenericMapperParameter
+{
+
+    public readonly string $name;
+
+    public readonly GenericTypeVariance $variance;
+
+    public readonly ?TypeNode $bound;
+
+    public readonly ?TypeNode $default;
+
+    public function __construct(
+        GenericTypeParameter $typeParameter,
+        public readonly TypeNode $innerMapperInputType,
+        public readonly TypeNode $innerMapperOutputType,
+    )
+    {
+        $this->name = $typeParameter->name;
+        $this->variance = $typeParameter->variance;
+        $this->bound = $typeParameter->bound;
+        $this->default = $typeParameter->default;
+    }
+
+    public static function input(GenericTypeParameter $typeParameter): self
+    {
+        return new self(
+            $typeParameter,
+            new IdentifierTypeNode('mixed'),
+            new IdentifierTypeNode($typeParameter->name),
+        );
+    }
+
+    public static function output(GenericTypeParameter $typeParameter): self
+    {
+        return new self(
+            $typeParameter,
+            new IdentifierTypeNode($typeParameter->name),
+            new IdentifierTypeNode('mixed'),
+        );
+    }
+
+}

--- a/src/Compiler/Mapper/Input/DiscriminatedObjectInputMapperCompiler.php
+++ b/src/Compiler/Mapper/Input/DiscriminatedObjectInputMapperCompiler.php
@@ -10,12 +10,14 @@ use PHPStan\PhpDocParser\Ast\Type\TypeNode;
 use ShipMonk\InputMapper\Compiler\CompiledExpr;
 use ShipMonk\InputMapper\Compiler\Exception\CannotCompileMapperException;
 use ShipMonk\InputMapper\Compiler\Mapper\GenericMapperCompiler;
+use ShipMonk\InputMapper\Compiler\Mapper\GenericMapperParameter;
 use ShipMonk\InputMapper\Compiler\Mapper\MapperCompiler;
 use ShipMonk\InputMapper\Compiler\Php\PhpCodeBuilder;
 use ShipMonk\InputMapper\Compiler\Type\GenericTypeParameter;
 use ShipMonk\InputMapper\Compiler\Type\PhpDocTypeUtils;
 use ShipMonk\InputMapper\Runtime\Exception\MappingFailedException;
 use function array_keys;
+use function array_map;
 use function count;
 use function ucfirst;
 
@@ -146,12 +148,9 @@ class DiscriminatedObjectInputMapperCompiler implements GenericMapperCompiler
         );
     }
 
-    /**
-     * @return list<GenericTypeParameter>
-     */
     public function getGenericParameters(): array
     {
-        return $this->genericParameters;
+        return array_map(GenericMapperParameter::input(...), $this->genericParameters);
     }
 
 }

--- a/src/Compiler/Mapper/Input/ObjectInputMapperCompiler.php
+++ b/src/Compiler/Mapper/Input/ObjectInputMapperCompiler.php
@@ -10,6 +10,7 @@ use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
 use PHPStan\PhpDocParser\Ast\Type\TypeNode;
 use ShipMonk\InputMapper\Compiler\CompiledExpr;
 use ShipMonk\InputMapper\Compiler\Mapper\GenericMapperCompiler;
+use ShipMonk\InputMapper\Compiler\Mapper\GenericMapperParameter;
 use ShipMonk\InputMapper\Compiler\Mapper\MapperCompiler;
 use ShipMonk\InputMapper\Compiler\Mapper\UndefinedAwareMapperCompiler;
 use ShipMonk\InputMapper\Compiler\Php\PhpCodeBuilder;
@@ -17,6 +18,7 @@ use ShipMonk\InputMapper\Compiler\Type\GenericTypeParameter;
 use ShipMonk\InputMapper\Runtime\Exception\MappingFailedException;
 use function array_fill_keys;
 use function array_keys;
+use function array_map;
 use function array_push;
 use function count;
 use function ucfirst;
@@ -136,12 +138,9 @@ class ObjectInputMapperCompiler implements GenericMapperCompiler
         );
     }
 
-    /**
-     * @return list<GenericTypeParameter>
-     */
     public function getGenericParameters(): array
     {
-        return $this->genericParameters;
+        return array_map(GenericMapperParameter::input(...), $this->genericParameters);
     }
 
     /**

--- a/src/Compiler/Mapper/Output/DiscriminatedObjectOutputMapperCompiler.php
+++ b/src/Compiler/Mapper/Output/DiscriminatedObjectOutputMapperCompiler.php
@@ -10,11 +10,13 @@ use PHPStan\PhpDocParser\Ast\Type\TypeNode;
 use ShipMonk\InputMapper\Compiler\CompiledExpr;
 use ShipMonk\InputMapper\Compiler\Exception\CannotCompileMapperException;
 use ShipMonk\InputMapper\Compiler\Mapper\GenericMapperCompiler;
+use ShipMonk\InputMapper\Compiler\Mapper\GenericMapperParameter;
 use ShipMonk\InputMapper\Compiler\Mapper\MapperCompiler;
 use ShipMonk\InputMapper\Compiler\Php\PhpCodeBuilder;
 use ShipMonk\InputMapper\Compiler\Type\GenericTypeParameter;
 use ShipMonk\InputMapper\Compiler\Type\PhpDocTypeUtils;
 use ShipMonk\InputMapper\Runtime\Exception\MappingFailedException;
+use function array_map;
 use function count;
 use function ucfirst;
 
@@ -101,12 +103,9 @@ class DiscriminatedObjectOutputMapperCompiler implements GenericMapperCompiler
         return new IdentifierTypeNode('mixed'); // exact type unknown because subtypes are resolved at runtime via delegates
     }
 
-    /**
-     * @return list<GenericTypeParameter>
-     */
     public function getGenericParameters(): array
     {
-        return $this->genericParameters;
+        return array_map(GenericMapperParameter::output(...), $this->genericParameters);
     }
 
 }

--- a/src/Compiler/Mapper/Output/ObjectOutputMapperCompiler.php
+++ b/src/Compiler/Mapper/Output/ObjectOutputMapperCompiler.php
@@ -11,9 +11,11 @@ use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
 use PHPStan\PhpDocParser\Ast\Type\TypeNode;
 use ShipMonk\InputMapper\Compiler\CompiledExpr;
 use ShipMonk\InputMapper\Compiler\Mapper\GenericMapperCompiler;
+use ShipMonk\InputMapper\Compiler\Mapper\GenericMapperParameter;
 use ShipMonk\InputMapper\Compiler\Mapper\MapperCompiler;
 use ShipMonk\InputMapper\Compiler\Php\PhpCodeBuilder;
 use ShipMonk\InputMapper\Compiler\Type\GenericTypeParameter;
+use function array_map;
 use function count;
 use function ucfirst;
 
@@ -153,12 +155,9 @@ class ObjectOutputMapperCompiler implements GenericMapperCompiler
         return ArrayShapeNode::createSealed($items);
     }
 
-    /**
-     * @return list<GenericTypeParameter>
-     */
     public function getGenericParameters(): array
     {
-        return $this->genericParameters;
+        return array_map(GenericMapperParameter::output(...), $this->genericParameters);
     }
 
 }

--- a/src/Compiler/Php/PhpCodeBuilder.php
+++ b/src/Compiler/Php/PhpCodeBuilder.php
@@ -53,6 +53,7 @@ use PHPStan\PhpDocParser\Ast\Type\ObjectShapeItemNode;
 use PHPStan\PhpDocParser\Ast\Type\TypeNode;
 use ShipMonk\InputMapper\Compiler\CompiledExpr;
 use ShipMonk\InputMapper\Compiler\Mapper\GenericMapperCompiler;
+use ShipMonk\InputMapper\Compiler\Mapper\GenericMapperParameter;
 use ShipMonk\InputMapper\Compiler\Mapper\MapperCompiler;
 use ShipMonk\InputMapper\Compiler\Type\GenericTypeParameter;
 use ShipMonk\InputMapper\Compiler\Type\PhpDocTypeUtils;
@@ -82,7 +83,7 @@ class PhpCodeBuilder extends BuilderFactory
 {
 
     /**
-     * @var list<GenericTypeParameter>
+     * @var list<GenericMapperParameter>
      */
     private array $genericParameters = [];
 
@@ -553,7 +554,7 @@ class PhpCodeBuilder extends BuilderFactory
         return "/**\n * " . implode("\n * ", $lines) . "\n */";
     }
 
-    public function inputMapperClassConstructor(MapperCompiler $mapperCompiler): ClassMethod
+    public function mapperClassConstructor(MapperCompiler $mapperCompiler): ClassMethod
     {
         $mapperConstructorPhpDocLines = [];
         $mapperConstructorBuilder = $this->method('__construct');
@@ -569,10 +570,10 @@ class PhpCodeBuilder extends BuilderFactory
 
             $innerMappersType = ArrayShapeNode::createSealed(Arrays::map(
                 $mapperCompiler->getGenericParameters(),
-                static function (GenericTypeParameter $genericParameter): ArrayShapeItemNode {
+                static function (GenericMapperParameter $genericParameter): ArrayShapeItemNode {
                     return new ArrayShapeItemNode(
                         keyName: null,
-                        valueType: new GenericTypeNode(new IdentifierTypeNode(Mapper::class), [new IdentifierTypeNode('mixed'), new IdentifierTypeNode($genericParameter->name)]),
+                        valueType: new GenericTypeNode(new IdentifierTypeNode(Mapper::class), [$genericParameter->innerMapperInputType, $genericParameter->innerMapperOutputType]),
                         optional: false,
                     );
                 },
@@ -588,12 +589,12 @@ class PhpCodeBuilder extends BuilderFactory
             ->getNode();
     }
 
-    public function inputMapperClass(
+    public function mapperClass(
         string $shortClassName,
         MapperCompiler $mapperCompiler,
     ): Class_
     {
-        $mapperConstructor = $this->inputMapperClassConstructor($mapperCompiler);
+        $mapperConstructor = $this->mapperClassConstructor($mapperCompiler);
 
         $mapMethod = $this->mapperMethod('map', $mapperCompiler)
             ->makePublic()
@@ -650,7 +651,7 @@ class PhpCodeBuilder extends BuilderFactory
     /**
      * @return list<Stmt>
      */
-    public function inputMapperFile(
+    public function mapperFile(
         string $mapperClassName,
         MapperCompiler $mapperCompiler,
     ): array
@@ -663,7 +664,7 @@ class PhpCodeBuilder extends BuilderFactory
             $this->genericParameters = $mapperCompiler->getGenericParameters();
         }
 
-        $mapperClass = $this->inputMapperClass($shortClassName, $mapperCompiler)
+        $mapperClass = $this->mapperClass($shortClassName, $mapperCompiler)
             ->getNode();
 
         return $this->file($namespaceName, [$mapperClass]);
@@ -714,122 +715,6 @@ class PhpCodeBuilder extends BuilderFactory
             ->addStmt($this->return($mapper->expr));
     }
 
-    public function outputMapperClassConstructor(MapperCompiler $mapperCompiler): ClassMethod
-    {
-        $mapperConstructorPhpDocLines = [];
-        $mapperConstructorBuilder = $this->method('__construct');
-
-        $providerParameter = $this->param('provider')->setType($this->importClass(MapperProvider::class))->getNode();
-        $providerParameter->flags = ClassNode::MODIFIER_PRIVATE | ClassNode::MODIFIER_READONLY;
-        $mapperConstructorBuilder->addParam($providerParameter);
-
-        if ($mapperCompiler instanceof GenericMapperCompiler && count($mapperCompiler->getGenericParameters()) > 0) {
-            $innerMappersParameter = $this->param('genericInnerMappers')->setType('array')->getNode();
-            $innerMappersParameter->flags = ClassNode::MODIFIER_PRIVATE | ClassNode::MODIFIER_READONLY;
-            $mapperConstructorBuilder->addParam($innerMappersParameter);
-
-            $innerMappersType = ArrayShapeNode::createSealed(Arrays::map(
-                $mapperCompiler->getGenericParameters(),
-                static function (GenericTypeParameter $genericParameter): ArrayShapeItemNode {
-                    return new ArrayShapeItemNode(
-                        keyName: null,
-                        valueType: new GenericTypeNode(new IdentifierTypeNode(Mapper::class), [new IdentifierTypeNode($genericParameter->name), new IdentifierTypeNode('mixed')]),
-                        optional: false,
-                    );
-                },
-            ));
-
-            $innerMappersType = $this->importType($innerMappersType);
-            $mapperConstructorPhpDocLines[] = "@param {$innerMappersType} \$genericInnerMappers";
-        }
-
-        return $mapperConstructorBuilder
-            ->makePublic()
-            ->setDocComment($this->phpDoc($mapperConstructorPhpDocLines))
-            ->getNode();
-    }
-
-    public function outputMapperClass(
-        string $shortClassName,
-        MapperCompiler $mapperCompiler,
-    ): Class_
-    {
-        $mapperConstructor = $this->outputMapperClassConstructor($mapperCompiler);
-
-        $mapMethod = $this->mapperMethod('map', $mapperCompiler)
-            ->makePublic()
-            ->getNode();
-
-        $inputType = $this->importType($mapperCompiler->getInputType());
-        $outputType = $this->importType($mapperCompiler->getOutputType());
-
-        $mapperCompilerType = $this->importClass($mapperCompiler::class);
-
-        $implementsType = new GenericTypeNode(
-            new IdentifierTypeNode($this->importClass(Mapper::class)),
-            [$inputType, $outputType],
-        );
-
-        $phpDocLines = [
-            "Generated mapper by {@see $mapperCompilerType}. Do not edit directly.",
-            '',
-        ];
-
-        if ($mapperCompiler instanceof GenericMapperCompiler) {
-            foreach ($mapperCompiler->getGenericParameters() as $genericParameter) {
-                $importedParameter = new GenericTypeParameter(
-                    $genericParameter->name,
-                    $genericParameter->variance,
-                    $genericParameter->bound !== null ? $this->importType($genericParameter->bound) : null,
-                    $genericParameter->default !== null ? $this->importType($genericParameter->default) : null,
-                );
-                $phpDocLines[] = $importedParameter->toPhpDocLine();
-            }
-        }
-
-        $phpDocLines[] = "@implements {$implementsType}";
-        $phpDoc = $this->phpDoc($phpDocLines);
-
-        $constants = Arrays::map(
-            $this->constants,
-            function (Expr|bool|int|float|string|array|null $value, string $name): ClassConst {
-                return $this->classConst($name, $value)
-                    ->makePrivate()
-                    ->getNode();
-            },
-        );
-
-        return $this->class($shortClassName)
-            ->setDocComment($phpDoc)
-            ->implement($this->importClass(Mapper::class))
-            ->addStmts($constants)
-            ->addStmt($mapperConstructor)
-            ->addStmt($mapMethod)
-            ->addStmts(array_values($this->methods));
-    }
-
-    /**
-     * @return list<Stmt>
-     */
-    public function outputMapperFile(
-        string $mapperClassName,
-        MapperCompiler $mapperCompiler,
-    ): array
-    {
-        $pos = strrpos($mapperClassName, '\\');
-        $namespaceName = $pos === false ? '' : substr($mapperClassName, 0, $pos);
-        $shortClassName = $pos === false ? $mapperClassName : substr($mapperClassName, $pos + 1);
-
-        if ($mapperCompiler instanceof GenericMapperCompiler) {
-            $this->genericParameters = $mapperCompiler->getGenericParameters();
-        }
-
-        $mapperClass = $this->outputMapperClass($shortClassName, $mapperCompiler)
-            ->getNode();
-
-        return $this->file($namespaceName, [$mapperClass]);
-    }
-
     /**
      * @param list<Stmt> $statements
      * @return list<Stmt>
@@ -860,7 +745,7 @@ class PhpCodeBuilder extends BuilderFactory
     }
 
     /**
-     * @return list<GenericTypeParameter>
+     * @return list<GenericMapperParameter>
      */
     public function getGenericParameters(): array
     {

--- a/src/Runtime/MapperProvider.php
+++ b/src/Runtime/MapperProvider.php
@@ -259,13 +259,11 @@ class MapperProvider
         $codeBuilder = new PhpCodeBuilder();
         $codePrinter = new PhpCodePrinter();
 
-        if ($direction === 'input') {
-            $mapperCompiler = $mapperCompilerFactory->create($type)->getInputMapperCompiler();
-            return $codePrinter->prettyPrintFile($codeBuilder->inputMapperFile($mapperClassName, $mapperCompiler));
-        }
+        $mapperCompiler = $direction === 'input'
+            ? $mapperCompilerFactory->create($type)->getInputMapperCompiler()
+            : $mapperCompilerFactory->create($type)->getOutputMapperCompiler();
 
-        $mapperCompiler = $mapperCompilerFactory->create($type)->getOutputMapperCompiler();
-        return $codePrinter->prettyPrintFile($codeBuilder->outputMapperFile($mapperClassName, $mapperCompiler));
+        return $codePrinter->prettyPrintFile($codeBuilder->mapperFile($mapperClassName, $mapperCompiler));
     }
 
     /**

--- a/tests/Compiler/Mapper/MapperCompilerTestCase.php
+++ b/tests/Compiler/Mapper/MapperCompilerTestCase.php
@@ -44,7 +44,7 @@ abstract class MapperCompilerTestCase extends InputMapperTestCase
 
         $builder = new PhpCodeBuilder();
         $printer = new PhpCodePrinter();
-        $mapperCode = $printer->prettyPrintFile($builder->inputMapperFile($mapperClassName, $mapperCompiler));
+        $mapperCode = $printer->prettyPrintFile($builder->mapperFile($mapperClassName, $mapperCompiler));
         self::assertSnapshot($mapperPath, $mapperCode);
 
         if (!class_exists($mapperClassName, autoload: false)) {
@@ -87,7 +87,7 @@ abstract class MapperCompilerTestCase extends InputMapperTestCase
 
         $builder = new PhpCodeBuilder();
         $printer = new PhpCodePrinter();
-        $mapperCode = $printer->prettyPrintFile($builder->outputMapperFile($mapperClassName, $mapperCompiler));
+        $mapperCode = $printer->prettyPrintFile($builder->mapperFile($mapperClassName, $mapperCompiler));
         self::assertSnapshot($mapperPath, $mapperCode);
 
         if (!class_exists($mapperClassName, autoload: false)) {

--- a/tests/Runtime/InputMapperProviderTest.php
+++ b/tests/Runtime/InputMapperProviderTest.php
@@ -134,7 +134,7 @@ class InputMapperProviderTest extends InputMapperTestCase
 
             $codeBuilder = new PhpCodeBuilder();
             $codePrinter = new PhpCodePrinter();
-            $code = $codePrinter->prettyPrintFile($codeBuilder->inputMapperFile($mapperClassName, $mapperCompiler));
+            $code = $codePrinter->prettyPrintFile($codeBuilder->mapperFile($mapperClassName, $mapperCompiler));
             FileSystem::write($filePath, $code);
 
             // Now load from cache with autoRefresh=false


### PR DESCRIPTION
## Summary
- Introduce `GenericMapperParameter` wrapper that pairs `GenericTypeParameter` with the inner mapper's input/output types (`Mapper<mixed, T>` for input direction, `Mapper<T, mixed>` for output direction)
- `GenericMapperCompiler::getGenericParameters()` now returns `list<GenericMapperParameter>` — implementations use `GenericMapperParameter::input()` / `::output()` factory methods to express the mapping direction
- Collapse all `input*`/`output*` method pairs in `PhpCodeBuilder` into unified `mapperClassConstructor`/`mapperClass`/`mapperFile` methods

Follow-up to #109.

## Test plan
- [x] All 883 existing tests pass
- [x] PHPStan level 9 passes
- [x] Code coverage threshold met

Co-Authored-By: Claude Code