### PR TITLE
Detect source key collisions from SourceKey and PropertyNameTransformer

### DIFF
--- a/src/Compiler/MapperFactory/DefaultMapperCompilerFactory.php
+++ b/src/Compiler/MapperFactory/DefaultMapperCompilerFactory.php
@@ -360,6 +360,10 @@ class DefaultMapperCompilerFactory implements MapperCompilerFactory
                 $name = $parameterName;
             }
 
+            if (isset($constructorArgsProviders[$name])) {
+                throw CannotCreateMapperCompilerException::fromType($inputType, "multiple constructor parameters map to source key '{$name}'");
+            }
+
             $constructorArgsProviders[$name] = $this->createParameterMapperCompilerProvider($parameter, $type, $options);
         }
 
@@ -385,6 +389,7 @@ class DefaultMapperCompilerFactory implements MapperCompilerFactory
         $constructorTypesByClass = [];
 
         $propertyProviders = [];
+        $outputKeys = [];
 
         foreach ($classReflection->getProperties(ReflectionProperty::IS_PUBLIC) as $property) {
             if (!$property->isReadOnly()) {
@@ -417,6 +422,12 @@ class DefaultMapperCompilerFactory implements MapperCompilerFactory
             } else {
                 $outputKey = $propertyName;
             }
+
+            if (isset($outputKeys[$outputKey])) {
+                throw CannotCreateMapperCompilerException::fromType($inputType, "multiple properties map to source key '{$outputKey}'");
+            }
+
+            $outputKeys[$outputKey] = true;
 
             $provider = $this->createPropertyMapperCompilerProvider($property, $type, $options);
 

--- a/tests/Compiler/MapperFactory/Data/InputWithConflictingPropertySourceKeys.php
+++ b/tests/Compiler/MapperFactory/Data/InputWithConflictingPropertySourceKeys.php
@@ -1,0 +1,25 @@
+<?php declare(strict_types = 1);
+
+namespace ShipMonk\InputMapperTests\Compiler\MapperFactory\Data;
+
+use ShipMonk\InputMapper\Compiler\Attribute\SourceKey;
+
+class InputWithConflictingPropertySourceKeys
+{
+
+    #[SourceKey('value')]
+    public readonly int $firstValue;
+
+    #[SourceKey('value')]
+    public readonly int $secondValue;
+
+    public function __construct(
+        int $firstValue,
+        int $secondValue,
+    )
+    {
+        $this->firstValue = $firstValue;
+        $this->secondValue = $secondValue;
+    }
+
+}

--- a/tests/Compiler/MapperFactory/Data/InputWithConflictingSourceKeys.php
+++ b/tests/Compiler/MapperFactory/Data/InputWithConflictingSourceKeys.php
@@ -1,0 +1,20 @@
+<?php declare(strict_types = 1);
+
+namespace ShipMonk\InputMapperTests\Compiler\MapperFactory\Data;
+
+use ShipMonk\InputMapper\Compiler\Attribute\SourceKey;
+
+class InputWithConflictingSourceKeys
+{
+
+    public function __construct(
+        #[SourceKey('value')]
+        public readonly int $firstValue,
+
+        #[SourceKey('value')]
+        public readonly int $secondValue,
+    )
+    {
+    }
+
+}

--- a/tests/Compiler/MapperFactory/Data/InputWithSourceKeyCollidingWithPlainProperty.php
+++ b/tests/Compiler/MapperFactory/Data/InputWithSourceKeyCollidingWithPlainProperty.php
@@ -1,0 +1,19 @@
+<?php declare(strict_types = 1);
+
+namespace ShipMonk\InputMapperTests\Compiler\MapperFactory\Data;
+
+use ShipMonk\InputMapper\Compiler\Attribute\SourceKey;
+
+class InputWithSourceKeyCollidingWithPlainProperty
+{
+
+    public function __construct(
+        #[SourceKey('value')]
+        public readonly int $renamedValue,
+
+        public readonly int $value,
+    )
+    {
+    }
+
+}

--- a/tests/Compiler/MapperFactory/Data/InputWithTransformerCollidingKeys.php
+++ b/tests/Compiler/MapperFactory/Data/InputWithTransformerCollidingKeys.php
@@ -1,0 +1,15 @@
+<?php declare(strict_types = 1);
+
+namespace ShipMonk\InputMapperTests\Compiler\MapperFactory\Data;
+
+class InputWithTransformerCollidingKeys
+{
+
+    public function __construct(
+        public readonly int $fooBar,
+        public readonly int $foo_bar,
+    )
+    {
+    }
+
+}

--- a/tests/Compiler/MapperFactory/DefaultMapperCompilerFactoryTest.php
+++ b/tests/Compiler/MapperFactory/DefaultMapperCompilerFactoryTest.php
@@ -47,6 +47,8 @@ use ShipMonk\InputMapper\Compiler\Mapper\Output\ObjectOutputMapperCompiler;
 use ShipMonk\InputMapper\Compiler\Mapper\Output\OptionalOutputMapperCompiler;
 use ShipMonk\InputMapper\Compiler\Mapper\PassthroughMapperCompiler;
 use ShipMonk\InputMapper\Compiler\MapperFactory\DefaultMapperCompilerFactory;
+use ShipMonk\InputMapper\Compiler\PropertyNameTransformer\CamelToSnakeCasePropertyNameTransformer;
+use ShipMonk\InputMapper\Compiler\PropertyNameTransformer\PropertyNameTransformer;
 use ShipMonk\InputMapper\Compiler\Type\GenericTypeParameter;
 use ShipMonk\InputMapper\Compiler\Validator\Array\AssertListLength;
 use ShipMonk\InputMapper\Compiler\Validator\Int\AssertInt32;
@@ -75,6 +77,7 @@ use ShipMonk\InputMapperTests\Compiler\MapperFactory\Data\ColorEnum;
 use ShipMonk\InputMapperTests\Compiler\MapperFactory\Data\EnumFilterInput;
 use ShipMonk\InputMapperTests\Compiler\MapperFactory\Data\EqualsFilterInput;
 use ShipMonk\InputMapperTests\Compiler\MapperFactory\Data\InFilterInput;
+use ShipMonk\InputMapperTests\Compiler\MapperFactory\Data\InputWithConflictingSourceKeys;
 use ShipMonk\InputMapperTests\Compiler\MapperFactory\Data\InputWithDate;
 use ShipMonk\InputMapperTests\Compiler\MapperFactory\Data\InputWithIncompatibleDefaultValue;
 use ShipMonk\InputMapperTests\Compiler\MapperFactory\Data\InputWithIncompatibleMapperCompiler;
@@ -82,6 +85,8 @@ use ShipMonk\InputMapperTests\Compiler\MapperFactory\Data\InputWithIncompatibleV
 use ShipMonk\InputMapperTests\Compiler\MapperFactory\Data\InputWithoutConstructor;
 use ShipMonk\InputMapperTests\Compiler\MapperFactory\Data\InputWithPrivateConstructor;
 use ShipMonk\InputMapperTests\Compiler\MapperFactory\Data\InputWithRenamedSourceKey;
+use ShipMonk\InputMapperTests\Compiler\MapperFactory\Data\InputWithSourceKeyCollidingWithPlainProperty;
+use ShipMonk\InputMapperTests\Compiler\MapperFactory\Data\InputWithTransformerCollidingKeys;
 use ShipMonk\InputMapperTests\InputMapperTestCase;
 
 class DefaultMapperCompilerFactoryTest extends InputMapperTestCase
@@ -727,6 +732,30 @@ class DefaultMapperCompilerFactoryTest extends InputMapperTestCase
             [],
             'Cannot create mapper with validator %s, because mapper output type %s is not compatible with validator input type %s',
         ];
