### PR TITLE
Remove dead ?? fallbacks on non-nullable GenericTypeDefinition properties

### DIFF
--- a/src/Compiler/Type/PhpDocTypeUtils.php
+++ b/src/Compiler/Type/PhpDocTypeUtils.php
@@ -744,7 +744,7 @@ class PhpDocTypeUtils
 
         $targetTypeDef = self::getGenericTypeDefinition(new IdentifierTypeNode($targetTypeName));
 
-        foreach ($targetTypeDef->extends ?? [] as $possibleTarget => $value) {
+        foreach ($targetTypeDef->extends as $possibleTarget => $value) {
             $innerPath = self::findDownCastPath($sourceTypeName, $possibleTarget);
 
             if ($innerPath !== null) {
@@ -774,7 +774,7 @@ class PhpDocTypeUtils
             throw new LogicException('Invalid downcast path');
         }
 
-        $targetTypeParameters = Arrays::map($targetTypeDef->parameters ?? [], static function (GenericTypeParameter $parameter): TypeNode {
+        $targetTypeParameters = Arrays::map($targetTypeDef->parameters, static function (GenericTypeParameter $parameter): TypeNode {
             return $parameter->default ?? $parameter->bound ?? new IdentifierTypeNode('mixed');
         });
 
@@ -794,7 +794,7 @@ class PhpDocTypeUtils
     {
         if (strcasecmp($a->type->name, $b->type->name) === 0) {
             $typeDef = self::getGenericTypeDefinition($a->type);
-            return Arrays::every($typeDef->parameters ?? [], static function (GenericTypeParameter $parameter, int $idx) use ($a, $b): bool {
+            return Arrays::every($typeDef->parameters, static function (GenericTypeParameter $parameter, int $idx) use ($a, $b): bool {
                 $genericTypeA = self::getGenericTypeParameter($a, $idx);
                 $genericTypeB = self::getGenericTypeParameter($b, $idx);
 


### PR DESCRIPTION
## Summary

`GenericTypeDefinition::\$extends` and `::\$parameters` are typed as non-nullable readonly arrays with `[]` defaults in the constructor, so the `?? []` fallbacks in `PhpDocTypeUtils` (lines 747, 777, 797) are unreachable. PHPStan's `nullCoalesce.property` rule — enabled by `bleedingEdge` in recent PHPStan releases — correctly flags them, which is breaking CI on every new PR.

This PR drops the three dead `?? []` expressions; behavior is unchanged.

## Test plan

- [x] `composer check` passes locally (CS, PHPStan level 9, 889 PHPUnit tests, coverage, composer-deps)
- [x] CI on this branch should now be green