### PR TITLE
Support class-constant integer boundaries in int<min, max> ranges

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Input Mapper comes with built-in mappers for the following types:
 
 All built-in mappers support both input (array → object) and output (object → array) directions.
 
-The `int<TMin, TMax>` boundaries may be integer literals (`int<1, 10>`), the `min`/`max` keywords, or integer constants — both class constants (`int<1, Foo::MAX>`) and global constants (`int<0, PHP_INT_MAX>`).
+The `int<TMin, TMax>` boundaries may be integer literals (`int<1, 10>`), the `min`/`max` keywords, or integer class constants (`int<1, Foo::MAX>`). Global constants (e.g. `int<0, PHP_INT_MAX>`) are not supported.
 
 You can write your own mappers or replace the default mappers with your own.
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ Input Mapper comes with built-in mappers for the following types:
 
 All built-in mappers support both input (array → object) and output (object → array) directions.
 
+The `int<TMin, TMax>` boundaries may be integer literals (`int<1, 10>`), the `min`/`max` keywords, or integer constants — both class constants (`int<1, Foo::MAX>`) and global constants (`int<0, PHP_INT_MAX>`).
+
 You can write your own mappers or replace the default mappers with your own.
 
 ### Built-in validators

--- a/src/Compiler/MapperFactory/DefaultMapperCompilerFactory.php
+++ b/src/Compiler/MapperFactory/DefaultMapperCompilerFactory.php
@@ -8,6 +8,7 @@ use DateTimeInterface;
 use LogicException;
 use PHPStan\PhpDocParser\Ast\ConstExpr\ConstExprIntegerNode;
 use PHPStan\PhpDocParser\Ast\ConstExpr\ConstExprStringNode;
+use PHPStan\PhpDocParser\Ast\ConstExpr\ConstFetchNode;
 use PHPStan\PhpDocParser\Ast\PhpDoc\ParamTagValueNode;
 use PHPStan\PhpDocParser\Ast\PhpDoc\PhpDocNode;
 use PHPStan\PhpDocParser\Ast\PhpDoc\PhpDocTagNode;
@@ -73,9 +74,12 @@ use function array_map;
 use function class_exists;
 use function class_implements;
 use function class_parents;
+use function constant;
 use function count;
+use function defined;
 use function interface_exists;
 use function is_array;
+use function is_int;
 use function strtolower;
 use function substr;
 