+
+        yield 'InputWithConflictingSourceKeys' => [
+            InputWithConflictingSourceKeys::class,
+            [],
+            "Cannot create mapper for type ShipMonk\\InputMapperTests\\Compiler\\MapperFactory\\Data\\InputWithConflictingSourceKeys, because multiple constructor parameters map to source key 'value'",
+        ];
+
+        yield 'InputWithSourceKeyCollidingWithPlainProperty' => [
+            InputWithSourceKeyCollidingWithPlainProperty::class,
+            [],
+            "Cannot create mapper for type ShipMonk\\InputMapperTests\\Compiler\\MapperFactory\\Data\\InputWithSourceKeyCollidingWithPlainProperty, because multiple constructor parameters map to source key 'value'",
+        ];
+    }
+
+    public function testCreateErrorWithPropertyNameTransformerCollision(): void
+    {
+        $factory = self::createFactory(new CamelToSnakeCasePropertyNameTransformer());
+        $phpDocType = self::parseType(InputWithTransformerCollidingKeys::class);
+
+        self::assertException(
+            CannotCreateMapperCompilerException::class,
+            "Cannot create mapper for type ShipMonk\\InputMapperTests\\Compiler\\MapperFactory\\Data\\InputWithTransformerCollidingKeys, because multiple constructor parameters map to source key 'foo_bar'",
+            static fn () => $factory->create($phpDocType),
+        );
     }
 
     public function testCreateWithCustomFactory(): void
