### PR TITLE
Make PropertyNameTransformer accessible to DefaultMapperCompilerFactoryProvider subclasses

### DIFF
--- a/src/Compiler/MapperFactory/DefaultMapperCompilerFactoryProvider.php
+++ b/src/Compiler/MapperFactory/DefaultMapperCompilerFactoryProvider.php
@@ -15,7 +15,7 @@ class DefaultMapperCompilerFactoryProvider implements MapperCompilerFactoryProvi
     private ?MapperCompilerFactory $mapperCompilerFactory = null;
 
     public function __construct(
-        private readonly ?PropertyNameTransformer $propertyNameTransformer = null,
+        protected readonly ?PropertyNameTransformer $propertyNameTransformer = null,
     )
     {
     }

--- a/tests/Runtime/CamelToSnakeCaseMapperTest.php
+++ b/tests/Runtime/CamelToSnakeCaseMapperTest.php
@@ -3,7 +3,9 @@
 namespace ShipMonk\InputMapperTests\Runtime;
 
 use PHPUnit\Framework\Attributes\DataProvider;
+use ShipMonk\InputMapper\Compiler\MapperFactory\DefaultMapperCompilerFactory;
 use ShipMonk\InputMapper\Compiler\MapperFactory\DefaultMapperCompilerFactoryProvider;
+use ShipMonk\InputMapper\Compiler\MapperFactory\MapperCompilerFactory;
 use ShipMonk\InputMapper\Compiler\PropertyNameTransformer\CamelToSnakeCasePropertyNameTransformer;
 use ShipMonk\InputMapper\Compiler\PropertyNameTransformer\PropertyNameTransformer;
 use ShipMonk\InputMapper\Runtime\MapperProvider;
@@ -167,6 +169,38 @@ class CamelToSnakeCaseMapperTest extends InputMapperTestCase
         self::assertSame('John', $object->firstName);
 
         self::assertSame($data, $provider->getOutputMapper(PerClassOverrideInput::class)->map($object));
+    }
+
+    public function testSubclassCreateOverrideCanForwardTransformer(): void
+    {
+        $compilerFactoryProvider = new class (new CamelToSnakeCasePropertyNameTransformer()) extends DefaultMapperCompilerFactoryProvider {
+
+            protected function create(): MapperCompilerFactory
+            {
+                $config = $this->createParserConfig();
+
+                return new DefaultMapperCompilerFactory(
+                    $this->createPhpDocLexer($config),
+                    $this->createPhpDocParser($config),
+                    [],
+                    $this->propertyNameTransformer,
+                );
+            }
+
+        };
+
+        $provider = new MapperProvider(
+            sys_get_temp_dir(),
+            autoRefresh: true,
+            mapperCompilerFactoryProvider: $compilerFactoryProvider,
+        );
+
+        $data = ['user_id' => 1, 'first_name' => 'John', 'last_name' => 'Doe'];
+        $object = $provider->getInputMapper(CamelCasePropertiesInput::class)->map($data);
+
+        self::assertSame(1, $object->userId);
+        self::assertSame('John', $object->firstName);
+        self::assertSame('Doe', $object->lastName);
     }
 
     private function createProvider(): MapperProvider


### PR DESCRIPTION
## Problem

`DefaultMapperCompilerFactoryProvider` is designed for extension: `create()` is protected, and the class ships protected helpers (`createParserConfig()`, `createPhpDocLexer()`, `createPhpDocParser()`) whose only purpose is to be used by subclass `create()` overrides that construct a custom `MapperCompilerFactory`. However, the constructor stored the transformer privately:

```php
public function __construct(
    private readonly ?PropertyNameTransformer $propertyNameTransformer = null,
)
```

So any subclass overriding `create()` — i.e. every realistic subclass — cannot read the transformer and silently drops it when constructing its custom factory. A consumer wiring `new MySubclassProvider(new CamelToSnakeCasePropertyNameTransformer())` gets a factory with no key transformation and no error: inputs quietly expect camelCase keys instead of snake_case. The only workaround is redeclaring the constructor and shadowing the property.

## Fix

Widen the constructor property to `protected readonly`. This is the minimal change and matches how `DefaultMapperCompilerFactory` itself already declares the same property (`protected readonly` in its constructor). No BC break for callers; the property name merely becomes part of the API for extenders.

## Test

Added a test where an anonymous subclass overrides `create()` to build the factory from `$this->propertyNameTransformer`, then asserts via a compiled mapper that snake_case input keys map onto camelCase constructor parameters. This pins the contract that subclass overrides can forward the transformer.

Co-Authored-By: Claude Code