### PR TITLE
Add PropertyNameTransformer for global key naming strategies

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,26 @@ class Person
 }
 ```
 
+To rename keys globally — e.g. camelCase PHP properties ↔ snake_case wire keys — configure a `PropertyNameTransformer`
+on the `DefaultMapperCompilerFactoryProvider`. The transform is applied in both directions (input lookup and output emission),
+and `#[SourceKey]` always takes precedence over it on properties where it is set:
+
+```php
+use ShipMonk\InputMapper\Compiler\MapperFactory\DefaultMapperCompilerFactoryProvider;
+use ShipMonk\InputMapper\Compiler\PropertyNameTransformer\CamelToSnakeCasePropertyNameTransformer;
+use ShipMonk\InputMapper\Runtime\MapperProvider;
+
+$provider = new MapperProvider(
+    tempDir: __DIR__ . '/temp',
+    mapperCompilerFactoryProvider: new DefaultMapperCompilerFactoryProvider(
+        new CamelToSnakeCasePropertyNameTransformer(),
+    ),
+);
+```
+
+The built-in `CamelToSnakeCasePropertyNameTransformer` handles common acronym boundaries (`HTTPServer` → `http_server`,
+`parseURL` → `parse_url`). Implement `PropertyNameTransformer` yourself for other conventions.
+
 ### Parsing polymorphic classes (subtypes with a common parent)
 
 If you need to parse a hierarchy of classes, you can use the `#[Discriminator]` attribute.

--- a/src/Compiler/MapperFactory/DefaultMapperCompilerFactory.php
+++ b/src/Compiler/MapperFactory/DefaultMapperCompilerFactory.php
@@ -56,6 +56,7 @@ use ShipMonk\InputMapper\Compiler\Exception\CannotCreateMapperCompilerException;
 use ShipMonk\InputMapper\Compiler\Mapper\MapperCompilerProvider;
 use ShipMonk\InputMapper\Compiler\Mapper\OutputMapperCompilerProvider;
 use ShipMonk\InputMapper\Compiler\Mapper\UndefinedAwareMapperCompiler;
+use ShipMonk\InputMapper\Compiler\PropertyNameTransformer\PropertyNameTransformer;
 use ShipMonk\InputMapper\Compiler\Type\PhpDocTypeUtils;
 use ShipMonk\InputMapper\Compiler\Validator\Array\AssertListLength;
 use ShipMonk\InputMapper\Compiler\Validator\Int\AssertIntRange;
@@ -91,6 +92,7 @@ class DefaultMapperCompilerFactory implements MapperCompilerFactory
         protected readonly Lexer $phpDocLexer,
         protected readonly PhpDocParser $phpDocParser,
         protected array $mapperCompilerFactories = [],