@@ -746,7 +775,7 @@ class DefaultMapperCompilerFactoryTest extends InputMapperTestCase
         self::assertSame($customProvider, $factory->create($phpDocType));
     }
 
-    private static function createFactory(): DefaultMapperCompilerFactory
+    private static function createFactory(?PropertyNameTransformer $propertyNameTransformer = null): DefaultMapperCompilerFactory
     {
         $config = new ParserConfig([]);
         $phpDocLexer = new Lexer($config);
@@ -754,7 +783,7 @@ class DefaultMapperCompilerFactoryTest extends InputMapperTestCase
         $phpDocTypeParser = new TypeParser($config, $phpDocConstExprParser);
         $phpDocParser = new PhpDocParser($config, $phpDocTypeParser, $phpDocConstExprParser);
 
-        return new DefaultMapperCompilerFactory($phpDocLexer, $phpDocParser);
+        return new DefaultMapperCompilerFactory($phpDocLexer, $phpDocParser, propertyNameTransformer: $propertyNameTransformer);
     }
 
     private static function parseType(string $type): TypeNode

--- a/tests/Compiler/MapperFactory/DefaultMapperCompilerFactoryTest.php
+++ b/tests/Compiler/MapperFactory/DefaultMapperCompilerFactoryTest.php
@@ -77,6 +77,7 @@ use ShipMonk\InputMapperTests\Compiler\MapperFactory\Data\ColorEnum;
 use ShipMonk\InputMapperTests\Compiler\MapperFactory\Data\EnumFilterInput;
 use ShipMonk\InputMapperTests\Compiler\MapperFactory\Data\EqualsFilterInput;
 use ShipMonk\InputMapperTests\Compiler\MapperFactory\Data\InFilterInput;
+use ShipMonk\InputMapperTests\Compiler\MapperFactory\Data\InputWithConflictingPropertySourceKeys;
 use ShipMonk\InputMapperTests\Compiler\MapperFactory\Data\InputWithConflictingSourceKeys;
 use ShipMonk\InputMapperTests\Compiler\MapperFactory\Data\InputWithDate;
 use ShipMonk\InputMapperTests\Compiler\MapperFactory\Data\InputWithIncompatibleDefaultValue;
@@ -743,6 +744,12 @@ class DefaultMapperCompilerFactoryTest extends InputMapperTestCase
             InputWithSourceKeyCollidingWithPlainProperty::class,
             [],
             "Cannot create mapper for type ShipMonk\\InputMapperTests\\Compiler\\MapperFactory\\Data\\InputWithSourceKeyCollidingWithPlainProperty, because multiple constructor parameters map to source key 'value'",
+        ];
+
+        yield 'InputWithConflictingPropertySourceKeys' => [
+            InputWithConflictingPropertySourceKeys::class,
+            [],
+            "Cannot create mapper for type ShipMonk\\InputMapperTests\\Compiler\\MapperFactory\\Data\\InputWithConflictingPropertySourceKeys, because multiple properties map to source key 'value'",
         ];
     }
 


### PR DESCRIPTION
## Summary
- Throw `CannotCreateMapperCompilerException` when two constructor parameters or readonly properties resolve to the same source key, instead of silently overwriting one mapper with another.
- Covers all collision paths: duplicate `#[SourceKey]` values, a `#[SourceKey]` colliding with a plain property name, and a `PropertyNameTransformer` producing the same key for two distinct properties.

## Test plan
- [x] `composer check` (CS + PHPStan level 9 + PHPUnit) passes locally