### PR TITLE
Guard AssertIntRange type narrowing against int overflow at extreme bounds

### DIFF
--- a/src/Compiler/Validator/Int/AssertIntRange.php
+++ b/src/Compiler/Validator/Int/AssertIntRange.php
@@ -109,11 +109,11 @@ class AssertIntRange implements NarrowingValidatorCompiler
         }
 
         if ($this->gt !== null) {
-            $inclusiveLowerBounds[] = $this->gt + 1;
+            $inclusiveLowerBounds[] = $this->gt === PHP_INT_MAX ? PHP_INT_MAX : $this->gt + 1;
         }
 
         if ($this->lt !== null) {
-            $inclusiveUpperBounds[] = $this->lt - 1;
+            $inclusiveUpperBounds[] = $this->lt === PHP_INT_MIN ? PHP_INT_MIN : $this->lt - 1;
         }
 
         if ($this->lte !== null) {

--- a/tests/Compiler/Validator/Int/AssertIntRangeTest.php
+++ b/tests/Compiler/Validator/Int/AssertIntRangeTest.php
@@ -191,6 +191,16 @@ class AssertIntRangeTest extends ValidatorCompilerTestCase
             new AssertIntRange(gte: PHP_INT_MIN, lte: PHP_INT_MAX),
             'int',
         ];
+
+        yield [
+            new AssertIntRange(gt: PHP_INT_MAX),
+            'int<9223372036854775807, max>',
+        ];
+
+        yield [
+            new AssertIntRange(lt: PHP_INT_MIN),
+            'int<min, -9223372036854775808>',
+        ];
     }
 
 }


### PR DESCRIPTION
## Problem

`AssertIntRange::getNarrowedType()` converts exclusive bounds to inclusive ones with `$this->gt + 1` / `$this->lt - 1`. At the extremes these silently overflow to `float`:

- `AssertIntRange(gt: PHP_INT_MAX)` → `$this->gt + 1` becomes a float → emitted type `int<9.2233720368548E+18, max>`
- `AssertIntRange(lt: PHP_INT_MIN)` → `$this->lt - 1` becomes a float → emitted type `int<min, -9.2233720368548E+18>`

That malformed PHPDoc type leaks into the generated mapper's docblock.

## Fix

Clamp the exclusive-to-inclusive conversion at the extremes:

```php
$inclusiveLowerBounds[] = $this->gt === PHP_INT_MAX ? PHP_INT_MAX : $this->gt + 1;
$inclusiveUpperBounds[] = $this->lt === PHP_INT_MIN ? PHP_INT_MIN : $this->lt - 1;
```

`gt: PHP_INT_MAX` admits no integers, so `int<9223372036854775807, max>` is a sound (supertype-of-empty-set) and well-formed result. Runtime validation in `compile()` compares against the raw bounds without arithmetic and is unaffected — left unchanged.

## Tests

Two data-provider cases added to `provideGetNarrowedInputTypeData()` pinning the exact overflow inputs (`gt: PHP_INT_MAX`, `lt: PHP_INT_MIN`). Reverting the fix makes exactly these two cases fail with the float-formatted bound, confirming they pin the behavior.

`composer check` passes (927 tests, PHPStan level 9, CS, coverage-guard). No generated snapshot files changed.

Co-Authored-By: Claude Code