+        protected readonly ?PropertyNameTransformer $propertyNameTransformer = null,
     )
     {
         $this->setMapperCompilerFactory(BackedEnum::class, $this->createEnumMapperCompilerProvider(...));
@@ -346,11 +348,16 @@ class DefaultMapperCompilerFactory implements MapperCompilerFactory
         $constructorParameterTypes = $this->getConstructorParameterTypes($constructor, $genericParameterNames);
 
         foreach ($constructor->getParameters() as $parameter) {
-            $name = $parameter->getName();
-            $type = $constructorParameterTypes[$name];
+            $parameterName = $parameter->getName();
+            $type = $constructorParameterTypes[$parameterName];
+            $sourceKeyAttributes = $parameter->getAttributes(SourceKey::class);
 
-            foreach ($parameter->getAttributes(SourceKey::class) as $attribute) {
-                $name = $attribute->newInstance()->key;
+            if (count($sourceKeyAttributes) > 0) {
+                $name = $sourceKeyAttributes[0]->newInstance()->key;
+            } elseif ($this->propertyNameTransformer !== null) {
+                $name = $this->propertyNameTransformer->transform($parameterName);
+            } else {
+                $name = $parameterName;
             }
 
             $constructorArgsProviders[$name] = $this->createParameterMapperCompilerProvider($parameter, $type, $options);
@@ -401,10 +408,14 @@ class DefaultMapperCompilerFactory implements MapperCompilerFactory
             $type = $constructorTypesByClass[$declaringClassName][$propertyName]
                 ?? throw CannotCreateMapperCompilerException::fromType($inputType, "cannot determine type for property {$propertyName}");
 
-            $outputKey = $propertyName;
+            $sourceKeyAttributes = $property->getAttributes(SourceKey::class);
 
-            foreach ($property->getAttributes(SourceKey::class) as $attribute) {
-                $outputKey = $attribute->newInstance()->key;
+            if (count($sourceKeyAttributes) > 0) {
+                $outputKey = $sourceKeyAttributes[0]->newInstance()->key;
+            } elseif ($this->propertyNameTransformer !== null) {
+                $outputKey = $this->propertyNameTransformer->transform($propertyName);
+            } else {
+                $outputKey = $propertyName;
             }
 
             $provider = $this->createPropertyMapperCompilerProvider($property, $type, $options);

--- a/src/Compiler/MapperFactory/DefaultMapperCompilerFactory.php
+++ b/src/Compiler/MapperFactory/DefaultMapperCompilerFactory.php
@@ -355,7 +355,7 @@ class DefaultMapperCompilerFactory implements MapperCompilerFactory
             if (count($sourceKeyAttributes) > 0) {
                 $name = $sourceKeyAttributes[0]->newInstance()->key;
             } elseif ($this->propertyNameTransformer !== null) {
-                $name = $this->propertyNameTransformer->transform($parameterName);
+                $name = $this->propertyNameTransformer->transform($parameterName, $classReflection->getName());
             } else {
                 $name = $parameterName;
             }
@@ -413,7 +413,7 @@ class DefaultMapperCompilerFactory implements MapperCompilerFactory
             if (count($sourceKeyAttributes) > 0) {
                 $outputKey = $sourceKeyAttributes[0]->newInstance()->key;
             } elseif ($this->propertyNameTransformer !== null) {
-                $outputKey = $this->propertyNameTransformer->transform($propertyName);
+                $outputKey = $this->propertyNameTransformer->transform($propertyName, $classReflection->getName());
             } else {
                 $outputKey = $propertyName;
             }

--- a/src/Compiler/MapperFactory/DefaultMapperCompilerFactoryProvider.php
+++ b/src/Compiler/MapperFactory/DefaultMapperCompilerFactoryProvider.php
@@ -7,11 +7,18 @@ use PHPStan\PhpDocParser\Parser\ConstExprParser;
 use PHPStan\PhpDocParser\Parser\PhpDocParser;
 use PHPStan\PhpDocParser\Parser\TypeParser;
 use PHPStan\PhpDocParser\ParserConfig;
+use ShipMonk\InputMapper\Compiler\PropertyNameTransformer\PropertyNameTransformer;
 
 class DefaultMapperCompilerFactoryProvider implements MapperCompilerFactoryProvider
 {
 
     private ?MapperCompilerFactory $mapperCompilerFactory = null;
+
+    public function __construct(
+        private readonly ?PropertyNameTransformer $propertyNameTransformer = null,
+    )
+    {
+    }
 
     public function get(): MapperCompilerFactory
     {
@@ -21,7 +28,11 @@ class DefaultMapperCompilerFactoryProvider implements MapperCompilerFactoryProvi
     protected function create(): MapperCompilerFactory
     {
         $config = $this->createParserConfig();
-        return new DefaultMapperCompilerFactory($this->createPhpDocLexer($config), $this->createPhpDocParser($config));
+        return new DefaultMapperCompilerFactory(
+            $this->createPhpDocLexer($config),
+            $this->createPhpDocParser($config),
+            propertyNameTransformer: $this->propertyNameTransformer,
+        );
     }
 
     protected function createPhpDocLexer(ParserConfig $config): Lexer

--- a/src/Compiler/MapperFactory/DefaultMapperCompilerFactoryProvider.php
+++ b/src/Compiler/MapperFactory/DefaultMapperCompilerFactoryProvider.php
@@ -31,7 +31,8 @@ class DefaultMapperCompilerFactoryProvider implements MapperCompilerFactoryProvi
         return new DefaultMapperCompilerFactory(
             $this->createPhpDocLexer($config),
             $this->createPhpDocParser($config),
-            propertyNameTransformer: $this->propertyNameTransformer,
+            [],
+            $this->propertyNameTransformer,
         );
     }
 

--- a/src/Compiler/PropertyNameTransformer/CamelToSnakeCasePropertyNameTransformer.php
+++ b/src/Compiler/PropertyNameTransformer/CamelToSnakeCasePropertyNameTransformer.php
@@ -9,7 +9,10 @@ use function strtolower;
 class CamelToSnakeCasePropertyNameTransformer implements PropertyNameTransformer
 {
 
-    public function transform(string $propertyName): string
+    public function transform(
+        string $propertyName,
+        string $className,
+    ): string
     {
         $result = preg_replace('/(?<=[a-z0-9])([A-Z])|(?<=[A-Z])([A-Z][a-z])/', '_$1$2', $propertyName);
 

--- a/src/Compiler/PropertyNameTransformer/CamelToSnakeCasePropertyNameTransformer.php
+++ b/src/Compiler/PropertyNameTransformer/CamelToSnakeCasePropertyNameTransformer.php
@@ -1,0 +1,23 @@
+<?php declare(strict_types = 1);
+
+namespace ShipMonk\InputMapper\Compiler\PropertyNameTransformer;
+
+use LogicException;
+use function preg_replace;
+use function strtolower;
+
+class CamelToSnakeCasePropertyNameTransformer implements PropertyNameTransformer
+{
+
+    public function transform(string $propertyName): string
+    {
+        $result = preg_replace('/(?<=[a-z0-9])([A-Z])|(?<=[A-Z])([A-Z][a-z])/', '_$1$2', $propertyName);
+
+        if ($result === null) {
+            throw new LogicException('Failed to transform property name: ' . $propertyName);
+        }
+
+        return strtolower($result);
+    }
+
+}

--- a/src/Compiler/PropertyNameTransformer/PropertyNameTransformer.php
+++ b/src/Compiler/PropertyNameTransformer/PropertyNameTransformer.php
@@ -5,6 +5,12 @@ namespace ShipMonk\InputMapper\Compiler\PropertyNameTransformer;
 interface PropertyNameTransformer
 {
 
-    public function transform(string $propertyName): string;
+    /**
+     * @param class-string $className FQCN of the class being compiled (subclass in case of inheritance)
+     */
+    public function transform(
+        string $propertyName,
+        string $className,
+    ): string;
 
 }

--- a/src/Compiler/PropertyNameTransformer/PropertyNameTransformer.php
+++ b/src/Compiler/PropertyNameTransformer/PropertyNameTransformer.php
@@ -1,0 +1,10 @@
+<?php declare(strict_types = 1);
+
+namespace ShipMonk\InputMapper\Compiler\PropertyNameTransformer;
+
+interface PropertyNameTransformer
+{
+
+    public function transform(string $propertyName): string;
+
+}

--- a/tests/Runtime/CamelToSnakeCaseMapperTest.php
+++ b/tests/Runtime/CamelToSnakeCaseMapperTest.php
@@ -5,11 +5,13 @@ namespace ShipMonk\InputMapperTests\Runtime;
 use PHPUnit\Framework\Attributes\DataProvider;
 use ShipMonk\InputMapper\Compiler\MapperFactory\DefaultMapperCompilerFactoryProvider;
 use ShipMonk\InputMapper\Compiler\PropertyNameTransformer\CamelToSnakeCasePropertyNameTransformer;
+use ShipMonk\InputMapper\Compiler\PropertyNameTransformer\PropertyNameTransformer;
 use ShipMonk\InputMapper\Runtime\MapperProvider;
 use ShipMonk\InputMapperTests\InputMapperTestCase;
 use ShipMonk\InputMapperTests\Runtime\Data\AcronymCasedInput;
 use ShipMonk\InputMapperTests\Runtime\Data\CamelCasePropertiesInput;
 use ShipMonk\InputMapperTests\Runtime\Data\CamelCaseWithSourceKeyInput;
+use ShipMonk\InputMapperTests\Runtime\Data\PerClassOverrideInput;
 use function sys_get_temp_dir;
 
 class CamelToSnakeCaseMapperTest extends InputMapperTestCase
@@ -22,7 +24,7 @@ class CamelToSnakeCaseMapperTest extends InputMapperTestCase
     ): void
     {
         $transformer = new CamelToSnakeCasePropertyNameTransformer();
-        self::assertSame($expected, $transformer->transform($input));
+        self::assertSame($expected, $transformer->transform($input, CamelCasePropertiesInput::class));
     }
 
     /**
@@ -132,6 +134,39 @@ class CamelToSnakeCaseMapperTest extends InputMapperTestCase
         self::assertSame('Alice', $object->firstName);
 
         self::assertSame($data, $provider->getOutputMapper(CamelCaseWithSourceKeyInput::class)->map($object));
+    }
+
+    public function testTransformerReceivesClassNameAndCanOverridePerClass(): void
+    {
+        $provider = new MapperProvider(
+            sys_get_temp_dir(),
+            autoRefresh: true,
+            mapperCompilerFactoryProvider: new DefaultMapperCompilerFactoryProvider(
+                new class implements PropertyNameTransformer {
+
+                    public function transform(
+                        string $propertyName,
+                        string $className,
+                    ): string
+                    {
+                        if ($className === PerClassOverrideInput::class) {
+                            return $propertyName;
+                        }
+
+                        return (new CamelToSnakeCasePropertyNameTransformer())->transform($propertyName, $className);
+                    }
+
+                },
+            ),
+        );
+
+        $data = ['userId' => 1, 'firstName' => 'John'];
+        $object = $provider->getInputMapper(PerClassOverrideInput::class)->map($data);
+
+        self::assertSame(1, $object->userId);
+        self::assertSame('John', $object->firstName);
+
+        self::assertSame($data, $provider->getOutputMapper(PerClassOverrideInput::class)->map($object));
     }
 
     private function createProvider(): MapperProvider

--- a/tests/Runtime/CamelToSnakeCaseMapperTest.php
+++ b/tests/Runtime/CamelToSnakeCaseMapperTest.php
@@ -67,9 +67,24 @@ class CamelToSnakeCaseMapperTest extends InputMapperTestCase
 
         // trailing digit glued to preceding word
         yield 'htmlParser5' => ['htmlParser5', 'html_parser5'];
+        yield 'Version2' => ['Version2', 'version2'];
+
+        // digit treated as lowercase — splits before subsequent uppercase
+        yield 'html5Parser' => ['html5Parser', 'html5_parser'];
+
+        // digit-letter acronym is ambiguous — `3D` is split because `3` behaves like lowercase
+        yield 'load3DModel' => ['load3DModel', 'load3_d_model'];
 
         // adjacent acronyms collapse — no information to split on
         yield 'getHTTPURL' => ['getHTTPURL', 'get_httpurl'];
+
+        // already snake_case stays as-is
+        yield 'already_snake' => ['already_snake', 'already_snake'];
+        yield 'foo_bar_baz' => ['foo_bar_baz', 'foo_bar_baz'];
+
+        // non-ASCII letters are not recognised as word characters by the regex
+        yield 'unicode lowercase preceding uppercase is not a boundary' => ['žlutýString', 'žlutýstring'];
+        yield 'ASCII lowercase preceding uppercase still splits around unicode' => ['čauString', 'čau_string'];
 
         // empty string
         yield 'empty' => ['', ''];

--- a/tests/Runtime/CamelToSnakeCaseMapperTest.php
+++ b/tests/Runtime/CamelToSnakeCaseMapperTest.php
@@ -1,0 +1,86 @@
+<?php declare(strict_types = 1);
+
+namespace ShipMonk\InputMapperTests\Runtime;
+
+use ShipMonk\InputMapper\Compiler\MapperFactory\DefaultMapperCompilerFactoryProvider;
+use ShipMonk\InputMapper\Compiler\PropertyNameTransformer\CamelToSnakeCasePropertyNameTransformer;
+use ShipMonk\InputMapper\Runtime\MapperProvider;
+use ShipMonk\InputMapperTests\InputMapperTestCase;
+use ShipMonk\InputMapperTests\Runtime\Data\AcronymCasedInput;
+use ShipMonk\InputMapperTests\Runtime\Data\CamelCasePropertiesInput;
+use ShipMonk\InputMapperTests\Runtime\Data\CamelCaseWithSourceKeyInput;
+use function sys_get_temp_dir;
+
+class CamelToSnakeCaseMapperTest extends InputMapperTestCase
+{
+
+    public function testCamelToSnakeCaseTransformerConvertsSimpleNames(): void
+    {
+        $transformer = new CamelToSnakeCasePropertyNameTransformer();
+        self::assertSame('first_name', $transformer->transform('firstName'));
+        self::assertSame('user_id', $transformer->transform('userId'));
+        self::assertSame('id', $transformer->transform('id'));
+        self::assertSame('url', $transformer->transform('url'));
+        self::assertSame('a', $transformer->transform('a'));
+    }
+
+    public function testCamelToSnakeCaseTransformerHandlesAcronyms(): void
+    {
+        $transformer = new CamelToSnakeCasePropertyNameTransformer();
+        self::assertSame('http_server', $transformer->transform('HTTPServer'));
+        self::assertSame('user_id_value', $transformer->transform('userIDValue'));
+        self::assertSame('parse_url', $transformer->transform('parseURL'));
+    }
+
+    public function testRoundTripAppliesSnakeCaseInBothDirections(): void
+    {
+        $provider = $this->createProvider();
+
+        $snakeCaseData = ['user_id' => 1, 'first_name' => 'John', 'last_name' => 'Doe'];
+        $object = $provider->getInputMapper(CamelCasePropertiesInput::class)->map($snakeCaseData);
+
+        self::assertSame(1, $object->userId);
+        self::assertSame('John', $object->firstName);
+        self::assertSame('Doe', $object->lastName);
+
+        self::assertSame($snakeCaseData, $provider->getOutputMapper(CamelCasePropertiesInput::class)->map($object));
+    }
+
+    public function testSourceKeyOverrideIsNotTransformed(): void
+    {
+        $provider = $this->createProvider();
+
+        $data = ['user_id' => 42, 'CustomKey' => 'Alice'];
+        $object = $provider->getInputMapper(CamelCaseWithSourceKeyInput::class)->map($data);
+
+        self::assertSame(42, $object->userId);
+        self::assertSame('Alice', $object->firstName);
+
+        self::assertSame($data, $provider->getOutputMapper(CamelCaseWithSourceKeyInput::class)->map($object));
+    }
+
+    public function testAcronymProperties(): void
+    {
+        $provider = $this->createProvider();
+
+        $data = ['http_server' => 'nginx', 'user_id_value' => 7];
+        $object = $provider->getInputMapper(AcronymCasedInput::class)->map($data);
+
+        self::assertSame('nginx', $object->HTTPServer);
+        self::assertSame(7, $object->userIDValue);
+
+        self::assertSame($data, $provider->getOutputMapper(AcronymCasedInput::class)->map($object));
+    }
+
+    private function createProvider(): MapperProvider
+    {
+        return new MapperProvider(
+            sys_get_temp_dir(),
+            autoRefresh: true,
+            mapperCompilerFactoryProvider: new DefaultMapperCompilerFactoryProvider(
+                new CamelToSnakeCasePropertyNameTransformer(),
+            ),
+        );
+    }
+
+}

--- a/tests/Runtime/CamelToSnakeCaseMapperTest.php
+++ b/tests/Runtime/CamelToSnakeCaseMapperTest.php
@@ -2,6 +2,7 @@
 
 namespace ShipMonk\InputMapperTests\Runtime;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use ShipMonk\InputMapper\Compiler\MapperFactory\DefaultMapperCompilerFactoryProvider;
 use ShipMonk\InputMapper\Compiler\PropertyNameTransformer\CamelToSnakeCasePropertyNameTransformer;
 use ShipMonk\InputMapper\Runtime\MapperProvider;
@@ -14,36 +15,95 @@ use function sys_get_temp_dir;
 class CamelToSnakeCaseMapperTest extends InputMapperTestCase
 {
 
-    public function testCamelToSnakeCaseTransformerConvertsSimpleNames(): void
+    #[DataProvider('provideTransformData')]
+    public function testTransform(
+        string $input,
+        string $expected,
+    ): void
     {
         $transformer = new CamelToSnakeCasePropertyNameTransformer();
-        self::assertSame('first_name', $transformer->transform('firstName'));
-        self::assertSame('user_id', $transformer->transform('userId'));
-        self::assertSame('id', $transformer->transform('id'));
-        self::assertSame('url', $transformer->transform('url'));
-        self::assertSame('a', $transformer->transform('a'));
+        self::assertSame($expected, $transformer->transform($input));
     }
 
-    public function testCamelToSnakeCaseTransformerHandlesAcronyms(): void
+    /**
+     * @return iterable<string, array{string, string}>
+     */
+    public static function provideTransformData(): iterable
     {
-        $transformer = new CamelToSnakeCasePropertyNameTransformer();
-        self::assertSame('http_server', $transformer->transform('HTTPServer'));
-        self::assertSame('user_id_value', $transformer->transform('userIDValue'));
-        self::assertSame('parse_url', $transformer->transform('parseURL'));
+        // simple camelCase
+        yield 'camelCase' => ['camelCase', 'camel_case'];
+        yield 'firstName' => ['firstName', 'first_name'];
+        yield 'userId' => ['userId', 'user_id'];
+        yield 'userName' => ['userName', 'user_name'];
+
+        // leading uppercase (PascalCase)
+        yield 'FirstName' => ['FirstName', 'first_name'];
+
+        // already lowercase / single word
+        yield 'id' => ['id', 'id'];
+        yield 'url' => ['url', 'url'];
+        yield 'a' => ['a', 'a'];
+
+        // single uppercase letter
+        yield 'A' => ['A', 'a'];
+
+        // whole identifier is an acronym
+        yield 'ID' => ['ID', 'id'];
+        yield 'API' => ['API', 'api'];
+
+        // acronym followed by a Word
+        yield 'HTTPServer' => ['HTTPServer', 'http_server'];
+        yield 'URLParser' => ['URLParser', 'url_parser'];
+
+        // word followed by trailing acronym
+        yield 'parseURL' => ['parseURL', 'parse_url'];
+        yield 'userID' => ['userID', 'user_id'];
+
+        // acronym in the middle
+        yield 'userIDValue' => ['userIDValue', 'user_id_value'];
+
+        // two-letter acronym at start
+        yield 'IOError' => ['IOError', 'io_error'];
+
+        // trailing digit glued to preceding word
+        yield 'htmlParser5' => ['htmlParser5', 'html_parser5'];
+
+        // adjacent acronyms collapse — no information to split on
+        yield 'getHTTPURL' => ['getHTTPURL', 'get_httpurl'];
+
+        // empty string
+        yield 'empty' => ['', ''];
     }
 
-    public function testRoundTripAppliesSnakeCaseInBothDirections(): void
+    /**
+     * @param class-string $className
+     * @param array<string, mixed> $snakeCaseData
+     */
+    #[DataProvider('provideRoundTripData')]
+    public function testRoundTrip(
+        string $className,
+        array $snakeCaseData,
+    ): void
     {
         $provider = $this->createProvider();
+        $object = $provider->getInputMapper($className)->map($snakeCaseData);
+        self::assertSame($snakeCaseData, $provider->getOutputMapper($className)->map($object));
+    }
 
-        $snakeCaseData = ['user_id' => 1, 'first_name' => 'John', 'last_name' => 'Doe'];
-        $object = $provider->getInputMapper(CamelCasePropertiesInput::class)->map($snakeCaseData);
+    /**
+     * @return iterable<string, array{class-string, array<string, mixed>}>
+     */
+    public static function provideRoundTripData(): iterable
+    {
+        yield 'plain camelCase properties' => [
+            CamelCasePropertiesInput::class,
+            ['user_id' => 1, 'first_name' => 'John', 'last_name' => 'Doe'],
+        ];
 
-        self::assertSame(1, $object->userId);
-        self::assertSame('John', $object->firstName);
-        self::assertSame('Doe', $object->lastName);
-
-        self::assertSame($snakeCaseData, $provider->getOutputMapper(CamelCasePropertiesInput::class)->map($object));
+        yield 'properties with embedded acronyms' => [
+            AcronymCasedInput::class,
+            ['http_server' => 'nginx', 'user_id_value' => 7],
+        ];
     }
 
     public function testSourceKeyOverrideIsNotTransformed(): void
@@ -57,19 +117,6 @@ class CamelToSnakeCaseMapperTest extends InputMapperTestCase
         self::assertSame('Alice', $object->firstName);
 
         self::assertSame($data, $provider->getOutputMapper(CamelCaseWithSourceKeyInput::class)->map($object));
-    }
-
-    public function testAcronymProperties(): void
-    {
-        $provider = $this->createProvider();
-
-        $data = ['http_server' => 'nginx', 'user_id_value' => 7];
-        $object = $provider->getInputMapper(AcronymCasedInput::class)->map($data);
-
-        self::assertSame('nginx', $object->HTTPServer);
-        self::assertSame(7, $object->userIDValue);
-
-        self::assertSame($data, $provider->getOutputMapper(AcronymCasedInput::class)->map($object));
     }
 
     private function createProvider(): MapperProvider

--- a/tests/Runtime/Data/AcronymCasedInput.php
+++ b/tests/Runtime/Data/AcronymCasedInput.php
@@ -1,0 +1,15 @@
+<?php declare(strict_types = 1);
+
+namespace ShipMonk\InputMapperTests\Runtime\Data;
+
+class AcronymCasedInput
+{
+
+    public function __construct(
+        public readonly string $HTTPServer,
+        public readonly int $userIDValue,
+    )
+    {
+    }
+
+}

--- a/tests/Runtime/Data/CamelCasePropertiesInput.php
+++ b/tests/Runtime/Data/CamelCasePropertiesInput.php
@@ -1,0 +1,16 @@
+<?php declare(strict_types = 1);
+
+namespace ShipMonk\InputMapperTests\Runtime\Data;
+
+class CamelCasePropertiesInput
+{
+
+    public function __construct(
+        public readonly int $userId,
+        public readonly string $firstName,
+        public readonly string $lastName,
+    )
+    {
+    }
+
+}

--- a/tests/Runtime/Data/CamelCaseWithSourceKeyInput.php
+++ b/tests/Runtime/Data/CamelCaseWithSourceKeyInput.php
@@ -1,0 +1,18 @@
+<?php declare(strict_types = 1);
+
+namespace ShipMonk\InputMapperTests\Runtime\Data;
+
+use ShipMonk\InputMapper\Compiler\Attribute\SourceKey;
+
+class CamelCaseWithSourceKeyInput
+{
+
+    public function __construct(
+        public readonly int $userId,
+        #[SourceKey('CustomKey')]
+        public readonly string $firstName,
+    )
+    {
+    }
+
+}

--- a/tests/Runtime/Data/PerClassOverrideInput.php
+++ b/tests/Runtime/Data/PerClassOverrideInput.php
@@ -1,0 +1,15 @@
+<?php declare(strict_types = 1);
+
+namespace ShipMonk\InputMapperTests\Runtime\Data;
+
+class PerClassOverrideInput
+{
+
+    public function __construct(
+        public readonly int $userId,
+        public readonly string $firstName,
+    )
+    {
+    }
+
+}


### PR DESCRIPTION
## Summary

Adds an optional `PropertyNameTransformer` that rewrites serialized keys in both mapping directions with a single global hook, instead of annotating every property with `#[SourceKey]`.

- New `PropertyNameTransformer` interface plumbed through `DefaultMapperCompilerFactoryProvider` → `DefaultMapperCompilerFactory`.
- Applied in `createConstructorArgsProviders()` (input) and `createPropertyProviders()` (output), so both directions stay symmetric.
- Explicit `#[SourceKey(...)]` always wins verbatim — the transformer is skipped when the attribute is present.
- Ships a `CamelToSnakeCasePropertyNameTransformer` built-in that also handles acronym boundaries (`HTTPServer` → `http_server`, `userIDValue` → `user_id_value`).
- The `MapperProvider` and `MapperCompilerFactoryProvider` interfaces are unchanged; users opt in by constructing the default factory provider with a transformer:

```php
new MapperProvider(
    $tempDir,
    autoRefresh: true,
    mapperCompilerFactoryProvider: new DefaultMapperCompilerFactoryProvider(
        new CamelToSnakeCasePropertyNameTransformer(),
    ),
);
```

## Test plan

- [x] Unit tests for `CamelToSnakeCasePropertyNameTransformer` (simple camelCase, acronyms)
- [x] Round-trip test: snake_case array → PHP object with camelCase properties → snake_case array
- [x] `#[SourceKey]` override test: key stays verbatim and is not transformed
- [x] `composer check` passes (CS, PHPStan level 9, 894 PHPUnit tests, coverage, composer-deps)