@@ -665,6 +669,18 @@ class DefaultMapperCompilerFactory implements MapperCompilerFactory
     {
         if ($boundaryType instanceof ConstTypeNode && $boundaryType->constExpr instanceof ConstExprIntegerNode) {
             return (int) $boundaryType->constExpr->value;
+        }
+
+        if ($boundaryType instanceof ConstTypeNode && $boundaryType->constExpr instanceof ConstFetchNode) {
+            $constantName = (string) $boundaryType->constExpr;
+
+            if (defined($constantName)) {
+                $constantValue = constant($constantName);
+
+                if (is_int($constantValue)) {
+                    return $constantValue;
+                }
+            }
         }
 
         if ($boundaryType instanceof IdentifierTypeNode && $boundaryType->name === $extremeName) {

--- a/src/Compiler/MapperFactory/DefaultMapperCompilerFactory.php
+++ b/src/Compiler/MapperFactory/DefaultMapperCompilerFactory.php
@@ -6,16 +6,13 @@ use BackedEnum;
 use DateTimeImmutable;
 use DateTimeInterface;
 use LogicException;
-use PHPStan\PhpDocParser\Ast\ConstExpr\ConstExprIntegerNode;
 use PHPStan\PhpDocParser\Ast\ConstExpr\ConstExprStringNode;
-use PHPStan\PhpDocParser\Ast\ConstExpr\ConstFetchNode;
 use PHPStan\PhpDocParser\Ast\PhpDoc\ParamTagValueNode;
 use PHPStan\PhpDocParser\Ast\PhpDoc\PhpDocNode;
 use PHPStan\PhpDocParser\Ast\PhpDoc\PhpDocTagNode;
 use PHPStan\PhpDocParser\Ast\PhpDoc\VarTagValueNode;
 use PHPStan\PhpDocParser\Ast\Type\ArrayShapeNode;
 use PHPStan\PhpDocParser\Ast\Type\ArrayTypeNode;
-use PHPStan\PhpDocParser\Ast\Type\ConstTypeNode;
 use PHPStan\PhpDocParser\Ast\Type\GenericTypeNode;
 use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
 use PHPStan\PhpDocParser\Ast\Type\NullableTypeNode;
@@ -74,12 +71,9 @@ use function array_map;
 use function class_exists;
 use function class_implements;
 use function class_parents;
-use function constant;
 use function count;
-use function defined;
 use function interface_exists;
 use function is_array;
-use function is_int;
 use function strtolower;
 use function substr;
 
@@ -667,20 +661,10 @@ class DefaultMapperCompilerFactory implements MapperCompilerFactory
         string $extremeName,
     ): ?int
     {
-        if ($boundaryType instanceof ConstTypeNode && $boundaryType->constExpr instanceof ConstExprIntegerNode) {
-            return (int) $boundaryType->constExpr->value;
-        }
+        $boundaryValue = PhpDocTypeUtils::tryResolveIntegerBoundary($boundaryType);
 
-        if ($boundaryType instanceof ConstTypeNode && $boundaryType->constExpr instanceof ConstFetchNode) {
-            $constantName = (string) $boundaryType->constExpr;
-
-            if (defined($constantName)) {
-                $constantValue = constant($constantName);
-
-                if (is_int($constantValue)) {
-                    return $constantValue;
-                }
-            }
+        if ($boundaryValue !== null) {
+            return $boundaryValue;
         }
 
         if ($boundaryType instanceof IdentifierTypeNode && $boundaryType->name === $extremeName) {

--- a/src/Compiler/Type/PhpDocTypeUtils.php
+++ b/src/Compiler/Type/PhpDocTypeUtils.php
@@ -56,6 +56,7 @@ use function array_values;
 use function class_exists;
 use function constant;
 use function count;
+use function defined;
 use function get_debug_type;
 use function get_object_vars;
 use function in_array;
@@ -357,6 +358,10 @@ class PhpDocTypeUtils
         } elseif ($type instanceof ArrayShapeItemNode) {
             self::resolve($type->valueType, $context, $genericParameterNames); // intentionally not resolving key type
 
+        } elseif ($type instanceof ConstFetchNode) {
+            if ($type->className !== '' && !in_array($type->className, $genericParameterNames, true)) {
+                $type->className = Reflection::expandClassName($type->className, $context); // @phpstan-ignore argument.type (expandClassName expects ReflectionClass<object>, ReflectionClass<covariant object> given; Nette should use covariant too)
+            }
         } elseif (is_object($type)) {
             foreach (get_object_vars($type) as $item) {
                 self::resolve($item, $context, $genericParameterNames);
@@ -1167,6 +1172,18 @@ class PhpDocTypeUtils
     {
         if ($boundaryType instanceof ConstTypeNode && $boundaryType->constExpr instanceof ConstExprIntegerNode) {
             return (int) $boundaryType->constExpr->value;
+        }
+
+        if ($boundaryType instanceof ConstTypeNode && $boundaryType->constExpr instanceof ConstFetchNode) {
+            $constantName = (string) $boundaryType->constExpr;
+
+            if (defined($constantName)) {
+                $constantValue = constant($constantName);
+
+                if (is_int($constantValue)) {
+                    return $constantValue;
+                }
+            }
         }
 
         if ($boundaryType instanceof IdentifierTypeNode && $boundaryType->name === $extremeName) {

--- a/src/Compiler/Type/PhpDocTypeUtils.php
+++ b/src/Compiler/Type/PhpDocTypeUtils.php
@@ -1164,26 +1164,41 @@ class PhpDocTypeUtils
         return $type;
     }
 
+    /**
+     * Resolves an integer literal or integer class constant boundary of `int<min, max>` to its value.
+     */
+    public static function tryResolveIntegerBoundary(TypeNode $boundaryType): ?int
+    {
+        if (!$boundaryType instanceof ConstTypeNode) {
+            return null;
+        }
+
+        if ($boundaryType->constExpr instanceof ConstExprIntegerNode) {
+            return (int) $boundaryType->constExpr->value;
+        }
+
+        if ($boundaryType->constExpr instanceof ConstFetchNode) {
+            $constantName = (string) $boundaryType->constExpr;
+
+            if (defined($constantName)) {
+                $constantValue = constant($constantName);
+                return is_int($constantValue) ? $constantValue : null;
+            }
+        }
+
+        return null;
+    }
+
     private static function resolveIntegerBoundary(
         TypeNode $boundaryType,
         string $extremeName,
         int $extremeValue,
     ): int
     {
-        if ($boundaryType instanceof ConstTypeNode && $boundaryType->constExpr instanceof ConstExprIntegerNode) {
-            return (int) $boundaryType->constExpr->value;
-        }
+        $boundaryValue = self::tryResolveIntegerBoundary($boundaryType);
 
-        if ($boundaryType instanceof ConstTypeNode && $boundaryType->constExpr instanceof ConstFetchNode) {
-            $constantName = (string) $boundaryType->constExpr;
-
-            if (defined($constantName)) {
-                $constantValue = constant($constantName);
-
-                if (is_int($constantValue)) {
-                    return $constantValue;
-                }
-            }
+        if ($boundaryValue !== null) {
+            return $boundaryValue;
         }
 
         if ($boundaryType instanceof IdentifierTypeNode && $boundaryType->name === $extremeName) {

--- a/tests/Compiler/MapperFactory/Data/InputWithConstantIntRange.php
+++ b/tests/Compiler/MapperFactory/Data/InputWithConstantIntRange.php
@@ -1,0 +1,17 @@
+<?php declare(strict_types = 1);
+
+namespace ShipMonk\InputMapperTests\Compiler\MapperFactory\Data;
+
+class InputWithConstantIntRange
+{
+
+    /**
+     * @param int<1, IntRangeLimit::MAX> $quantity
+     */
+    public function __construct(
+        public readonly int $quantity,
+    )
+    {
+    }
+
+}

--- a/tests/Compiler/MapperFactory/Data/IntRangeLimit.php
+++ b/tests/Compiler/MapperFactory/Data/IntRangeLimit.php
@@ -1,0 +1,10 @@
+<?php declare(strict_types = 1);
+
+namespace ShipMonk\InputMapperTests\Compiler\MapperFactory\Data;
+
+class IntRangeLimit
+{
+
+    public const MAX = 10_000_000;
+
+}

--- a/tests/Compiler/MapperFactory/DefaultMapperCompilerFactoryTest.php
+++ b/tests/Compiler/MapperFactory/DefaultMapperCompilerFactoryTest.php
@@ -79,6 +79,7 @@ use ShipMonk\InputMapperTests\Compiler\MapperFactory\Data\EqualsFilterInput;
 use ShipMonk\InputMapperTests\Compiler\MapperFactory\Data\InFilterInput;
 use ShipMonk\InputMapperTests\Compiler\MapperFactory\Data\InputWithConflictingPropertySourceKeys;
 use ShipMonk\InputMapperTests\Compiler\MapperFactory\Data\InputWithConflictingSourceKeys;
+use ShipMonk\InputMapperTests\Compiler\MapperFactory\Data\InputWithConstantIntRange;
 use ShipMonk\InputMapperTests\Compiler\MapperFactory\Data\InputWithDate;
 use ShipMonk\InputMapperTests\Compiler\MapperFactory\Data\InputWithIncompatibleDefaultValue;
 use ShipMonk\InputMapperTests\Compiler\MapperFactory\Data\InputWithIncompatibleMapperCompiler;
@@ -88,6 +89,7 @@ use ShipMonk\InputMapperTests\Compiler\MapperFactory\Data\InputWithPrivateConstr
 use ShipMonk\InputMapperTests\Compiler\MapperFactory\Data\InputWithRenamedSourceKey;
 use ShipMonk\InputMapperTests\Compiler\MapperFactory\Data\InputWithSourceKeyCollidingWithPlainProperty;
 use ShipMonk\InputMapperTests\Compiler\MapperFactory\Data\InputWithTransformerCollidingKeys;
+use ShipMonk\InputMapperTests\Compiler\MapperFactory\Data\IntRangeLimit;
 use ShipMonk\InputMapperTests\InputMapperTestCase;
 
 class DefaultMapperCompilerFactoryTest extends InputMapperTestCase
@@ -163,6 +165,20 @@ class DefaultMapperCompilerFactoryTest extends InputMapperTestCase
                     ),
                 ],
                 allowExtraKeys: true,
+            ),
+        ];
+
+        yield 'InputWithConstantIntRange' => [
+            InputWithConstantIntRange::class,
+            [],
+            new ObjectInputMapperCompiler(
+                InputWithConstantIntRange::class,
+                [
+                    'quantity' => new ValidatedInputMapperCompiler(
+                        new IntInputMapperCompiler(),
+                        [new AssertIntRange(gte: 1, lte: IntRangeLimit::MAX)],
+                    ),
+                ],
             ),
         ];
 
@@ -714,6 +730,12 @@ class DefaultMapperCompilerFactoryTest extends InputMapperTestCase
             'int<foo, bar>',
             [],
             'Cannot create mapper for type int<foo, bar>, because integer boundary foo is not supported',
+        ];
+
+        yield 'int<1, DateTimeInterface::ATOM>' => [
+            'int<1, DateTimeInterface::ATOM>',
+            [],
+            'Cannot create mapper for type int<1, DateTimeInterface::ATOM>, because integer boundary DateTimeInterface::ATOM is not supported',
         ];
 
         yield 'EnumFilterInput<int>' => [

--- a/tests/Compiler/Type/PhpDocTypeUtilsTest.php
+++ b/tests/Compiler/Type/PhpDocTypeUtilsTest.php
@@ -10,9 +10,12 @@ use PhpParser\Node\Identifier;
 use PhpParser\Node\Name;
 use PhpParser\Node\NullableType;
 use PhpParser\Node\UnionType;
+use PHPStan\PhpDocParser\Ast\ConstExpr\ConstExprIntegerNode;
+use PHPStan\PhpDocParser\Ast\ConstExpr\ConstFetchNode;
 use PHPStan\PhpDocParser\Ast\Type\ArrayShapeItemNode;
 use PHPStan\PhpDocParser\Ast\Type\ArrayShapeNode;
 use PHPStan\PhpDocParser\Ast\Type\ArrayTypeNode;
+use PHPStan\PhpDocParser\Ast\Type\ConstTypeNode;
 use PHPStan\PhpDocParser\Ast\Type\GenericTypeNode;
 use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
 use PHPStan\PhpDocParser\Ast\Type\IntersectionTypeNode;
@@ -560,6 +563,16 @@ class PhpDocTypeUtilsTest extends InputMapperTestCase
             new ReflectionClass(self::class),
             ['T'],
             '(T | string)',
+        ];
+
+        yield 'int<1, TestCase::CONSTANT>' => [
+            new GenericTypeNode(new IdentifierTypeNode('int'), [
+                new ConstTypeNode(new ConstExprIntegerNode('1')),
+                new ConstTypeNode(new ConstFetchNode('TestCase', 'CONSTANT')),
+            ]),
+            new ReflectionClass(self::class),
+            [],
+            'int<1, PHPUnit\\Framework\\TestCase::CONSTANT>',
         ];
     }
 


### PR DESCRIPTION
## Summary

Allow **class integer constants** as boundaries in `int<min, max>` ranges, e.g.:

```php
final class ReceiveInput
{
    /**
     * @param int<1, Transaction::MAX_QUANTITY> $quantity
     */
    public function __construct(
        public int $quantity,
    ) {}
}
```

Today this throws during mapper compilation:

```
Cannot create mapper for type int<1, Transaction::MAX_QUANTITY>,
because integer boundary Transaction::MAX_QUANTITY is not supported
```

…so the only workaround is to inline the magic number (`int<1, 10000000>`) and lose the symbolic reference. PHPStan already understands class-constant boundaries in `int<...>`, so the mapper compiler rejecting them is a surprising gap.

## What changed

Two small pieces, both scoped to the existing integer-boundary handling:

1. **`PhpDocTypeUtils::resolve()`** now expands the class name of a class-constant boundary (`ConstFetchNode`) to its FQN. The resolver already walks the type AST but skipped `ConstFetchNode`, so `Foo::BAR` reached the compiler with the unresolved short name and `constant()` could not find it.
2. **`resolveIntegerBoundary()`** — in both `DefaultMapperCompilerFactory` and `PhpDocTypeUtils` (the latter is reached via `isSubTypeOf()` when the factory validates the mapper output type against the declared parameter type) — now evaluates an **integer** class constant boundary and uses its value.

A non-integer constant (e.g. a string class constant) still falls through to the existing *"integer boundary … is not supported"* error, so no misuse is silently accepted.

### Scope: class constants only

Only **class constants** are supported. Global constants (e.g. `int<0, PHP_INT_MAX>`) are **not** supported: they parse as an `IdentifierTypeNode` rather than a `ConstFetchNode`, so `resolveIntegerBoundary()` never evaluates them and they still error with *"integer boundary PHP_INT_MAX is not supported"*. The README documents this limitation.

## Tests

- `PhpDocTypeUtilsTest::provideResolveData` — a `ConstFetchNode` class name is expanded to its FQN.
- `DefaultMapperCompilerFactoryTest`:
  - `int<1, IntRangeLimit::MAX>` compiles to `AssertIntRange(gte: 1, lte: IntRangeLimit::MAX)` (new `InputWithConstantIntRange` / `IntRangeLimit` fixtures).
  - `int<1, DateTimeInterface::ATOM>` (non-integer constant) still errors.
- README: documented that `int<TMin, TMax>` boundaries may be integer literals, `min`/`max`, or integer class constants, and that global constants are not supported.

`composer check` (composer-normalize, editorconfig, phpcs, phpstan, coverage, dependency-analyser) and the full test suite pass locally on PHP 8.5.
