### PR TITLE
Fix isSubTypeOf check for non-empty-string as supertype

### DIFF
--- a/src/Compiler/Type/PhpDocTypeUtils.php
+++ b/src/Compiler/Type/PhpDocTypeUtils.php
@@ -539,6 +539,16 @@ class PhpDocTypeUtils
 
                 'never' => $a instanceof IdentifierTypeNode && $a->name === 'never',
 
+                'non-empty-string' => match (true) {
+                    $a instanceof IdentifierTypeNode => $a->name === 'non-empty-string',
+                    $a instanceof ConstTypeNode => match (true) {
+                        $a->constExpr instanceof ConstExprStringNode => $a->constExpr->value !== '',
+                        $a->constExpr instanceof ConstFetchNode => is_string($constValue = constant((string) $a->constExpr)) && $constValue !== '',
+                        default => false,
+                    },
+                    default => false,
+                },
+
                 'non-empty-list' => match (true) {
                     $a instanceof ArrayShapeNode => Arrays::every($a->items, static fn (ArrayShapeItemNode $item, int $idx) => self::getArrayShapeKey($item) === (string) $idx)
                         && Arrays::some($a->items, static fn (ArrayShapeItemNode $item) => !$item->optional),

--- a/tests/Compiler/Type/PhpDocTypeUtilsTest.php
+++ b/tests/Compiler/Type/PhpDocTypeUtilsTest.php
@@ -1330,6 +1330,20 @@ class PhpDocTypeUtilsTest extends InputMapperTestCase
             ],
         ];
 
+        yield 'non-empty-string' => [
+            'true' => [
+                'non-empty-string',
+                '"abc"',
+                'DateTimeImmutable::RFC3339',
+            ],
+
+            'false' => [
+                'string',
+                '""',
+                'int',
+            ],
+        ];
+
         yield 'true' => [
             'true' => [
                 'true',


### PR DESCRIPTION
## Summary

`PhpDocTypeUtils::isSubTypeOf($a, $b)` incorrectly returned `false` whenever `$b` was `non-empty-string`. Because `non-empty-string` contains a hyphen, `isKeyword()` classifies it as a keyword and routes the check into the `match ($b->name)` block at `PhpDocTypeUtils.php:480` — which had no case for `non-empty-string` and fell through to `default => false`.

## Impact

This broke parameter compatibility checks whenever a mapper output type was narrowed to `non-empty-string` and the parameter type was also `non-empty-string`, producing the confusing error:

> `Cannot use mapper ValidatedInputMapperCompiler for parameter $name of method X::__construct, because mapper output type 'non-empty-string' is not compatible with parameter type 'non-empty-string'`

Reproducer — combining `#[AssertStringLength(min: 1, max: 255)]` with a `non-empty-string` parameter:

```php
/** @var non-empty-string */
#[AssertStringLength(min: 1, max: 255)]
public string $name,
```

## Fix

Added a `non-empty-string` case to the match in `isSubTypeOf()`, modeled after the existing `non-empty-list` case, plus `ConstTypeNode` handling for non-empty string literals.

## Test plan

- [x] Added `non-empty-string` coverage to `PhpDocTypeUtilsTest::isSubTypeOfDataProvider` (covers `non-empty-string`, non-empty string literal, class-const string, and negative cases for `string`, empty string literal, `int`)
- [x] `composer check` passes (CS, PHPStan level 9, 889 tests, coverage guard, dep analyser)