### PR TITLE
Add Codec support: bidirectional custom mapping between intermediate and domain types

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,6 +295,183 @@ class Truck extends Vehicle {
 }
 ```
 
+### Custom mapping with Codecs
+
+Codecs are the primary way to provide custom bidirectional mapping for classes that don't follow the standard public-constructor pattern. A codec converts between an intermediate type (that the library knows how to map from/to `mixed`) and your domain type.
+
+Implement the `Codec` interface with two methods: `decode()` for input and `encode()` for output:
+
+```php
+use ShipMonk\InputMapper\Runtime\Codec;
+use ShipMonk\InputMapper\Runtime\Exception\MappingFailedException;
+
+class Money
+{
+    public function __construct(
+        public readonly string $currency,
+        public readonly int $cents,
+    ) {}
+}
+
+/**
+ * @implements Codec<array{currency: string, cents: int}, Money>
+ */
+class MoneyCodec implements Codec
+{
+    public function decode(mixed $data, array $path = []): Money
+    {
+        if ($data['cents'] < 0) {
+            throw MappingFailedException::incorrectValue($data['cents'], [...$path, 'cents'], 'non-negative integer');
+        }
+
+        return new Money($data['currency'], $data['cents']);
+    }
+
+    public function encode(mixed $data, array $path = []): array
+    {
+        return ['currency' => $data->currency, 'cents' => $data->cents];
+    }
+}
+```
+
+Then register the codec with the mapper provider:
+
+```php
+$mapperProvider->registerCodec(new MoneyCodec());
+
+// Now Money can be used as a field type in any mapped class
+$inputMapper = $mapperProvider->getInputMapper(Money::class);
+$money = $inputMapper->map(['currency' => 'USD', 'cents' => 1299]);
+
+$outputMapper = $mapperProvider->getOutputMapper(Money::class);
+$data = $outputMapper->map($money); // ['currency' => 'USD', 'cents' => 1299]
+```
+
+The library auto-compiles the `mixed → intermediate` bridge (e.g. validating that the input is `array{currency: string, cents: int}`). Your codec only handles the `intermediate → domain` conversion.
+
+The codec's domain classes are inferred from its generic parameters. When resolving a codec for a class, the class hierarchy is walked from the most specific type to the least specific one, and at each level registered codecs take precedence over type-based mapper compiler factories (such as the built-in `DateTimeInterface` handling). Registering two codecs claiming the same domain class is an error. Codecs must be registered before the first mapper is compiled — and note that compiled mappers are cached on disk, so without `autoRefresh: true` changing codec registrations does not invalidate previously compiled mappers.
+
+#### Parameterized Codecs (Codec Factories)
+
+For generic codecs that handle a family of classes, use `registerCodecFactory()`. The factory receives the concrete class name at runtime:
+
+```php
+use ShipMonk\InputMapper\Runtime\Codec;
+use ShipMonk\InputMapper\Runtime\CodecRegistry;
+
+abstract class TypedId
+{
+    public function __construct(public readonly string $value) {}
+}
+
+class AccountId extends TypedId {}
+class OrderId extends TypedId {}
+
+/**
+ * @template T of TypedId
+ * @implements Codec<string, T>
+ */
+class TypedIdCodec implements Codec
+{
+    /** @param class-string<T> $className */
+    public function __construct(private readonly string $className) {}
+
+    public static function create(string $className, CodecRegistry $registry): self
+    {
+        return new self($className);
+    }
+
+    public function decode(mixed $data, array $path = []): TypedId
+    {
+        return new ($this->className)($data);
+    }
+
+    public function encode(mixed $data, array $path = []): string
+    {
+        return $data->value;
+    }
+}
+
+$mapperProvider->registerCodecFactory(TypedIdCodec::class, TypedIdCodec::create(...));
+
+// Both AccountId and OrderId are now automatically mapped via TypedIdCodec
+$accountId = $mapperProvider->getInputMapper(AccountId::class)->map('acc-123');
+```
+
+#### Asymmetric Codecs
+
+Codecs support asymmetric types — you can decode into one type and encode from a different (typically wider) type. The full signature is `Codec<DI, EI, DO, EO>` where `DI`/`EO` are intermediate types and `EI`/`DO` are domain types, with defaults `DO = EI` and `EO = DI` for the common symmetric case.
+
+```php
+use ShipMonk\InputMapper\Runtime\Codec;
+
+/**
+ * Decode: string → DateTimeImmutable
+ * Encode: DateTimeInterface → string
+ *
+ * @implements Codec<string, DateTimeInterface, DateTimeImmutable, string>
+ */
+class DateTimeInterfaceCodec implements Codec
+{
+    public function decode(mixed $data, array $path = []): DateTimeImmutable
+    {
+        return new DateTimeImmutable($data);
+    }
+
+    public function encode(mixed $data, array $path = []): string
+    {
+        return $data->format('c');
+    }
+}
+```
+
+#### Codecs as attributes
+
+Instead of registering a codec globally, you can apply a codec to a single property. Mark the codec class itself with `#[Attribute]` and use it directly:
+
+```php
+use ShipMonk\InputMapper\Compiler\Attribute\MapCodec;
+use ShipMonk\InputMapper\Compiler\Attribute\MapNullable;
+
+class EventInput
+{
+    public function __construct(
+        #[DateTimeFormatCodec(format: 'Y-m-d')]
+        public readonly DateTimeImmutable $date,
+
+        #[MapNullable(new MapCodec(new DateTimeFormatCodec(format: 'Y-m-d\TH:i:sP')))]
+        public readonly ?DateTimeImmutable $startsAt,
+    ) {}
+}
+```
+
+To compose a codec with other mapper attributes (like `MapNullable` above), wrap it in `MapCodec` — or let the codec class implement `MapperCompilerProvider` itself by delegating to `MapCodec`, so it can be nested directly:
+
+```php
+use ShipMonk\InputMapper\Compiler\Attribute\MapCodec;
+use ShipMonk\InputMapper\Compiler\Mapper\MapperCompiler;
+use ShipMonk\InputMapper\Compiler\Mapper\MapperCompilerProvider;
+use ShipMonk\InputMapper\Compiler\MapperFactory\MapperCompilerFactory;
+
+#[Attribute(Attribute::TARGET_PARAMETER | Attribute::TARGET_PROPERTY)]
+class DateTimeFormatCodec implements Codec, MapperCompilerProvider
+{
+    // ... decode() and encode() as usual ...
+
+    public function getInputMapperCompiler(MapperCompilerFactory $mapperCompilerFactory, array $options): MapperCompiler
+    {
+        return (new MapCodec($this))->getInputMapperCompiler($mapperCompilerFactory, $options);
+    }
+
+    public function getOutputMapperCompiler(MapperCompilerFactory $mapperCompilerFactory, array $options): MapperCompiler
+    {
+        return (new MapCodec($this))->getOutputMapperCompiler($mapperCompilerFactory, $options);
+    }
+}
+```
+
+Codecs used as attributes are re-instantiated inside the generated mapper, so all their constructor arguments must be scalar or null values readable from properties of the same name.
+
 ### Using custom mappers
 
 To map a class with your own hand-written mapper, implement the `Mapper` interface and register a factory for the class with `MapperProvider`:

--- a/README.md
+++ b/README.md
@@ -349,7 +349,9 @@ $data = $outputMapper->map($money); // ['currency' => 'USD', 'cents' => 1299]
 
 The library auto-compiles the `mixed → intermediate` bridge (e.g. validating that the input is `array{currency: string, cents: int}`). Your codec only handles the `intermediate → domain` conversion.
 
-The codec's domain classes are inferred from its generic parameters. When resolving a codec for a class, the class hierarchy is walked from the most specific type to the least specific one, and at each level registered codecs take precedence over type-based mapper compiler factories (such as the built-in `DateTimeInterface` handling). Registering two codecs claiming the same domain class is an error. Codecs must be registered before the first mapper is compiled — and note that compiled mappers are cached on disk, so without `autoRefresh: true` changing codec registrations does not invalidate previously compiled mappers.
+The codec's domain classes are inferred from its generic parameters (an `@implements` annotation inherited from a parent class works too). When resolving a codec for a class, the class hierarchy is walked from the most specific type to the least specific one, and at each level registered codecs take precedence over type-based mapper compiler factories (such as the built-in `DateTimeInterface` handling). Hand-written mappers registered via `registerInputFactory()` / `registerOutputFactory()` take precedence over codecs. Registering two codecs claiming the same domain class is an error, as is registering a codec whose domain type cannot be resolved to a class or interface.
+
+Register codecs before compiling mappers: a mapper already compiled for a domain class does not observe later codec registrations — whether it is loaded in the current process or cached on disk (mappers are cached per domain class name, and with `autoRefresh` disabled the cached file is reused even if codec registrations changed, which can mean either silently skipped codec validation or a runtime `LogicException` about an unregistered codec).
 
 #### Parameterized Codecs (Codec Factories)
 
@@ -471,6 +473,8 @@ class DateTimeFormatCodec implements Codec, MapperCompilerProvider
 ```
 
 Codecs used as attributes are re-instantiated inside the generated mapper, so all their constructor arguments must be scalar or null values readable from properties of the same name.
+
+A codec attribute that wants to provide its own mapper compilers must implement the full `MapperCompilerProvider` interface (both directions, as above); a codec implementing neither provider interface is wrapped in `MapCodec` automatically. Multiple codec attributes on one promoted constructor property are chained: decoding applies them in declaration order, encoding in reverse order.
 
 ### Using custom mappers
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,5 +1,47 @@
 # Upgrading Guide
 
+## From 2.x to 3.0 (Codecs)
+
+This release introduces **codecs** — user-defined bidirectional conversions between an intermediate wire type and a domain type (see the README section "Custom mapping with Codecs"). Supporting codec attributes that compose with other mapper attributes required extending the mapper compiler provider SPI.
+
+### Breaking Changes
+
+#### 1. `InputMapperCompilerProvider` / `OutputMapperCompilerProvider` methods receive the factory and options
+
+Providers sometimes need to compile a mapper for a type they only know at provide-time (e.g. a codec's intermediate type). Both SPI methods now receive the `MapperCompilerFactory` and the current options:
+
+```php
+// before
+public function getInputMapperCompiler(): MapperCompiler;
+public function getOutputMapperCompiler(): MapperCompiler;
+
+// after
+public function getInputMapperCompiler(MapperCompilerFactory $mapperCompilerFactory, array $options): MapperCompiler;
+public function getOutputMapperCompiler(MapperCompilerFactory $mapperCompilerFactory, array $options): MapperCompiler;
+```
+
+If you implement custom attributes, update the signatures and pass both arguments along when delegating to inner providers.
+
+#### 2. `MapperCompilerFactoryProvider::get()` receives the codec registry
+
+```php
+// before
+public function get(): MapperCompilerFactory;
+
+// after
+public function get(?CodecRegistry $codecRegistry = null): MapperCompilerFactory;
+```
+
+`MapperProvider` passes its codec registry to the factory provider when compiling mappers. Custom implementations should forward the registry to `DefaultMapperCompilerFactory` (or handle codec resolution themselves).
+
+#### 3. Protected API changes in `DefaultMapperCompilerFactory` and `DefaultMapperCompilerFactoryProvider`
+
+Relevant only for subclasses:
+
+- `DefaultMapperCompilerFactory::__construct()` gained a `CodecRegistry $codecRegistry` parameter.
+- `DefaultMapperCompilerFactory::addValidatorProvider()` gained an `array $options` parameter.
+- `DefaultMapperCompilerFactoryProvider::create()` gained a `?CodecRegistry $codecRegistry` parameter.
+
 ## From 0.x to 1.0 (Bidirectional Mapping)
 
 This release introduces **output mapping** (object → scalar) alongside the existing input mapping (scalar → object). This required significant architectural changes: attribute classes are now separated from compiler classes, mapper compilers are organized by direction (input/output), and the runtime supports both input and output mappers.

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -22,17 +22,17 @@ public function getOutputMapperCompiler(MapperCompilerFactory $mapperCompilerFac
 
 If you implement custom attributes, update the signatures and pass both arguments along when delegating to inner providers.
 
-#### 2. `MapperCompilerFactoryProvider::get()` receives the codec registry
+#### 2. `MapperCompilerFactoryProvider` gains `getCodecRegistry()`
 
 ```php
-// before
-public function get(): MapperCompilerFactory;
-
-// after
-public function get(?CodecRegistry $codecRegistry = null): MapperCompilerFactory;
+interface MapperCompilerFactoryProvider
+{
+    public function get(): MapperCompilerFactory;
+    public function getCodecRegistry(): CodecRegistry; // new
+}
 ```
 
-`MapperProvider` passes its codec registry to the factory provider when compiling mappers. Custom implementations should forward the registry to `DefaultMapperCompilerFactory` (or handle codec resolution themselves).
+The factory provider owns the codec registry (like it owns the rest of the compile-time configuration); `MapperProvider::registerCodec()` / `registerCodecFactory()` / `getCodec()` delegate to it, so the compiled mappers and the runtime codec lookup always share one registry. `DefaultMapperCompilerFactoryProvider` accepts an optional `CodecRegistry` in its constructor and creates one by default.
 
 #### 3. Protected API changes in `DefaultMapperCompilerFactory` and `DefaultMapperCompilerFactoryProvider`
 
@@ -40,7 +40,8 @@ Relevant only for subclasses:
 
 - `DefaultMapperCompilerFactory::__construct()` gained a `CodecRegistry $codecRegistry` parameter.
 - `DefaultMapperCompilerFactory::addValidatorProvider()` gained an `array $options` parameter.
-- `DefaultMapperCompilerFactoryProvider::create()` gained a `?CodecRegistry $codecRegistry` parameter.
+- `DefaultMapperCompilerFactoryProvider` subclasses overriding `create()` should pass `$this->codecRegistry` to the factory they construct.
+- The `DELEGATE_OBJECT_MAPPING` and `GENERIC_PARAMETERS` option constants moved from `DefaultMapperCompilerFactory` to the `MapperCompilerFactory` interface (references through the class keep working).
 
 ## From 0.x to 1.0 (Bidirectional Mapping)
 

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -41,6 +41,13 @@ parameters:
             identifier: throws.unusedType
             paths: [tests/**/Data/*.php]
         -
+            identifiers:
+                - property.uninitialized
+                - property.unused
+                - constructor.unusedParameter
+                - shipmonk.deadProperty.neverWritten
+            path: tests/Compiler/Mapper/Codec/Data/UninitPropCodec.php
+        -
             message: '#throws checked exception ShipMonk\\InputMapper\\Runtime\\Exception\\MappingFailedException but it''s missing from the PHPDoc @throws tag\.#'
             paths: [tests/**/*Test.php]
         -

--- a/src-dev/PHPStan/IgnoreDeadInterfaceUsageProvider.php
+++ b/src-dev/PHPStan/IgnoreDeadInterfaceUsageProvider.php
@@ -3,8 +3,10 @@
 namespace ShipMonk\InputMapperDev\PHPStan;
 
 use ReflectionMethod;
+use ShipMonk\InputMapper\Runtime\Codec;
 use ShipMonk\PHPStan\DeadCode\Provider\ReflectionBasedMemberUsageProvider;
 use ShipMonk\PHPStan\DeadCode\Provider\VirtualUsageData;
+use function in_array;
 
 class IgnoreDeadInterfaceUsageProvider extends ReflectionBasedMemberUsageProvider
 {
@@ -13,6 +15,13 @@ class IgnoreDeadInterfaceUsageProvider extends ReflectionBasedMemberUsageProvide
     {
         if ($method->getDeclaringClass()->isInterface() || $method->isAbstract()) {
             return VirtualUsageData::withNote('interface methods kept for unification');
+        }
+
+        if (
+            in_array($method->getName(), ['decode', 'encode'], true)
+            && $method->getDeclaringClass()->implementsInterface(Codec::class)
+        ) {
+            return VirtualUsageData::withNote('codec methods are invoked by generated mappers');
         }
 
         return null;

--- a/src/Compiler/Attribute/MapArray.php
+++ b/src/Compiler/Attribute/MapArray.php
@@ -6,8 +6,8 @@ use Attribute;
 use ShipMonk\InputMapper\Compiler\Mapper\Input\ArrayInputMapperCompiler;
 use ShipMonk\InputMapper\Compiler\Mapper\MapperCompiler;
 use ShipMonk\InputMapper\Compiler\Mapper\MapperCompilerProvider;
-use ShipMonk\InputMapper\Compiler\MapperFactory\MapperCompilerFactory;
 use ShipMonk\InputMapper\Compiler\Mapper\Output\ArrayOutputMapperCompiler;
+use ShipMonk\InputMapper\Compiler\MapperFactory\MapperCompilerFactory;
 
 #[Attribute(Attribute::TARGET_PARAMETER | Attribute::TARGET_PROPERTY)]
 class MapArray implements MapperCompilerProvider

--- a/src/Compiler/Attribute/MapArray.php
+++ b/src/Compiler/Attribute/MapArray.php
@@ -6,6 +6,7 @@ use Attribute;
 use ShipMonk\InputMapper\Compiler\Mapper\Input\ArrayInputMapperCompiler;
 use ShipMonk\InputMapper\Compiler\Mapper\MapperCompiler;
 use ShipMonk\InputMapper\Compiler\Mapper\MapperCompilerProvider;
+use ShipMonk\InputMapper\Compiler\MapperFactory\MapperCompilerFactory;
 use ShipMonk\InputMapper\Compiler\Mapper\Output\ArrayOutputMapperCompiler;
 
 #[Attribute(Attribute::TARGET_PARAMETER | Attribute::TARGET_PROPERTY)]
@@ -19,19 +20,25 @@ class MapArray implements MapperCompilerProvider
     {
     }
 
-    public function getInputMapperCompiler(): MapperCompiler
+    public function getInputMapperCompiler(
+        MapperCompilerFactory $mapperCompilerFactory,
+        array $options,
+    ): MapperCompiler
     {
         return new ArrayInputMapperCompiler(
-            $this->keyMapperCompilerProvider->getInputMapperCompiler(),
-            $this->valueMapperCompilerProvider->getInputMapperCompiler(),
+            $this->keyMapperCompilerProvider->getInputMapperCompiler($mapperCompilerFactory, $options),
+            $this->valueMapperCompilerProvider->getInputMapperCompiler($mapperCompilerFactory, $options),
         );
     }
 
-    public function getOutputMapperCompiler(): MapperCompiler
+    public function getOutputMapperCompiler(
+        MapperCompilerFactory $mapperCompilerFactory,
+        array $options,
+    ): MapperCompiler
     {
         return new ArrayOutputMapperCompiler(
-            $this->keyMapperCompilerProvider->getOutputMapperCompiler(),
-            $this->valueMapperCompilerProvider->getOutputMapperCompiler(),
+            $this->keyMapperCompilerProvider->getOutputMapperCompiler($mapperCompilerFactory, $options),
+            $this->valueMapperCompilerProvider->getOutputMapperCompiler($mapperCompilerFactory, $options),
         );
     }
 

--- a/src/Compiler/Attribute/MapArrayShape.php
+++ b/src/Compiler/Attribute/MapArrayShape.php
@@ -6,8 +6,8 @@ use Attribute;
 use ShipMonk\InputMapper\Compiler\Mapper\Input\ArrayShapeInputMapperCompiler;
 use ShipMonk\InputMapper\Compiler\Mapper\MapperCompiler;
 use ShipMonk\InputMapper\Compiler\Mapper\MapperCompilerProvider;
-use ShipMonk\InputMapper\Compiler\MapperFactory\MapperCompilerFactory;
 use ShipMonk\InputMapper\Compiler\Mapper\Output\ArrayShapeOutputMapperCompiler;
+use ShipMonk\InputMapper\Compiler\MapperFactory\MapperCompilerFactory;
 
 #[Attribute(Attribute::TARGET_PARAMETER | Attribute::TARGET_PROPERTY)]
 class MapArrayShape implements MapperCompilerProvider

--- a/src/Compiler/Attribute/MapArrayShape.php
+++ b/src/Compiler/Attribute/MapArrayShape.php
@@ -6,6 +6,7 @@ use Attribute;
 use ShipMonk\InputMapper\Compiler\Mapper\Input\ArrayShapeInputMapperCompiler;
 use ShipMonk\InputMapper\Compiler\Mapper\MapperCompiler;
 use ShipMonk\InputMapper\Compiler\Mapper\MapperCompilerProvider;
+use ShipMonk\InputMapper\Compiler\MapperFactory\MapperCompilerFactory;
 use ShipMonk\InputMapper\Compiler\Mapper\Output\ArrayShapeOutputMapperCompiler;
 
 #[Attribute(Attribute::TARGET_PARAMETER | Attribute::TARGET_PROPERTY)]
@@ -22,23 +23,29 @@ class MapArrayShape implements MapperCompilerProvider
     {
     }
 
-    public function getInputMapperCompiler(): MapperCompiler
+    public function getInputMapperCompiler(
+        MapperCompilerFactory $mapperCompilerFactory,
+        array $options,
+    ): MapperCompiler
     {
         $compilerItems = [];
 
         foreach ($this->items as $item) {
-            $compilerItems[] = ['key' => $item->key, 'mapper' => $item->mapper->getInputMapperCompiler(), 'optional' => $item->optional];
+            $compilerItems[] = ['key' => $item->key, 'mapper' => $item->mapper->getInputMapperCompiler($mapperCompilerFactory, $options), 'optional' => $item->optional];
         }
 
         return new ArrayShapeInputMapperCompiler($compilerItems, $this->sealed);
     }
 
-    public function getOutputMapperCompiler(): MapperCompiler
+    public function getOutputMapperCompiler(
+        MapperCompilerFactory $mapperCompilerFactory,
+        array $options,
+    ): MapperCompiler
     {
         $compilerItems = [];
 
         foreach ($this->items as $item) {
-            $compilerItems[] = ['key' => $item->key, 'mapper' => $item->mapper->getOutputMapperCompiler(), 'optional' => $item->optional];
+            $compilerItems[] = ['key' => $item->key, 'mapper' => $item->mapper->getOutputMapperCompiler($mapperCompilerFactory, $options), 'optional' => $item->optional];
         }
 
         return new ArrayShapeOutputMapperCompiler($compilerItems, $this->sealed);

--- a/src/Compiler/Attribute/MapBool.php
+++ b/src/Compiler/Attribute/MapBool.php
@@ -7,18 +7,25 @@ use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
 use ShipMonk\InputMapper\Compiler\Mapper\Input\BoolInputMapperCompiler;
 use ShipMonk\InputMapper\Compiler\Mapper\MapperCompiler;
 use ShipMonk\InputMapper\Compiler\Mapper\MapperCompilerProvider;
+use ShipMonk\InputMapper\Compiler\MapperFactory\MapperCompilerFactory;
 use ShipMonk\InputMapper\Compiler\Mapper\PassthroughMapperCompiler;
 
 #[Attribute(Attribute::TARGET_PARAMETER | Attribute::TARGET_PROPERTY)]
 class MapBool implements MapperCompilerProvider
 {
 
-    public function getInputMapperCompiler(): MapperCompiler
+    public function getInputMapperCompiler(
+        MapperCompilerFactory $mapperCompilerFactory,
+        array $options,
+    ): MapperCompiler
     {
         return new BoolInputMapperCompiler();
     }
 
-    public function getOutputMapperCompiler(): MapperCompiler
+    public function getOutputMapperCompiler(
+        MapperCompilerFactory $mapperCompilerFactory,
+        array $options,
+    ): MapperCompiler
     {
         return new PassthroughMapperCompiler(new IdentifierTypeNode('bool'));
     }

--- a/src/Compiler/Attribute/MapBool.php
+++ b/src/Compiler/Attribute/MapBool.php
@@ -7,8 +7,8 @@ use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
 use ShipMonk\InputMapper\Compiler\Mapper\Input\BoolInputMapperCompiler;
 use ShipMonk\InputMapper\Compiler\Mapper\MapperCompiler;
 use ShipMonk\InputMapper\Compiler\Mapper\MapperCompilerProvider;
-use ShipMonk\InputMapper\Compiler\MapperFactory\MapperCompilerFactory;
 use ShipMonk\InputMapper\Compiler\Mapper\PassthroughMapperCompiler;
+use ShipMonk\InputMapper\Compiler\MapperFactory\MapperCompilerFactory;
 
 #[Attribute(Attribute::TARGET_PARAMETER | Attribute::TARGET_PROPERTY)]
 class MapBool implements MapperCompilerProvider

--- a/src/Compiler/Attribute/MapChain.php
+++ b/src/Compiler/Attribute/MapChain.php
@@ -5,6 +5,7 @@ namespace ShipMonk\InputMapper\Compiler\Attribute;
 use ShipMonk\InputMapper\Compiler\Mapper\Input\ChainMapperCompiler;
 use ShipMonk\InputMapper\Compiler\Mapper\MapperCompiler;
 use ShipMonk\InputMapper\Compiler\Mapper\MapperCompilerProvider;
+use ShipMonk\InputMapper\Compiler\MapperFactory\MapperCompilerFactory;
 use function array_map;
 use function array_reverse;
 
@@ -20,21 +21,27 @@ class MapChain implements MapperCompilerProvider
     {
     }
 
-    public function getInputMapperCompiler(): MapperCompiler
+    public function getInputMapperCompiler(
+        MapperCompilerFactory $mapperCompilerFactory,
+        array $options,
+    ): MapperCompiler
     {
         return new ChainMapperCompiler(
             array_map(
-                static fn (MapperCompilerProvider $provider): MapperCompiler => $provider->getInputMapperCompiler(),
+                static fn (MapperCompilerProvider $provider): MapperCompiler => $provider->getInputMapperCompiler($mapperCompilerFactory, $options),
                 $this->providers,
             ),
         );
     }
 
-    public function getOutputMapperCompiler(): MapperCompiler
+    public function getOutputMapperCompiler(
+        MapperCompilerFactory $mapperCompilerFactory,
+        array $options,
+    ): MapperCompiler
     {
         return new ChainMapperCompiler(
             array_map(
-                static fn (MapperCompilerProvider $provider): MapperCompiler => $provider->getOutputMapperCompiler(),
+                static fn (MapperCompilerProvider $provider): MapperCompiler => $provider->getOutputMapperCompiler($mapperCompilerFactory, $options),
                 array_reverse($this->providers),
             ),
         );

--- a/src/Compiler/Attribute/MapCodec.php
+++ b/src/Compiler/Attribute/MapCodec.php
@@ -1,0 +1,107 @@
+<?php declare(strict_types = 1);
+
+namespace ShipMonk\InputMapper\Compiler\Attribute;
+
+use Attribute;
+use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
+use ReflectionClass;
+use ShipMonk\InputMapper\Compiler\Exception\CannotCreateMapperCompilerException;
+use ShipMonk\InputMapper\Compiler\Mapper\Codec\InlineCodecInputMapperCompiler;
+use ShipMonk\InputMapper\Compiler\Mapper\Codec\InlineCodecOutputMapperCompiler;
+use ShipMonk\InputMapper\Compiler\Mapper\MapperCompiler;
+use ShipMonk\InputMapper\Compiler\Mapper\MapperCompilerProvider;
+use ShipMonk\InputMapper\Compiler\MapperFactory\DefaultMapperCompilerFactory;
+use ShipMonk\InputMapper\Compiler\MapperFactory\MapperCompilerFactory;
+use ShipMonk\InputMapper\Compiler\Type\PhpDocTypeUtils;
+use ShipMonk\InputMapper\Runtime\Codec;
+use function get_debug_type;
+use function is_scalar;
+
+/**
+ * Maps a value with the given codec instance, re-instantiated inside the generated mapper.
+ *
+ * The codec is re-created from its constructor arguments at compile time,
+ * so all its constructor arguments must be scalar or null values readable from properties of the same name.
+ */
+#[Attribute(Attribute::TARGET_PARAMETER | Attribute::TARGET_PROPERTY)]
+class MapCodec implements MapperCompilerProvider
+{
+
+    /**
+     * @param Codec<*, *, *, *> $codec
+     */
+    public function __construct(
+        public readonly Codec $codec,
+    )
+    {
+    }
+
+    public function getInputMapperCompiler(
+        MapperCompilerFactory $mapperCompilerFactory,
+        array $options,
+    ): MapperCompiler
+    {
+        $codecType = new IdentifierTypeNode($this->codec::class);
+        $intermediateType = PhpDocTypeUtils::inferGenericParameter($codecType, Codec::class, 0);
+        $domainType = PhpDocTypeUtils::inferGenericParameter($codecType, Codec::class, 2);
+        $options[DefaultMapperCompilerFactory::DELEGATE_OBJECT_MAPPING] ??= true;
+
+        return new InlineCodecInputMapperCompiler(
+            $this->codec::class,
+            $this->extractCodecConstructorArgs(),
+            $mapperCompilerFactory->create($intermediateType, $options)->getInputMapperCompiler($mapperCompilerFactory, $options),
+            $domainType,
+        );
+    }
+
+    public function getOutputMapperCompiler(
+        MapperCompilerFactory $mapperCompilerFactory,
+        array $options,
+    ): MapperCompiler
+    {
+        $codecType = new IdentifierTypeNode($this->codec::class);
+        $domainType = PhpDocTypeUtils::inferGenericParameter($codecType, Codec::class, 1);
+        $intermediateType = PhpDocTypeUtils::inferGenericParameter($codecType, Codec::class, 3);
+        $options[DefaultMapperCompilerFactory::DELEGATE_OBJECT_MAPPING] ??= true;
+
+        return new InlineCodecOutputMapperCompiler(
+            $this->codec::class,
+            $this->extractCodecConstructorArgs(),
+            $mapperCompilerFactory->create($intermediateType, $options)->getOutputMapperCompiler($mapperCompilerFactory, $options),
+            $domainType,
+        );
+    }
+
+    /**
+     * @return array<string, scalar|null>
+     */
+    protected function extractCodecConstructorArgs(): array
+    {
+        $args = [];
+        $reflection = new ReflectionClass($this->codec);
+        $constructor = $reflection->getConstructor();
+
+        if ($constructor === null) {
+            return $args;
+        }
+
+        foreach ($constructor->getParameters() as $parameter) {
+            $parameterName = $parameter->getName();
+
+            if (!$reflection->hasProperty($parameterName)) {
+                throw CannotCreateMapperCompilerException::withUnsupportedCodecConstructorArgument($this->codec::class, $parameterName, 'has no matching property');
+            }
+
+            $value = $reflection->getProperty($parameterName)->getValue($this->codec);
+
+            if ($value !== null && !is_scalar($value)) {
+                throw CannotCreateMapperCompilerException::withUnsupportedCodecConstructorArgument($this->codec::class, $parameterName, 'must be a scalar or null value, got ' . get_debug_type($value));
+            }
+
+            $args[$parameterName] = $value;
+        }
+
+        return $args;
+    }
+
+}

--- a/src/Compiler/Attribute/MapCodec.php
+++ b/src/Compiler/Attribute/MapCodec.php
@@ -5,12 +5,12 @@ namespace ShipMonk\InputMapper\Compiler\Attribute;
 use Attribute;
 use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
 use ReflectionClass;
+use ReflectionProperty;
 use ShipMonk\InputMapper\Compiler\Exception\CannotCreateMapperCompilerException;
 use ShipMonk\InputMapper\Compiler\Mapper\Codec\InlineCodecInputMapperCompiler;
 use ShipMonk\InputMapper\Compiler\Mapper\Codec\InlineCodecOutputMapperCompiler;
 use ShipMonk\InputMapper\Compiler\Mapper\MapperCompiler;
 use ShipMonk\InputMapper\Compiler\Mapper\MapperCompilerProvider;
-use ShipMonk\InputMapper\Compiler\MapperFactory\DefaultMapperCompilerFactory;
 use ShipMonk\InputMapper\Compiler\MapperFactory\MapperCompilerFactory;
 use ShipMonk\InputMapper\Compiler\Type\PhpDocTypeUtils;
 use ShipMonk\InputMapper\Runtime\Codec;
@@ -44,7 +44,7 @@ class MapCodec implements MapperCompilerProvider
         $codecType = new IdentifierTypeNode($this->codec::class);
         $intermediateType = PhpDocTypeUtils::inferGenericParameter($codecType, Codec::class, 0);
         $domainType = PhpDocTypeUtils::inferGenericParameter($codecType, Codec::class, 2);
-        $options[DefaultMapperCompilerFactory::DELEGATE_OBJECT_MAPPING] ??= true;
+        $options[MapperCompilerFactory::DELEGATE_OBJECT_MAPPING] ??= true;
 
         return new InlineCodecInputMapperCompiler(
             $this->codec::class,
@@ -62,7 +62,7 @@ class MapCodec implements MapperCompilerProvider
         $codecType = new IdentifierTypeNode($this->codec::class);
         $domainType = PhpDocTypeUtils::inferGenericParameter($codecType, Codec::class, 1);
         $intermediateType = PhpDocTypeUtils::inferGenericParameter($codecType, Codec::class, 3);
-        $options[DefaultMapperCompilerFactory::DELEGATE_OBJECT_MAPPING] ??= true;
+        $options[MapperCompilerFactory::DELEGATE_OBJECT_MAPPING] ??= true;
 
         return new InlineCodecOutputMapperCompiler(
             $this->codec::class,
@@ -87,12 +87,18 @@ class MapCodec implements MapperCompilerProvider
 
         foreach ($constructor->getParameters() as $parameter) {
             $parameterName = $parameter->getName();
+            $property = $this->findCodecProperty($reflection, $parameterName)
+                ?? throw CannotCreateMapperCompilerException::withUnsupportedCodecConstructorArgument($this->codec::class, $parameterName, 'has no matching property');
 
-            if (!$reflection->hasProperty($parameterName)) {
-                throw CannotCreateMapperCompilerException::withUnsupportedCodecConstructorArgument($this->codec::class, $parameterName, 'has no matching property');
+            if ($property->isStatic()) {
+                throw CannotCreateMapperCompilerException::withUnsupportedCodecConstructorArgument($this->codec::class, $parameterName, 'matches a static property');
             }
 
-            $value = $reflection->getProperty($parameterName)->getValue($this->codec);
+            if (!$property->isInitialized($this->codec)) {
+                throw CannotCreateMapperCompilerException::withUnsupportedCodecConstructorArgument($this->codec::class, $parameterName, 'matches an uninitialized property');
+            }
+
+            $value = $property->getValue($this->codec);
 
             if ($value !== null && !is_scalar($value)) {
                 throw CannotCreateMapperCompilerException::withUnsupportedCodecConstructorArgument($this->codec::class, $parameterName, 'must be a scalar or null value, got ' . get_debug_type($value));
@@ -102,6 +108,27 @@ class MapCodec implements MapperCompilerProvider
         }
 
         return $args;
+    }
+
+    /**
+     * Finds a property in the codec class hierarchy, including private properties of parent classes.
+     *
+     * @param ReflectionClass<T> $class
+     *
+     * @template T of object
+     */
+    private function findCodecProperty(
+        ReflectionClass $class,
+        string $name,
+    ): ?ReflectionProperty
+    {
+        for ($current = $class; $current !== false; $current = $current->getParentClass()) {
+            if ($current->hasProperty($name)) {
+                return $current->getProperty($name);
+            }
+        }
+
+        return null;
     }
 
 }

--- a/src/Compiler/Attribute/MapDateTimeImmutable.php
+++ b/src/Compiler/Attribute/MapDateTimeImmutable.php
@@ -7,8 +7,8 @@ use DateTimeInterface;
 use ShipMonk\InputMapper\Compiler\Mapper\Input\DateTimeImmutableInputMapperCompiler;
 use ShipMonk\InputMapper\Compiler\Mapper\MapperCompiler;
 use ShipMonk\InputMapper\Compiler\Mapper\MapperCompilerProvider;
-use ShipMonk\InputMapper\Compiler\MapperFactory\MapperCompilerFactory;
 use ShipMonk\InputMapper\Compiler\Mapper\Output\DateTimeImmutableOutputMapperCompiler;
+use ShipMonk\InputMapper\Compiler\MapperFactory\MapperCompilerFactory;
 use function is_array;
 use function ltrim;
 

--- a/src/Compiler/Attribute/MapDateTimeImmutable.php
+++ b/src/Compiler/Attribute/MapDateTimeImmutable.php
@@ -7,6 +7,7 @@ use DateTimeInterface;
 use ShipMonk\InputMapper\Compiler\Mapper\Input\DateTimeImmutableInputMapperCompiler;
 use ShipMonk\InputMapper\Compiler\Mapper\MapperCompiler;
 use ShipMonk\InputMapper\Compiler\Mapper\MapperCompilerProvider;
+use ShipMonk\InputMapper\Compiler\MapperFactory\MapperCompilerFactory;
 use ShipMonk\InputMapper\Compiler\Mapper\Output\DateTimeImmutableOutputMapperCompiler;
 use function is_array;
 use function ltrim;
@@ -29,12 +30,18 @@ class MapDateTimeImmutable implements MapperCompilerProvider
     {
     }
 
-    public function getInputMapperCompiler(): MapperCompiler
+    public function getInputMapperCompiler(
+        MapperCompilerFactory $mapperCompilerFactory,
+        array $options,
+    ): MapperCompiler
     {
         return new DateTimeImmutableInputMapperCompiler($this->format, $this->formatDescription, $this->defaultTimezone, $this->targetTimezone);
     }
 
-    public function getOutputMapperCompiler(): MapperCompiler
+    public function getOutputMapperCompiler(
+        MapperCompilerFactory $mapperCompilerFactory,
+        array $options,
+    ): MapperCompiler
     {
         $outputFormat = is_array($this->format) ? $this->format[0] : $this->format;
         $outputFormat = ltrim($outputFormat, '!');

--- a/src/Compiler/Attribute/MapDefaultValue.php
+++ b/src/Compiler/Attribute/MapDefaultValue.php
@@ -6,6 +6,7 @@ use Attribute;
 use ShipMonk\InputMapper\Compiler\Mapper\Input\DefaultValueInputMapperCompiler;
 use ShipMonk\InputMapper\Compiler\Mapper\MapperCompiler;
 use ShipMonk\InputMapper\Compiler\Mapper\MapperCompilerProvider;
+use ShipMonk\InputMapper\Compiler\MapperFactory\MapperCompilerFactory;
 
 #[Attribute(Attribute::TARGET_PARAMETER | Attribute::TARGET_PROPERTY)]
 class MapDefaultValue implements MapperCompilerProvider
@@ -18,14 +19,20 @@ class MapDefaultValue implements MapperCompilerProvider
     {
     }
 
-    public function getInputMapperCompiler(): MapperCompiler
+    public function getInputMapperCompiler(
+        MapperCompilerFactory $mapperCompilerFactory,
+        array $options,
+    ): MapperCompiler
     {
-        return new DefaultValueInputMapperCompiler($this->mapperCompilerProvider->getInputMapperCompiler(), $this->defaultValue);
+        return new DefaultValueInputMapperCompiler($this->mapperCompilerProvider->getInputMapperCompiler($mapperCompilerFactory, $options), $this->defaultValue);
     }
 
-    public function getOutputMapperCompiler(): MapperCompiler
+    public function getOutputMapperCompiler(
+        MapperCompilerFactory $mapperCompilerFactory,
+        array $options,
+    ): MapperCompiler
     {
-        return $this->mapperCompilerProvider->getOutputMapperCompiler();
+        return $this->mapperCompilerProvider->getOutputMapperCompiler($mapperCompilerFactory, $options);
     }
 
 }

--- a/src/Compiler/Attribute/MapDelegate.php
+++ b/src/Compiler/Attribute/MapDelegate.php
@@ -6,6 +6,7 @@ use Attribute;
 use ShipMonk\InputMapper\Compiler\Mapper\Input\DelegateInputMapperCompiler;
 use ShipMonk\InputMapper\Compiler\Mapper\MapperCompiler;
 use ShipMonk\InputMapper\Compiler\Mapper\MapperCompilerProvider;
+use ShipMonk\InputMapper\Compiler\MapperFactory\MapperCompilerFactory;
 use ShipMonk\InputMapper\Compiler\Mapper\Output\DelegateOutputMapperCompiler;
 use function array_map;
 
@@ -24,19 +25,25 @@ class MapDelegate implements MapperCompilerProvider
     {
     }
 
-    public function getInputMapperCompiler(): MapperCompiler
+    public function getInputMapperCompiler(
+        MapperCompilerFactory $mapperCompilerFactory,
+        array $options,
+    ): MapperCompiler
     {
         return new DelegateInputMapperCompiler(
             $this->className,
-            array_map(static fn (MapperCompilerProvider $p): MapperCompiler => $p->getInputMapperCompiler(), $this->innerMapperCompilerProviders),
+            array_map(static fn (MapperCompilerProvider $p): MapperCompiler => $p->getInputMapperCompiler($mapperCompilerFactory, $options), $this->innerMapperCompilerProviders),
         );
     }
 
-    public function getOutputMapperCompiler(): MapperCompiler
+    public function getOutputMapperCompiler(
+        MapperCompilerFactory $mapperCompilerFactory,
+        array $options,
+    ): MapperCompiler
     {
         return new DelegateOutputMapperCompiler(
             $this->className,
-            array_map(static fn (MapperCompilerProvider $p): MapperCompiler => $p->getOutputMapperCompiler(), $this->innerMapperCompilerProviders),
+            array_map(static fn (MapperCompilerProvider $p): MapperCompiler => $p->getOutputMapperCompiler($mapperCompilerFactory, $options), $this->innerMapperCompilerProviders),
         );
     }
 

--- a/src/Compiler/Attribute/MapDelegate.php
+++ b/src/Compiler/Attribute/MapDelegate.php
@@ -6,8 +6,8 @@ use Attribute;
 use ShipMonk\InputMapper\Compiler\Mapper\Input\DelegateInputMapperCompiler;
 use ShipMonk\InputMapper\Compiler\Mapper\MapperCompiler;
 use ShipMonk\InputMapper\Compiler\Mapper\MapperCompilerProvider;
-use ShipMonk\InputMapper\Compiler\MapperFactory\MapperCompilerFactory;
 use ShipMonk\InputMapper\Compiler\Mapper\Output\DelegateOutputMapperCompiler;
+use ShipMonk\InputMapper\Compiler\MapperFactory\MapperCompilerFactory;
 use function array_map;
 
 #[Attribute(Attribute::TARGET_PARAMETER | Attribute::TARGET_PROPERTY)]

--- a/src/Compiler/Attribute/MapDiscriminatedObject.php
+++ b/src/Compiler/Attribute/MapDiscriminatedObject.php
@@ -5,8 +5,8 @@ namespace ShipMonk\InputMapper\Compiler\Attribute;
 use ShipMonk\InputMapper\Compiler\Mapper\Input\DiscriminatedObjectInputMapperCompiler;
 use ShipMonk\InputMapper\Compiler\Mapper\MapperCompiler;
 use ShipMonk\InputMapper\Compiler\Mapper\MapperCompilerProvider;
-use ShipMonk\InputMapper\Compiler\MapperFactory\MapperCompilerFactory;
 use ShipMonk\InputMapper\Compiler\Mapper\Output\DiscriminatedObjectOutputMapperCompiler;
+use ShipMonk\InputMapper\Compiler\MapperFactory\MapperCompilerFactory;
 use ShipMonk\InputMapper\Compiler\Type\GenericTypeParameter;
 use function array_map;
 

--- a/src/Compiler/Attribute/MapDiscriminatedObject.php
+++ b/src/Compiler/Attribute/MapDiscriminatedObject.php
@@ -5,6 +5,7 @@ namespace ShipMonk\InputMapper\Compiler\Attribute;
 use ShipMonk\InputMapper\Compiler\Mapper\Input\DiscriminatedObjectInputMapperCompiler;
 use ShipMonk\InputMapper\Compiler\Mapper\MapperCompiler;
 use ShipMonk\InputMapper\Compiler\Mapper\MapperCompilerProvider;
+use ShipMonk\InputMapper\Compiler\MapperFactory\MapperCompilerFactory;
 use ShipMonk\InputMapper\Compiler\Mapper\Output\DiscriminatedObjectOutputMapperCompiler;
 use ShipMonk\InputMapper\Compiler\Type\GenericTypeParameter;
 use function array_map;
@@ -29,25 +30,31 @@ class MapDiscriminatedObject implements MapperCompilerProvider
     {
     }
 
-    public function getInputMapperCompiler(): MapperCompiler
+    public function getInputMapperCompiler(
+        MapperCompilerFactory $mapperCompilerFactory,
+        array $options,
+    ): MapperCompiler
     {
         return new DiscriminatedObjectInputMapperCompiler(
             $this->className,
             $this->discriminatorKeyName,
             array_map(
-                static fn (MapperCompilerProvider $provider): MapperCompiler => $provider->getInputMapperCompiler(),
+                static fn (MapperCompilerProvider $provider): MapperCompiler => $provider->getInputMapperCompiler($mapperCompilerFactory, $options),
                 $this->subtypeProviders,
             ),
             $this->genericParameters,
         );
     }
 
-    public function getOutputMapperCompiler(): MapperCompiler
+    public function getOutputMapperCompiler(
+        MapperCompilerFactory $mapperCompilerFactory,
+        array $options,
+    ): MapperCompiler
     {
         return new DiscriminatedObjectOutputMapperCompiler(
             $this->className,
             array_map(
-                static fn (MapperCompilerProvider $provider): MapperCompiler => $provider->getOutputMapperCompiler(),
+                static fn (MapperCompilerProvider $provider): MapperCompiler => $provider->getOutputMapperCompiler($mapperCompilerFactory, $options),
                 $this->subtypeProviders,
             ),
             $this->genericParameters,

--- a/src/Compiler/Attribute/MapEnum.php
+++ b/src/Compiler/Attribute/MapEnum.php
@@ -8,6 +8,7 @@ use ShipMonk\InputMapper\Compiler\Mapper\Input\EnumInputMapperCompiler;
 use ShipMonk\InputMapper\Compiler\Mapper\InputMapperCompilerProvider;
 use ShipMonk\InputMapper\Compiler\Mapper\MapperCompiler;
 use ShipMonk\InputMapper\Compiler\Mapper\MapperCompilerProvider;
+use ShipMonk\InputMapper\Compiler\MapperFactory\MapperCompilerFactory;
 use ShipMonk\InputMapper\Compiler\Mapper\Output\EnumOutputMapperCompiler;
 
 #[Attribute(Attribute::TARGET_PARAMETER | Attribute::TARGET_PROPERTY)]
@@ -24,12 +25,18 @@ class MapEnum implements MapperCompilerProvider
     {
     }
 
-    public function getInputMapperCompiler(): MapperCompiler
+    public function getInputMapperCompiler(
+        MapperCompilerFactory $mapperCompilerFactory,
+        array $options,
+    ): MapperCompiler
     {
-        return new EnumInputMapperCompiler($this->enumName, $this->backingValueMapperCompilerProvider->getInputMapperCompiler());
+        return new EnumInputMapperCompiler($this->enumName, $this->backingValueMapperCompilerProvider->getInputMapperCompiler($mapperCompilerFactory, $options));
     }
 
-    public function getOutputMapperCompiler(): MapperCompiler
+    public function getOutputMapperCompiler(
+        MapperCompilerFactory $mapperCompilerFactory,
+        array $options,
+    ): MapperCompiler
     {
         return new EnumOutputMapperCompiler($this->enumName);
     }

--- a/src/Compiler/Attribute/MapEnum.php
+++ b/src/Compiler/Attribute/MapEnum.php
@@ -8,8 +8,8 @@ use ShipMonk\InputMapper\Compiler\Mapper\Input\EnumInputMapperCompiler;
 use ShipMonk\InputMapper\Compiler\Mapper\InputMapperCompilerProvider;
 use ShipMonk\InputMapper\Compiler\Mapper\MapperCompiler;
 use ShipMonk\InputMapper\Compiler\Mapper\MapperCompilerProvider;
-use ShipMonk\InputMapper\Compiler\MapperFactory\MapperCompilerFactory;
 use ShipMonk\InputMapper\Compiler\Mapper\Output\EnumOutputMapperCompiler;
+use ShipMonk\InputMapper\Compiler\MapperFactory\MapperCompilerFactory;
 
 #[Attribute(Attribute::TARGET_PARAMETER | Attribute::TARGET_PROPERTY)]
 class MapEnum implements MapperCompilerProvider

--- a/src/Compiler/Attribute/MapFloat.php
+++ b/src/Compiler/Attribute/MapFloat.php
@@ -7,6 +7,7 @@ use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
 use ShipMonk\InputMapper\Compiler\Mapper\Input\FloatInputMapperCompiler;
 use ShipMonk\InputMapper\Compiler\Mapper\MapperCompiler;
 use ShipMonk\InputMapper\Compiler\Mapper\MapperCompilerProvider;
+use ShipMonk\InputMapper\Compiler\MapperFactory\MapperCompilerFactory;
 use ShipMonk\InputMapper\Compiler\Mapper\PassthroughMapperCompiler;
 
 #[Attribute(Attribute::TARGET_PARAMETER | Attribute::TARGET_PROPERTY)]
@@ -20,12 +21,18 @@ class MapFloat implements MapperCompilerProvider
     {
     }
 
-    public function getInputMapperCompiler(): MapperCompiler
+    public function getInputMapperCompiler(
+        MapperCompilerFactory $mapperCompilerFactory,
+        array $options,
+    ): MapperCompiler
     {
         return new FloatInputMapperCompiler($this->allowInfinity, $this->allowNan);
     }
 
-    public function getOutputMapperCompiler(): MapperCompiler
+    public function getOutputMapperCompiler(
+        MapperCompilerFactory $mapperCompilerFactory,
+        array $options,
+    ): MapperCompiler
     {
         return new PassthroughMapperCompiler(new IdentifierTypeNode('float'));
     }

--- a/src/Compiler/Attribute/MapFloat.php
+++ b/src/Compiler/Attribute/MapFloat.php
@@ -7,8 +7,8 @@ use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
 use ShipMonk\InputMapper\Compiler\Mapper\Input\FloatInputMapperCompiler;
 use ShipMonk\InputMapper\Compiler\Mapper\MapperCompiler;
 use ShipMonk\InputMapper\Compiler\Mapper\MapperCompilerProvider;
-use ShipMonk\InputMapper\Compiler\MapperFactory\MapperCompilerFactory;
 use ShipMonk\InputMapper\Compiler\Mapper\PassthroughMapperCompiler;
+use ShipMonk\InputMapper\Compiler\MapperFactory\MapperCompilerFactory;
 
 #[Attribute(Attribute::TARGET_PARAMETER | Attribute::TARGET_PROPERTY)]
 class MapFloat implements MapperCompilerProvider

--- a/src/Compiler/Attribute/MapInt.php
+++ b/src/Compiler/Attribute/MapInt.php
@@ -7,8 +7,8 @@ use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
 use ShipMonk\InputMapper\Compiler\Mapper\Input\IntInputMapperCompiler;
 use ShipMonk\InputMapper\Compiler\Mapper\MapperCompiler;
 use ShipMonk\InputMapper\Compiler\Mapper\MapperCompilerProvider;
-use ShipMonk\InputMapper\Compiler\MapperFactory\MapperCompilerFactory;
 use ShipMonk\InputMapper\Compiler\Mapper\PassthroughMapperCompiler;
+use ShipMonk\InputMapper\Compiler\MapperFactory\MapperCompilerFactory;
 
 #[Attribute(Attribute::TARGET_PARAMETER | Attribute::TARGET_PROPERTY)]
 class MapInt implements MapperCompilerProvider

--- a/src/Compiler/Attribute/MapInt.php
+++ b/src/Compiler/Attribute/MapInt.php
@@ -7,18 +7,25 @@ use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
 use ShipMonk\InputMapper\Compiler\Mapper\Input\IntInputMapperCompiler;
 use ShipMonk\InputMapper\Compiler\Mapper\MapperCompiler;
 use ShipMonk\InputMapper\Compiler\Mapper\MapperCompilerProvider;
+use ShipMonk\InputMapper\Compiler\MapperFactory\MapperCompilerFactory;
 use ShipMonk\InputMapper\Compiler\Mapper\PassthroughMapperCompiler;
 
 #[Attribute(Attribute::TARGET_PARAMETER | Attribute::TARGET_PROPERTY)]
 class MapInt implements MapperCompilerProvider
 {
 
-    public function getInputMapperCompiler(): MapperCompiler
+    public function getInputMapperCompiler(
+        MapperCompilerFactory $mapperCompilerFactory,
+        array $options,
+    ): MapperCompiler
     {
         return new IntInputMapperCompiler();
     }
 
-    public function getOutputMapperCompiler(): MapperCompiler
+    public function getOutputMapperCompiler(
+        MapperCompilerFactory $mapperCompilerFactory,
+        array $options,
+    ): MapperCompiler
     {
         return new PassthroughMapperCompiler(new IdentifierTypeNode('int'));
     }

--- a/src/Compiler/Attribute/MapList.php
+++ b/src/Compiler/Attribute/MapList.php
@@ -6,6 +6,7 @@ use Attribute;
 use ShipMonk\InputMapper\Compiler\Mapper\Input\ListInputMapperCompiler;
 use ShipMonk\InputMapper\Compiler\Mapper\MapperCompiler;
 use ShipMonk\InputMapper\Compiler\Mapper\MapperCompilerProvider;
+use ShipMonk\InputMapper\Compiler\MapperFactory\MapperCompilerFactory;
 use ShipMonk\InputMapper\Compiler\Mapper\Output\ListOutputMapperCompiler;
 
 #[Attribute(Attribute::TARGET_PARAMETER | Attribute::TARGET_PROPERTY)]
@@ -18,14 +19,20 @@ class MapList implements MapperCompilerProvider
     {
     }
 
-    public function getInputMapperCompiler(): MapperCompiler
+    public function getInputMapperCompiler(
+        MapperCompilerFactory $mapperCompilerFactory,
+        array $options,
+    ): MapperCompiler
     {
-        return new ListInputMapperCompiler($this->itemMapperCompilerProvider->getInputMapperCompiler());
+        return new ListInputMapperCompiler($this->itemMapperCompilerProvider->getInputMapperCompiler($mapperCompilerFactory, $options));
     }
 
-    public function getOutputMapperCompiler(): MapperCompiler
+    public function getOutputMapperCompiler(
+        MapperCompilerFactory $mapperCompilerFactory,
+        array $options,
+    ): MapperCompiler
     {
-        return new ListOutputMapperCompiler($this->itemMapperCompilerProvider->getOutputMapperCompiler());
+        return new ListOutputMapperCompiler($this->itemMapperCompilerProvider->getOutputMapperCompiler($mapperCompilerFactory, $options));
     }
 
 }

--- a/src/Compiler/Attribute/MapList.php
+++ b/src/Compiler/Attribute/MapList.php
@@ -6,8 +6,8 @@ use Attribute;
 use ShipMonk\InputMapper\Compiler\Mapper\Input\ListInputMapperCompiler;
 use ShipMonk\InputMapper\Compiler\Mapper\MapperCompiler;
 use ShipMonk\InputMapper\Compiler\Mapper\MapperCompilerProvider;
-use ShipMonk\InputMapper\Compiler\MapperFactory\MapperCompilerFactory;
 use ShipMonk\InputMapper\Compiler\Mapper\Output\ListOutputMapperCompiler;
+use ShipMonk\InputMapper\Compiler\MapperFactory\MapperCompilerFactory;
 
 #[Attribute(Attribute::TARGET_PARAMETER | Attribute::TARGET_PROPERTY)]
 class MapList implements MapperCompilerProvider

--- a/src/Compiler/Attribute/MapMixed.php
+++ b/src/Compiler/Attribute/MapMixed.php
@@ -7,8 +7,8 @@ use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
 use ShipMonk\InputMapper\Compiler\Mapper\Input\MixedInputMapperCompiler;
 use ShipMonk\InputMapper\Compiler\Mapper\MapperCompiler;
 use ShipMonk\InputMapper\Compiler\Mapper\MapperCompilerProvider;
-use ShipMonk\InputMapper\Compiler\MapperFactory\MapperCompilerFactory;
 use ShipMonk\InputMapper\Compiler\Mapper\PassthroughMapperCompiler;
+use ShipMonk\InputMapper\Compiler\MapperFactory\MapperCompilerFactory;
 
 #[Attribute(Attribute::TARGET_PARAMETER | Attribute::TARGET_PROPERTY)]
 class MapMixed implements MapperCompilerProvider

--- a/src/Compiler/Attribute/MapMixed.php
+++ b/src/Compiler/Attribute/MapMixed.php
@@ -7,18 +7,25 @@ use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
 use ShipMonk\InputMapper\Compiler\Mapper\Input\MixedInputMapperCompiler;
 use ShipMonk\InputMapper\Compiler\Mapper\MapperCompiler;
 use ShipMonk\InputMapper\Compiler\Mapper\MapperCompilerProvider;
+use ShipMonk\InputMapper\Compiler\MapperFactory\MapperCompilerFactory;
 use ShipMonk\InputMapper\Compiler\Mapper\PassthroughMapperCompiler;
 
 #[Attribute(Attribute::TARGET_PARAMETER | Attribute::TARGET_PROPERTY)]
 class MapMixed implements MapperCompilerProvider
 {
 
-    public function getInputMapperCompiler(): MapperCompiler
+    public function getInputMapperCompiler(
+        MapperCompilerFactory $mapperCompilerFactory,
+        array $options,
+    ): MapperCompiler
     {
         return new MixedInputMapperCompiler();
     }
 
-    public function getOutputMapperCompiler(): MapperCompiler
+    public function getOutputMapperCompiler(
+        MapperCompilerFactory $mapperCompilerFactory,
+        array $options,
+    ): MapperCompiler
     {
         return new PassthroughMapperCompiler(new IdentifierTypeNode('mixed'));
     }

--- a/src/Compiler/Attribute/MapNullable.php
+++ b/src/Compiler/Attribute/MapNullable.php
@@ -6,6 +6,7 @@ use Attribute;
 use ShipMonk\InputMapper\Compiler\Mapper\Input\NullableInputMapperCompiler;
 use ShipMonk\InputMapper\Compiler\Mapper\MapperCompiler;
 use ShipMonk\InputMapper\Compiler\Mapper\MapperCompilerProvider;
+use ShipMonk\InputMapper\Compiler\MapperFactory\MapperCompilerFactory;
 use ShipMonk\InputMapper\Compiler\Mapper\Output\NullableOutputMapperCompiler;
 
 #[Attribute(Attribute::TARGET_PARAMETER | Attribute::TARGET_PROPERTY)]
@@ -18,14 +19,20 @@ class MapNullable implements MapperCompilerProvider
     {
     }
 
-    public function getInputMapperCompiler(): MapperCompiler
+    public function getInputMapperCompiler(
+        MapperCompilerFactory $mapperCompilerFactory,
+        array $options,
+    ): MapperCompiler
     {
-        return new NullableInputMapperCompiler($this->innerMapperCompilerProvider->getInputMapperCompiler());
+        return new NullableInputMapperCompiler($this->innerMapperCompilerProvider->getInputMapperCompiler($mapperCompilerFactory, $options));
     }
 
-    public function getOutputMapperCompiler(): MapperCompiler
+    public function getOutputMapperCompiler(
+        MapperCompilerFactory $mapperCompilerFactory,
+        array $options,
+    ): MapperCompiler
     {
-        return new NullableOutputMapperCompiler($this->innerMapperCompilerProvider->getOutputMapperCompiler());
+        return new NullableOutputMapperCompiler($this->innerMapperCompilerProvider->getOutputMapperCompiler($mapperCompilerFactory, $options));
     }
 
 }

--- a/src/Compiler/Attribute/MapNullable.php
+++ b/src/Compiler/Attribute/MapNullable.php
@@ -6,8 +6,8 @@ use Attribute;
 use ShipMonk\InputMapper\Compiler\Mapper\Input\NullableInputMapperCompiler;
 use ShipMonk\InputMapper\Compiler\Mapper\MapperCompiler;
 use ShipMonk\InputMapper\Compiler\Mapper\MapperCompilerProvider;
-use ShipMonk\InputMapper\Compiler\MapperFactory\MapperCompilerFactory;
 use ShipMonk\InputMapper\Compiler\Mapper\Output\NullableOutputMapperCompiler;
+use ShipMonk\InputMapper\Compiler\MapperFactory\MapperCompilerFactory;
 
 #[Attribute(Attribute::TARGET_PARAMETER | Attribute::TARGET_PROPERTY)]
 class MapNullable implements MapperCompilerProvider

--- a/src/Compiler/Attribute/MapObject.php
+++ b/src/Compiler/Attribute/MapObject.php
@@ -6,6 +6,7 @@ use ShipMonk\InputMapper\Compiler\Mapper\Input\ObjectInputMapperCompiler;
 use ShipMonk\InputMapper\Compiler\Mapper\InputMapperCompilerProvider;
 use ShipMonk\InputMapper\Compiler\Mapper\MapperCompiler;
 use ShipMonk\InputMapper\Compiler\Mapper\MapperCompilerProvider;
+use ShipMonk\InputMapper\Compiler\MapperFactory\MapperCompilerFactory;
 use ShipMonk\InputMapper\Compiler\Mapper\Output\ObjectOutputMapperCompiler;
 use ShipMonk\InputMapper\Compiler\Mapper\OutputMapperCompilerProvider;
 use ShipMonk\InputMapper\Compiler\Type\GenericTypeParameter;
@@ -30,12 +31,15 @@ class MapObject implements MapperCompilerProvider
     {
     }
 
-    public function getInputMapperCompiler(): MapperCompiler
+    public function getInputMapperCompiler(
+        MapperCompilerFactory $mapperCompilerFactory,
+        array $options,
+    ): MapperCompiler
     {
         return new ObjectInputMapperCompiler(
             $this->className,
             array_map(
-                static fn (InputMapperCompilerProvider $provider): MapperCompiler => $provider->getInputMapperCompiler(),
+                static fn (InputMapperCompilerProvider $provider): MapperCompiler => $provider->getInputMapperCompiler($mapperCompilerFactory, $options),
                 $this->constructorArgsProviders,
             ),
             $this->allowExtraKeys,
@@ -43,12 +47,15 @@ class MapObject implements MapperCompilerProvider
         );
     }
 
-    public function getOutputMapperCompiler(): MapperCompiler
+    public function getOutputMapperCompiler(
+        MapperCompilerFactory $mapperCompilerFactory,
+        array $options,
+    ): MapperCompiler
     {
         return new ObjectOutputMapperCompiler(
             $this->className,
             array_map(
-                static fn (array $pair): array => [$pair[0], $pair[1]->getOutputMapperCompiler()],
+                static fn (array $pair): array => [$pair[0], $pair[1]->getOutputMapperCompiler($mapperCompilerFactory, $options)],
                 $this->propertyProviders,
             ),
             $this->genericParameters,

--- a/src/Compiler/Attribute/MapObject.php
+++ b/src/Compiler/Attribute/MapObject.php
@@ -6,9 +6,9 @@ use ShipMonk\InputMapper\Compiler\Mapper\Input\ObjectInputMapperCompiler;
 use ShipMonk\InputMapper\Compiler\Mapper\InputMapperCompilerProvider;
 use ShipMonk\InputMapper\Compiler\Mapper\MapperCompiler;
 use ShipMonk\InputMapper\Compiler\Mapper\MapperCompilerProvider;
-use ShipMonk\InputMapper\Compiler\MapperFactory\MapperCompilerFactory;
 use ShipMonk\InputMapper\Compiler\Mapper\Output\ObjectOutputMapperCompiler;
 use ShipMonk\InputMapper\Compiler\Mapper\OutputMapperCompilerProvider;
+use ShipMonk\InputMapper\Compiler\MapperFactory\MapperCompilerFactory;
 use ShipMonk\InputMapper\Compiler\Type\GenericTypeParameter;
 use function array_map;
 

--- a/src/Compiler/Attribute/MapOptional.php
+++ b/src/Compiler/Attribute/MapOptional.php
@@ -6,8 +6,8 @@ use Attribute;
 use ShipMonk\InputMapper\Compiler\Mapper\Input\OptionalInputMapperCompiler;
 use ShipMonk\InputMapper\Compiler\Mapper\MapperCompiler;
 use ShipMonk\InputMapper\Compiler\Mapper\MapperCompilerProvider;
-use ShipMonk\InputMapper\Compiler\MapperFactory\MapperCompilerFactory;
 use ShipMonk\InputMapper\Compiler\Mapper\Output\OptionalOutputMapperCompiler;
+use ShipMonk\InputMapper\Compiler\MapperFactory\MapperCompilerFactory;
 
 #[Attribute(Attribute::TARGET_PARAMETER | Attribute::TARGET_PROPERTY)]
 class MapOptional implements MapperCompilerProvider

--- a/src/Compiler/Attribute/MapOptional.php
+++ b/src/Compiler/Attribute/MapOptional.php
@@ -6,6 +6,7 @@ use Attribute;
 use ShipMonk\InputMapper\Compiler\Mapper\Input\OptionalInputMapperCompiler;
 use ShipMonk\InputMapper\Compiler\Mapper\MapperCompiler;
 use ShipMonk\InputMapper\Compiler\Mapper\MapperCompilerProvider;
+use ShipMonk\InputMapper\Compiler\MapperFactory\MapperCompilerFactory;
 use ShipMonk\InputMapper\Compiler\Mapper\Output\OptionalOutputMapperCompiler;
 
 #[Attribute(Attribute::TARGET_PARAMETER | Attribute::TARGET_PROPERTY)]
@@ -18,14 +19,20 @@ class MapOptional implements MapperCompilerProvider
     {
     }
 
-    public function getInputMapperCompiler(): MapperCompiler
+    public function getInputMapperCompiler(
+        MapperCompilerFactory $mapperCompilerFactory,
+        array $options,
+    ): MapperCompiler
     {
-        return new OptionalInputMapperCompiler($this->mapperCompilerProvider->getInputMapperCompiler());
+        return new OptionalInputMapperCompiler($this->mapperCompilerProvider->getInputMapperCompiler($mapperCompilerFactory, $options));
     }
 
-    public function getOutputMapperCompiler(): MapperCompiler
+    public function getOutputMapperCompiler(
+        MapperCompilerFactory $mapperCompilerFactory,
+        array $options,
+    ): MapperCompiler
     {
-        return new OptionalOutputMapperCompiler($this->mapperCompilerProvider->getOutputMapperCompiler());
+        return new OptionalOutputMapperCompiler($this->mapperCompilerProvider->getOutputMapperCompiler($mapperCompilerFactory, $options));
     }
 
 }

--- a/src/Compiler/Attribute/MapString.php
+++ b/src/Compiler/Attribute/MapString.php
@@ -7,18 +7,25 @@ use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
 use ShipMonk\InputMapper\Compiler\Mapper\Input\StringInputMapperCompiler;
 use ShipMonk\InputMapper\Compiler\Mapper\MapperCompiler;
 use ShipMonk\InputMapper\Compiler\Mapper\MapperCompilerProvider;
+use ShipMonk\InputMapper\Compiler\MapperFactory\MapperCompilerFactory;
 use ShipMonk\InputMapper\Compiler\Mapper\PassthroughMapperCompiler;
 
 #[Attribute(Attribute::TARGET_PARAMETER | Attribute::TARGET_PROPERTY)]
 class MapString implements MapperCompilerProvider
 {
 
-    public function getInputMapperCompiler(): MapperCompiler
+    public function getInputMapperCompiler(
+        MapperCompilerFactory $mapperCompilerFactory,
+        array $options,
+    ): MapperCompiler
     {
         return new StringInputMapperCompiler();
     }
 
-    public function getOutputMapperCompiler(): MapperCompiler
+    public function getOutputMapperCompiler(
+        MapperCompilerFactory $mapperCompilerFactory,
+        array $options,
+    ): MapperCompiler
     {
         return new PassthroughMapperCompiler(new IdentifierTypeNode('string'));
     }

--- a/src/Compiler/Attribute/MapString.php
+++ b/src/Compiler/Attribute/MapString.php
@@ -7,8 +7,8 @@ use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
 use ShipMonk\InputMapper\Compiler\Mapper\Input\StringInputMapperCompiler;
 use ShipMonk\InputMapper\Compiler\Mapper\MapperCompiler;
 use ShipMonk\InputMapper\Compiler\Mapper\MapperCompilerProvider;
-use ShipMonk\InputMapper\Compiler\MapperFactory\MapperCompilerFactory;
 use ShipMonk\InputMapper\Compiler\Mapper\PassthroughMapperCompiler;
+use ShipMonk\InputMapper\Compiler\MapperFactory\MapperCompilerFactory;
 
 #[Attribute(Attribute::TARGET_PARAMETER | Attribute::TARGET_PROPERTY)]
 class MapString implements MapperCompilerProvider

--- a/src/Compiler/Attribute/MapValidated.php
+++ b/src/Compiler/Attribute/MapValidated.php
@@ -6,6 +6,7 @@ use Attribute;
 use ShipMonk\InputMapper\Compiler\Mapper\Input\ValidatedInputMapperCompiler;
 use ShipMonk\InputMapper\Compiler\Mapper\MapperCompiler;
 use ShipMonk\InputMapper\Compiler\Mapper\MapperCompilerProvider;
+use ShipMonk\InputMapper\Compiler\MapperFactory\MapperCompilerFactory;
 use ShipMonk\InputMapper\Compiler\Validator\ValidatorCompiler;
 
 #[Attribute(Attribute::TARGET_PARAMETER | Attribute::TARGET_PROPERTY)]
@@ -22,17 +23,23 @@ class MapValidated implements MapperCompilerProvider
     {
     }
 
-    public function getInputMapperCompiler(): MapperCompiler
+    public function getInputMapperCompiler(
+        MapperCompilerFactory $mapperCompilerFactory,
+        array $options,
+    ): MapperCompiler
     {
-        return new ValidatedInputMapperCompiler($this->mapperCompilerProvider->getInputMapperCompiler(), $this->validatorCompilers);
+        return new ValidatedInputMapperCompiler($this->mapperCompilerProvider->getInputMapperCompiler($mapperCompilerFactory, $options), $this->validatorCompilers);
     }
 
     /**
      * Validators are input-only, output mapping passes through without validation
      */
-    public function getOutputMapperCompiler(): MapperCompiler
+    public function getOutputMapperCompiler(
+        MapperCompilerFactory $mapperCompilerFactory,
+        array $options,
+    ): MapperCompiler
     {
-        return $this->mapperCompilerProvider->getOutputMapperCompiler();
+        return $this->mapperCompilerProvider->getOutputMapperCompiler($mapperCompilerFactory, $options);
     }
 
 }

--- a/src/Compiler/Exception/CannotCreateMapperCompilerException.php
+++ b/src/Compiler/Exception/CannotCreateMapperCompilerException.php
@@ -61,6 +61,16 @@ class CannotCreateMapperCompilerException extends LogicException
         return new self("Cannot use mapper {$mapperCompilerClass} for parameter \${$parameterName} of method {$methodFullName}, because {$reason}", 0, $previous);
     }
 
+    public static function withUnsupportedCodecConstructorArgument(
+        string $codecClassName,
+        string $parameterName,
+        string $reason,
+        ?Throwable $previous = null,
+    ): self
+    {
+        return new self("Cannot compile codec {$codecClassName} inline, because constructor argument \${$parameterName} {$reason}", 0, $previous);
+    }
+
     public static function withIncompatibleValidator(
         ValidatorCompiler $validatorCompiler,
         MapperCompiler $mapperCompiler,

--- a/src/Compiler/Mapper/Codec/AbstractInlineCodecMapperCompiler.php
+++ b/src/Compiler/Mapper/Codec/AbstractInlineCodecMapperCompiler.php
@@ -10,11 +10,16 @@ use ShipMonk\InputMapper\Compiler\CompiledExpr;
 use ShipMonk\InputMapper\Compiler\Mapper\MapperCompiler;
 use ShipMonk\InputMapper\Compiler\Php\PhpCodeBuilder;
 use ShipMonk\InputMapper\Runtime\Codec;
+use WeakMap;
 use function array_map;
-use function array_values;
 
 abstract class AbstractInlineCodecMapperCompiler implements MapperCompiler
 {
+
+    /**
+     * @var WeakMap<PhpCodeBuilder, string>|null property name per generated class, so repeated compilation does not duplicate properties
+     */
+    private ?WeakMap $codecPropertyNames = null;
 
     /**
      * @param class-string<Codec<*, *, *, *>> $codecClassName
@@ -35,8 +40,21 @@ abstract class AbstractInlineCodecMapperCompiler implements MapperCompiler
      */
     protected function compileCodecAccess(PhpCodeBuilder $builder): CompiledExpr
     {
-        $codecPropertyName = $builder->uniqPropertyName('codec');
+        $this->codecPropertyNames ??= new WeakMap();
+        $codecPropertyName = $this->codecPropertyNames[$builder] ??= $this->addCodecProperty($builder);
 
+        $codecShortName = $builder->importClass($this->codecClassName);
+        $argExprs = array_map($builder->val(...), $this->constructorArgs);
+        $newCodec = $builder->new($codecShortName, $argExprs);
+        $codecAccess = $builder->propertyFetch($builder->var('this'), $codecPropertyName);
+        $coalesceAssign = new Coalesce($codecAccess, $newCodec);
+
+        return new CompiledExpr($codecAccess, [new Expression($coalesceAssign)]);
+    }
+
+    private function addCodecProperty(PhpCodeBuilder $builder): string
+    {
+        $codecPropertyName = $builder->uniqPropertyName('codec');
         $codecShortName = $builder->importClass($this->codecClassName);
         $codecProperty = $builder->property($codecPropertyName)
             ->makePrivate()
@@ -45,12 +63,7 @@ abstract class AbstractInlineCodecMapperCompiler implements MapperCompiler
             ->getNode();
         $builder->addProperty($codecProperty);
 
-        $argExprs = array_map($builder->val(...), array_values($this->constructorArgs));
-        $newCodec = $builder->new($codecShortName, $argExprs);
-        $codecAccess = $builder->propertyFetch($builder->var('this'), $codecPropertyName);
-        $coalesceAssign = new Coalesce($codecAccess, $newCodec);
-
-        return new CompiledExpr($codecAccess, [new Expression($coalesceAssign)]);
+        return $codecPropertyName;
     }
 
 }

--- a/src/Compiler/Mapper/Codec/AbstractInlineCodecMapperCompiler.php
+++ b/src/Compiler/Mapper/Codec/AbstractInlineCodecMapperCompiler.php
@@ -35,7 +35,7 @@ abstract class AbstractInlineCodecMapperCompiler implements MapperCompiler
      */
     protected function compileCodecAccess(PhpCodeBuilder $builder): CompiledExpr
     {
-        $codecPropertyName = $builder->uniqVariableName('codec');
+        $codecPropertyName = $builder->uniqPropertyName('codec');
 
         $codecShortName = $builder->importClass($this->codecClassName);
         $codecProperty = $builder->property($codecPropertyName)

--- a/src/Compiler/Mapper/Codec/AbstractInlineCodecMapperCompiler.php
+++ b/src/Compiler/Mapper/Codec/AbstractInlineCodecMapperCompiler.php
@@ -1,0 +1,56 @@
+<?php declare(strict_types = 1);
+
+namespace ShipMonk\InputMapper\Compiler\Mapper\Codec;
+
+use PhpParser\Node\Expr\AssignOp\Coalesce;
+use PhpParser\Node\Name;
+use PhpParser\Node\NullableType;
+use PhpParser\Node\Stmt\Expression;
+use ShipMonk\InputMapper\Compiler\CompiledExpr;
+use ShipMonk\InputMapper\Compiler\Mapper\MapperCompiler;
+use ShipMonk\InputMapper\Compiler\Php\PhpCodeBuilder;
+use ShipMonk\InputMapper\Runtime\Codec;
+use function array_map;
+use function array_values;
+
+abstract class AbstractInlineCodecMapperCompiler implements MapperCompiler
+{
+
+    /**
+     * @param class-string<Codec<*, *, *, *>> $codecClassName
+     * @param array<string, scalar|null> $constructorArgs
+     */
+    public function __construct(
+        public readonly string $codecClassName,
+        public readonly array $constructorArgs,
+        public readonly MapperCompiler $intermediateMapperCompiler,
+    )
+    {
+    }
+
+    /**
+     * Registers a lazily initialized codec property on the generated class.
+     * Returns a CompiledExpr whose expr is the codec property access
+     * and whose statements contain the coalesce-assign: `$this->codec ??= new CodecClass(args);`
+     */
+    protected function compileCodecAccess(PhpCodeBuilder $builder): CompiledExpr
+    {
+        $codecPropertyName = $builder->uniqVariableName('codec');
+
+        $codecShortName = $builder->importClass($this->codecClassName);
+        $codecProperty = $builder->property($codecPropertyName)
+            ->makePrivate()
+            ->setType(new NullableType(new Name($codecShortName)))
+            ->setDefault(null)
+            ->getNode();
+        $builder->addProperty($codecProperty);
+
+        $argExprs = array_map($builder->val(...), array_values($this->constructorArgs));
+        $newCodec = $builder->new($codecShortName, $argExprs);
+        $codecAccess = $builder->propertyFetch($builder->var('this'), $codecPropertyName);
+        $coalesceAssign = new Coalesce($codecAccess, $newCodec);
+
+        return new CompiledExpr($codecAccess, [new Expression($coalesceAssign)]);
+    }
+
+}

--- a/src/Compiler/Mapper/Codec/CodecInputMapperCompiler.php
+++ b/src/Compiler/Mapper/Codec/CodecInputMapperCompiler.php
@@ -1,0 +1,55 @@
+<?php declare(strict_types = 1);
+
+namespace ShipMonk\InputMapper\Compiler\Mapper\Codec;
+
+use PhpParser\Node\Expr;
+use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
+use PHPStan\PhpDocParser\Ast\Type\TypeNode;
+use ShipMonk\InputMapper\Compiler\CompiledExpr;
+use ShipMonk\InputMapper\Compiler\Mapper\MapperCompiler;
+use ShipMonk\InputMapper\Compiler\Php\PhpCodeBuilder;
+use ShipMonk\InputMapper\Runtime\Codec;
+
+class CodecInputMapperCompiler implements MapperCompiler
+{
+
+    /**
+     * @param class-string<Codec<*, *, *, *>> $codecClassName
+     * @param class-string $domainClassName
+     */
+    public function __construct(
+        public readonly string $codecClassName,
+        public readonly MapperCompiler $intermediateMapperCompiler,
+        public readonly string $domainClassName,
+    )
+    {
+    }
+
+    public function compile(
+        Expr $value,
+        Expr $path,
+        PhpCodeBuilder $builder,
+    ): CompiledExpr
+    {
+        $intermediate = $this->intermediateMapperCompiler->compile($value, $path, $builder);
+
+        $provider = $builder->propertyFetch($builder->var('this'), 'provider');
+        $codecClassExpr = $builder->classConstFetch($builder->importClass($this->codecClassName), 'class');
+        $domainClassExpr = $builder->classConstFetch($builder->importClass($this->domainClassName), 'class');
+        $codec = $builder->methodCall($provider, 'getCodec', [$codecClassExpr, $domainClassExpr]);
+        $decoded = $builder->methodCall($codec, 'decode', [$intermediate->expr, $path]);
+
+        return new CompiledExpr($decoded, $intermediate->statements);
+    }
+
+    public function getInputType(): TypeNode
+    {
+        return $this->intermediateMapperCompiler->getInputType();
+    }
+
+    public function getOutputType(): TypeNode
+    {
+        return new IdentifierTypeNode($this->domainClassName);
+    }
+
+}

--- a/src/Compiler/Mapper/Codec/CodecMapperCompilerProvider.php
+++ b/src/Compiler/Mapper/Codec/CodecMapperCompilerProvider.php
@@ -1,0 +1,50 @@
+<?php declare(strict_types = 1);
+
+namespace ShipMonk\InputMapper\Compiler\Mapper\Codec;
+
+use ShipMonk\InputMapper\Compiler\Mapper\MapperCompiler;
+use ShipMonk\InputMapper\Compiler\Mapper\MapperCompilerProvider;
+use ShipMonk\InputMapper\Compiler\MapperFactory\MapperCompilerFactory;
+use ShipMonk\InputMapper\Runtime\Codec;
+
+class CodecMapperCompilerProvider implements MapperCompilerProvider
+{
+
+    /**
+     * @param class-string<Codec<*, *, *, *>> $codecClassName
+     * @param class-string $domainClassName
+     */
+    public function __construct(
+        public readonly string $codecClassName,
+        public readonly MapperCompiler $intermediateInputMapperCompiler,
+        public readonly MapperCompiler $intermediateOutputMapperCompiler,
+        public readonly string $domainClassName,
+    )
+    {
+    }
+
+    public function getInputMapperCompiler(
+        MapperCompilerFactory $mapperCompilerFactory,
+        array $options,
+    ): MapperCompiler
+    {
+        return new CodecInputMapperCompiler(
+            $this->codecClassName,
+            $this->intermediateInputMapperCompiler,
+            $this->domainClassName,
+        );
+    }
+
+    public function getOutputMapperCompiler(
+        MapperCompilerFactory $mapperCompilerFactory,
+        array $options,
+    ): MapperCompiler
+    {
+        return new CodecOutputMapperCompiler(
+            $this->codecClassName,
+            $this->intermediateOutputMapperCompiler,
+            $this->domainClassName,
+        );
+    }
+
+}

--- a/src/Compiler/Mapper/Codec/CodecOutputMapperCompiler.php
+++ b/src/Compiler/Mapper/Codec/CodecOutputMapperCompiler.php
@@ -1,0 +1,58 @@
+<?php declare(strict_types = 1);
+
+namespace ShipMonk\InputMapper\Compiler\Mapper\Codec;
+
+use PhpParser\Node\Expr;
+use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
+use PHPStan\PhpDocParser\Ast\Type\TypeNode;
+use ShipMonk\InputMapper\Compiler\CompiledExpr;
+use ShipMonk\InputMapper\Compiler\Mapper\MapperCompiler;
+use ShipMonk\InputMapper\Compiler\Php\PhpCodeBuilder;
+use ShipMonk\InputMapper\Runtime\Codec;
+
+class CodecOutputMapperCompiler implements MapperCompiler
+{
+
+    /**
+     * @param class-string<Codec<*, *, *, *>> $codecClassName
+     * @param class-string $domainClassName
+     */
+    public function __construct(
+        public readonly string $codecClassName,
+        public readonly MapperCompiler $intermediateMapperCompiler,
+        public readonly string $domainClassName,
+    )
+    {
+    }
+
+    public function compile(
+        Expr $value,
+        Expr $path,
+        PhpCodeBuilder $builder,
+    ): CompiledExpr
+    {
+        $provider = $builder->propertyFetch($builder->var('this'), 'provider');
+        $codecClassExpr = $builder->classConstFetch($builder->importClass($this->codecClassName), 'class');
+        $domainClassExpr = $builder->classConstFetch($builder->importClass($this->domainClassName), 'class');
+        $codec = $builder->methodCall($provider, 'getCodec', [$codecClassExpr, $domainClassExpr]);
+
+        $encodedVarName = $builder->uniqVariableName('encoded');
+        $encodeCall = $builder->methodCall($codec, 'encode', [$value, $path]);
+        $statements = [$builder->assign($builder->var($encodedVarName), $encodeCall)];
+
+        $outputCompiled = $this->intermediateMapperCompiler->compile($builder->var($encodedVarName), $path, $builder);
+
+        return new CompiledExpr($outputCompiled->expr, [...$statements, ...$outputCompiled->statements]);
+    }
+
+    public function getInputType(): TypeNode
+    {
+        return new IdentifierTypeNode($this->domainClassName);
+    }
+
+    public function getOutputType(): TypeNode
+    {
+        return $this->intermediateMapperCompiler->getOutputType();
+    }
+
+}

--- a/src/Compiler/Mapper/Codec/InlineCodecInputMapperCompiler.php
+++ b/src/Compiler/Mapper/Codec/InlineCodecInputMapperCompiler.php
@@ -1,0 +1,53 @@
+<?php declare(strict_types = 1);
+
+namespace ShipMonk\InputMapper\Compiler\Mapper\Codec;
+
+use PhpParser\Node\Expr;
+use PHPStan\PhpDocParser\Ast\Type\TypeNode;
+use ShipMonk\InputMapper\Compiler\CompiledExpr;
+use ShipMonk\InputMapper\Compiler\Mapper\MapperCompiler;
+use ShipMonk\InputMapper\Compiler\Php\PhpCodeBuilder;
+use ShipMonk\InputMapper\Runtime\Codec;
+
+class InlineCodecInputMapperCompiler extends AbstractInlineCodecMapperCompiler
+{
+
+    /**
+     * @param class-string<Codec<*, *, *, *>> $codecClassName
+     * @param array<string, scalar|null> $constructorArgs
+     */
+    public function __construct(
+        string $codecClassName,
+        array $constructorArgs,
+        MapperCompiler $intermediateMapperCompiler,
+        public readonly TypeNode $domainOutputType,
+    )
+    {
+        parent::__construct($codecClassName, $constructorArgs, $intermediateMapperCompiler);
+    }
+
+    public function compile(
+        Expr $value,
+        Expr $path,
+        PhpCodeBuilder $builder,
+    ): CompiledExpr
+    {
+        $intermediate = $this->intermediateMapperCompiler->compile($value, $path, $builder);
+        $codec = $this->compileCodecAccess($builder);
+
+        $decoded = $builder->methodCall($codec->expr, 'decode', [$intermediate->expr, $path]);
+
+        return new CompiledExpr($decoded, [...$intermediate->statements, ...$codec->statements]);
+    }
+
+    public function getInputType(): TypeNode
+    {
+        return $this->intermediateMapperCompiler->getInputType();
+    }
+
+    public function getOutputType(): TypeNode
+    {
+        return $this->domainOutputType;
+    }
+
+}

--- a/src/Compiler/Mapper/Codec/InlineCodecOutputMapperCompiler.php
+++ b/src/Compiler/Mapper/Codec/InlineCodecOutputMapperCompiler.php
@@ -1,0 +1,59 @@
+<?php declare(strict_types = 1);
+
+namespace ShipMonk\InputMapper\Compiler\Mapper\Codec;
+
+use PhpParser\Node\Expr;
+use PHPStan\PhpDocParser\Ast\Type\TypeNode;
+use ShipMonk\InputMapper\Compiler\CompiledExpr;
+use ShipMonk\InputMapper\Compiler\Mapper\MapperCompiler;
+use ShipMonk\InputMapper\Compiler\Php\PhpCodeBuilder;
+use ShipMonk\InputMapper\Runtime\Codec;
+
+class InlineCodecOutputMapperCompiler extends AbstractInlineCodecMapperCompiler
+{
+
+    /**
+     * @param class-string<Codec<*, *, *, *>> $codecClassName
+     * @param array<string, scalar|null> $constructorArgs
+     */
+    public function __construct(
+        string $codecClassName,
+        array $constructorArgs,
+        MapperCompiler $intermediateMapperCompiler,
+        public readonly TypeNode $domainInputType,
+    )
+    {
+        parent::__construct($codecClassName, $constructorArgs, $intermediateMapperCompiler);
+    }
+
+    public function compile(
+        Expr $value,
+        Expr $path,
+        PhpCodeBuilder $builder,
+    ): CompiledExpr
+    {
+        $codec = $this->compileCodecAccess($builder);
+
+        $encodedVarName = $builder->uniqVariableName('encoded');
+        $encodeCall = $builder->methodCall($codec->expr, 'encode', [$value, $path]);
+        $statements = [
+            ...$codec->statements,
+            $builder->assign($builder->var($encodedVarName), $encodeCall),
+        ];
+
+        $outputCompiled = $this->intermediateMapperCompiler->compile($builder->var($encodedVarName), $path, $builder);
+
+        return new CompiledExpr($outputCompiled->expr, [...$statements, ...$outputCompiled->statements]);
+    }
+
+    public function getInputType(): TypeNode
+    {
+        return $this->domainInputType;
+    }
+
+    public function getOutputType(): TypeNode
+    {
+        return $this->intermediateMapperCompiler->getOutputType();
+    }
+
+}

--- a/src/Compiler/Mapper/InputMapperCompilerProvider.php
+++ b/src/Compiler/Mapper/InputMapperCompilerProvider.php
@@ -2,9 +2,17 @@
 
 namespace ShipMonk\InputMapper\Compiler\Mapper;
 
+use ShipMonk\InputMapper\Compiler\MapperFactory\MapperCompilerFactory;
+
 interface InputMapperCompilerProvider
 {
 
-    public function getInputMapperCompiler(): MapperCompiler;
+    /**
+     * @param array<string, mixed> $options
+     */
+    public function getInputMapperCompiler(
+        MapperCompilerFactory $mapperCompilerFactory,
+        array $options,
+    ): MapperCompiler;
 
 }

--- a/src/Compiler/Mapper/OutputMapperCompilerProvider.php
+++ b/src/Compiler/Mapper/OutputMapperCompilerProvider.php
@@ -2,9 +2,17 @@
 
 namespace ShipMonk\InputMapper\Compiler\Mapper;
 
+use ShipMonk\InputMapper\Compiler\MapperFactory\MapperCompilerFactory;
+
 interface OutputMapperCompilerProvider
 {
 
-    public function getOutputMapperCompiler(): MapperCompiler;
+    /**
+     * @param array<string, mixed> $options
+     */
+    public function getOutputMapperCompiler(
+        MapperCompilerFactory $mapperCompilerFactory,
+        array $options,
+    ): MapperCompiler;
 
 }

--- a/src/Compiler/MapperFactory/DefaultMapperCompilerFactory.php
+++ b/src/Compiler/MapperFactory/DefaultMapperCompilerFactory.php
@@ -53,7 +53,6 @@ use ShipMonk\InputMapper\Compiler\Attribute\Optional as OptionalAttribute;
 use ShipMonk\InputMapper\Compiler\Attribute\SourceKey;
 use ShipMonk\InputMapper\Compiler\Exception\CannotCreateMapperCompilerException;
 use ShipMonk\InputMapper\Compiler\Mapper\Codec\CodecMapperCompilerProvider;
-use ShipMonk\InputMapper\Compiler\Mapper\InputMapperCompilerProvider;
 use ShipMonk\InputMapper\Compiler\Mapper\MapperCompilerProvider;
 use ShipMonk\InputMapper\Compiler\Mapper\OutputMapperCompilerProvider;
 use ShipMonk\InputMapper\Compiler\Mapper\UndefinedAwareMapperCompiler;
@@ -85,13 +84,12 @@ use function substr;
 class DefaultMapperCompilerFactory implements MapperCompilerFactory
 {
 
-    final public const DELEGATE_OBJECT_MAPPING = 'delegateObjectMapping';
-    final public const GENERIC_PARAMETERS = 'genericParameters';
-
     /**
      * @var array<string, class-string<Codec<*, *, *, *>>>|null
      */
     private ?array $codecDomainClassMap = null;
+
+    private int $codecDomainClassMapFactoryCount = 0;
 
     /**
      * @param array<class-string, callable(class-string, array<string, mixed>): MapperCompilerProvider> $mapperCompilerFactories
@@ -551,7 +549,7 @@ class DefaultMapperCompilerFactory implements MapperCompilerFactory
         foreach ($parameterReflection->getAttributes(Codec::class, ReflectionAttribute::IS_INSTANCEOF) as $attribute) {
             $codec = $attribute->newInstance();
 
-            if (!$codec instanceof InputMapperCompilerProvider) {
+            if (!$codec instanceof MapperCompilerProvider) {
                 $providers[] = new MapCodec($codec);
             }
         }
@@ -613,11 +611,25 @@ class DefaultMapperCompilerFactory implements MapperCompilerFactory
             }
         }
 
-        return match (count($outputProviders)) {
-            0 => $this->createInner($type, $options),
-            1 => $outputProviders[0],
-            default => throw CannotCreateMapperCompilerException::fromType($type, 'multiple OutputMapperCompilerProvider attributes found on property $' . $propertyReflection->getName()),
-        };
+        if (count($outputProviders) === 0) {
+            return $this->createInner($type, $options);
+        }
+
+        if (count($outputProviders) === 1) {
+            return $outputProviders[0];
+        }
+
+        $chainableProviders = [];
+
+        foreach ($outputProviders as $outputProvider) {
+            if (!$outputProvider instanceof MapperCompilerProvider) {
+                throw CannotCreateMapperCompilerException::fromType($type, 'multiple OutputMapperCompilerProvider attributes found on property $' . $propertyReflection->getName());
+            }
+
+            $chainableProviders[] = $outputProvider;
+        }
+
+        return new MapChain($chainableProviders);
     }
 
     /**
@@ -694,30 +706,55 @@ class DefaultMapperCompilerFactory implements MapperCompilerFactory
     /**
      * Maps domain classes (the codec EI and DO generic parameters) to codec classes registered in the codec registry.
      *
+     * The map is rebuilt when the registry gains new codec registrations, so codecs registered late are picked up
+     * by mappers that are not compiled yet.
+     *
      * @return array<string, class-string<Codec<*, *, *, *>>>
      */
     protected function getCodecDomainClassMap(): array
     {
-        if ($this->codecDomainClassMap === null) {
-            $this->codecDomainClassMap = [];
+        $codecFactories = $this->codecRegistry->getFactories();
 
-            foreach ($this->codecRegistry->getFactories() as $codecClassName => $factory) {
+        if ($this->codecDomainClassMap === null || count($codecFactories) !== $this->codecDomainClassMapFactoryCount) {
+            $codecDomainClassMap = [];
+
+            foreach ($codecFactories as $codecClassName => $factory) {
                 $codecType = new IdentifierTypeNode($codecClassName);
+                $domainClassNames = [];
 
                 foreach ([1, 2] as $parameter) {
-                    $domainType = PhpDocTypeUtils::inferGenericParameter($codecType, Codec::class, $parameter);
+                    try {
+                        $domainType = PhpDocTypeUtils::inferGenericParameter($codecType, Codec::class, $parameter);
+                    } catch (LogicException $e) {
+                        throw new LogicException("Unable to infer domain class of codec '{$codecClassName}', check its @implements annotation: {$e->getMessage()}", 0, $e);
+                    }
 
-                    if ($domainType instanceof IdentifierTypeNode && !PhpDocTypeUtils::isKeyword($domainType)) {
-                        $conflictingCodecClassName = $this->codecDomainClassMap[$domainType->name] ?? null;
-
-                        if ($conflictingCodecClassName !== null && $conflictingCodecClassName !== $codecClassName) {
-                            throw new LogicException("Multiple codecs registered for domain class '{$domainType->name}': {$conflictingCodecClassName}, {$codecClassName}.");
-                        }
-
-                        $this->codecDomainClassMap[$domainType->name] = $codecClassName;
+                    if (
+                        $domainType instanceof IdentifierTypeNode
+                        && !PhpDocTypeUtils::isKeyword($domainType)
+                        && (class_exists($domainType->name) || interface_exists($domainType->name))
+                    ) {
+                        $domainClassNames[$domainType->name] = true;
                     }
                 }
+
+                if (count($domainClassNames) === 0) {
+                    throw new LogicException("Codec '{$codecClassName}' does not declare any class or interface as its domain type, check its @implements annotation.");
+                }
+
+                foreach ($domainClassNames as $domainClassName => $true) {
+                    $conflictingCodecClassName = $codecDomainClassMap[$domainClassName] ?? null;
+
+                    if ($conflictingCodecClassName !== null && $conflictingCodecClassName !== $codecClassName) {
+                        throw new LogicException("Multiple codecs registered for domain class '{$domainClassName}': {$conflictingCodecClassName}, {$codecClassName}.");
+                    }
+
+                    $codecDomainClassMap[$domainClassName] = $codecClassName;
+                }
             }
+
+            $this->codecDomainClassMap = $codecDomainClassMap;
+            $this->codecDomainClassMapFactoryCount = count($codecFactories);
         }
 
         return $this->codecDomainClassMap;

--- a/src/Compiler/MapperFactory/DefaultMapperCompilerFactory.php
+++ b/src/Compiler/MapperFactory/DefaultMapperCompilerFactory.php
@@ -543,14 +543,14 @@ class DefaultMapperCompilerFactory implements MapperCompilerFactory
         };
 
         foreach ($validators as $validator) {
-            $provider = $this->addValidatorProvider($provider, $validator);
+            $provider = $this->addValidatorProvider($provider, $validator, $options);
         }
 
         foreach ($parameterReflection->getAttributes(OptionalAttribute::class, ReflectionAttribute::IS_INSTANCEOF) as $attribute) {
             $provider = new MapDefaultValue($provider, $attribute->newInstance()->default);
         }
 
-        $mapper = $provider->getInputMapperCompiler();
+        $mapper = $provider->getInputMapperCompiler($this, $options);
 
         if (!PhpDocTypeUtils::isSubTypeOf($mapper->getOutputType(), $type)) {
             throw CannotCreateMapperCompilerException::withIncompatibleMapperForMethodParameter($mapper, $parameterReflection, $type);
@@ -588,38 +588,42 @@ class DefaultMapperCompilerFactory implements MapperCompilerFactory
         };
     }
 
+    /**
+     * @param array<string, mixed> $options
+     */
     protected function addValidatorProvider(
         MapperCompilerProvider $provider,
         ValidatorCompiler $validatorCompiler,
+        array $options,
     ): MapperCompilerProvider
     {
         if ($provider instanceof MapDefaultValue) {
             return new MapDefaultValue(
-                $this->addValidatorProvider($provider->mapperCompilerProvider, $validatorCompiler),
+                $this->addValidatorProvider($provider->mapperCompilerProvider, $validatorCompiler, $options),
                 $provider->defaultValue,
             );
         }
 
         if ($provider instanceof MapOptional) {
             return new MapOptional(
-                $this->addValidatorProvider($provider->mapperCompilerProvider, $validatorCompiler),
+                $this->addValidatorProvider($provider->mapperCompilerProvider, $validatorCompiler, $options),
             );
         }
 
         if ($provider instanceof MapNullable) {
             return new MapNullable(
-                $this->addValidatorProvider($provider->innerMapperCompilerProvider, $validatorCompiler),
+                $this->addValidatorProvider($provider->innerMapperCompilerProvider, $validatorCompiler, $options),
             );
         }
 
-        $mapperOutputType = $provider->getInputMapperCompiler()->getOutputType();
+        $mapperOutputType = $provider->getInputMapperCompiler($this, $options)->getOutputType();
         $validatorInputType = $validatorCompiler->getInputType();
 
         if (PhpDocTypeUtils::isSubTypeOf($mapperOutputType, $validatorInputType)) {
             return new MapValidated($provider, [$validatorCompiler]);
         }
 
-        throw CannotCreateMapperCompilerException::withIncompatibleValidator($validatorCompiler, $provider->getInputMapperCompiler());
+        throw CannotCreateMapperCompilerException::withIncompatibleValidator($validatorCompiler, $provider->getInputMapperCompiler($this, $options));
     }
 
     /**

--- a/src/Compiler/MapperFactory/DefaultMapperCompilerFactory.php
+++ b/src/Compiler/MapperFactory/DefaultMapperCompilerFactory.php
@@ -34,6 +34,7 @@ use ShipMonk\InputMapper\Compiler\Attribute\MapArray;
 use ShipMonk\InputMapper\Compiler\Attribute\MapArrayShape;
 use ShipMonk\InputMapper\Compiler\Attribute\MapBool;
 use ShipMonk\InputMapper\Compiler\Attribute\MapChain;
+use ShipMonk\InputMapper\Compiler\Attribute\MapCodec;
 use ShipMonk\InputMapper\Compiler\Attribute\MapDateTimeImmutable;
 use ShipMonk\InputMapper\Compiler\Attribute\MapDefaultValue;
 use ShipMonk\InputMapper\Compiler\Attribute\MapDelegate;
@@ -51,6 +52,8 @@ use ShipMonk\InputMapper\Compiler\Attribute\MapValidated;
 use ShipMonk\InputMapper\Compiler\Attribute\Optional as OptionalAttribute;
 use ShipMonk\InputMapper\Compiler\Attribute\SourceKey;
 use ShipMonk\InputMapper\Compiler\Exception\CannotCreateMapperCompilerException;
+use ShipMonk\InputMapper\Compiler\Mapper\Codec\CodecMapperCompilerProvider;
+use ShipMonk\InputMapper\Compiler\Mapper\InputMapperCompilerProvider;
 use ShipMonk\InputMapper\Compiler\Mapper\MapperCompilerProvider;
 use ShipMonk\InputMapper\Compiler\Mapper\OutputMapperCompilerProvider;
 use ShipMonk\InputMapper\Compiler\Mapper\UndefinedAwareMapperCompiler;
@@ -64,6 +67,8 @@ use ShipMonk\InputMapper\Compiler\Validator\Int\AssertNonPositiveInt;
 use ShipMonk\InputMapper\Compiler\Validator\Int\AssertPositiveInt;
 use ShipMonk\InputMapper\Compiler\Validator\String\AssertStringNonEmpty;
 use ShipMonk\InputMapper\Compiler\Validator\ValidatorCompiler;
+use ShipMonk\InputMapper\Runtime\Codec;
+use ShipMonk\InputMapper\Runtime\CodecRegistry;
 use ShipMonk\InputMapper\Runtime\Optional;
 use function array_column;
 use function array_fill_keys;
@@ -84,6 +89,11 @@ class DefaultMapperCompilerFactory implements MapperCompilerFactory
     final public const GENERIC_PARAMETERS = 'genericParameters';
 
     /**
+     * @var array<string, class-string<Codec<*, *, *, *>>>|null
+     */
+    private ?array $codecDomainClassMap = null;
+
+    /**
      * @param array<class-string, callable(class-string, array<string, mixed>): MapperCompilerProvider> $mapperCompilerFactories
      */
     public function __construct(
@@ -91,6 +101,7 @@ class DefaultMapperCompilerFactory implements MapperCompilerFactory
         protected readonly PhpDocParser $phpDocParser,
         protected array $mapperCompilerFactories = [],
         protected readonly ?PropertyNameTransformer $propertyNameTransformer = null,
+        protected readonly CodecRegistry $codecRegistry = new CodecRegistry(),
     )
     {
         $this->setMapperCompilerFactory(BackedEnum::class, $this->createEnumMapperCompilerProvider(...));
@@ -294,8 +305,13 @@ class DefaultMapperCompilerFactory implements MapperCompilerFactory
         }
 
         $classLikeNames = [$className => true, ...$classParents, ...$classImplements];
+        $codecDomainClassMap = $this->getCodecDomainClassMap();
 
         foreach ($classLikeNames as $classLikeName => $true) {
+            if (isset($codecDomainClassMap[$classLikeName])) {
+                return $this->createCodecMapperCompilerProvider($codecDomainClassMap[$classLikeName], $className, $options);
+            }
+
             if (isset($this->mapperCompilerFactories[$classLikeName])) {
                 $factory = $this->mapperCompilerFactories[$classLikeName];
                 return $factory($className, $options);
@@ -532,6 +548,14 @@ class DefaultMapperCompilerFactory implements MapperCompilerFactory
             $providers[] = $attribute->newInstance();
         }
 
+        foreach ($parameterReflection->getAttributes(Codec::class, ReflectionAttribute::IS_INSTANCEOF) as $attribute) {
+            $codec = $attribute->newInstance();
+
+            if (!$codec instanceof InputMapperCompilerProvider) {
+                $providers[] = new MapCodec($codec);
+            }
+        }
+
         foreach ($parameterReflection->getAttributes(ValidatorCompiler::class, ReflectionAttribute::IS_INSTANCEOF) as $attribute) {
             $validators[] = $attribute->newInstance();
         }
@@ -579,6 +603,14 @@ class DefaultMapperCompilerFactory implements MapperCompilerFactory
 
         foreach ($propertyReflection->getAttributes(OutputMapperCompilerProvider::class, ReflectionAttribute::IS_INSTANCEOF) as $attribute) {
             $outputProviders[] = $attribute->newInstance();
+        }
+
+        foreach ($propertyReflection->getAttributes(Codec::class, ReflectionAttribute::IS_INSTANCEOF) as $attribute) {
+            $codec = $attribute->newInstance();
+
+            if (!$codec instanceof OutputMapperCompilerProvider) {
+                $outputProviders[] = new MapCodec($codec);
+            }
         }
 
         return match (count($outputProviders)) {
@@ -657,6 +689,61 @@ class DefaultMapperCompilerFactory implements MapperCompilerFactory
         }
 
         throw CannotCreateMapperCompilerException::fromType(new IdentifierTypeNode($className));
+    }
+
+    /**
+     * Maps domain classes (the codec EI and DO generic parameters) to codec classes registered in the codec registry.
+     *
+     * @return array<string, class-string<Codec<*, *, *, *>>>
+     */
+    protected function getCodecDomainClassMap(): array
+    {
+        if ($this->codecDomainClassMap === null) {
+            $this->codecDomainClassMap = [];
+
+            foreach ($this->codecRegistry->getFactories() as $codecClassName => $factory) {
+                $codecType = new IdentifierTypeNode($codecClassName);
+
+                foreach ([1, 2] as $parameter) {
+                    $domainType = PhpDocTypeUtils::inferGenericParameter($codecType, Codec::class, $parameter);
+
+                    if ($domainType instanceof IdentifierTypeNode && !PhpDocTypeUtils::isKeyword($domainType)) {
+                        $conflictingCodecClassName = $this->codecDomainClassMap[$domainType->name] ?? null;
+
+                        if ($conflictingCodecClassName !== null && $conflictingCodecClassName !== $codecClassName) {
+                            throw new LogicException("Multiple codecs registered for domain class '{$domainType->name}': {$conflictingCodecClassName}, {$codecClassName}.");
+                        }
+
+                        $this->codecDomainClassMap[$domainType->name] = $codecClassName;
+                    }
+                }
+            }
+        }
+
+        return $this->codecDomainClassMap;
+    }
+
+    /**
+     * @param class-string<Codec<*, *, *, *>> $codecClassName
+     * @param class-string $domainClassName
+     * @param array<string, mixed> $options
+     */
+    protected function createCodecMapperCompilerProvider(
+        string $codecClassName,
+        string $domainClassName,
+        array $options,
+    ): MapperCompilerProvider
+    {
+        $codecType = new IdentifierTypeNode($codecClassName);
+        $decodeInputType = PhpDocTypeUtils::inferGenericParameter($codecType, Codec::class, 0);
+        $encodeOutputType = PhpDocTypeUtils::inferGenericParameter($codecType, Codec::class, 3);
+
+        return new CodecMapperCompilerProvider(
+            $codecClassName,
+            $this->createInner($decodeInputType, $options)->getInputMapperCompiler($this, $options),
+            $this->createInner($encodeOutputType, $options)->getOutputMapperCompiler($this, $options),
+            $domainClassName,
+        );
     }
 
     protected function resolveIntegerBoundary(

--- a/src/Compiler/MapperFactory/DefaultMapperCompilerFactoryProvider.php
+++ b/src/Compiler/MapperFactory/DefaultMapperCompilerFactoryProvider.php
@@ -15,25 +15,27 @@ class DefaultMapperCompilerFactoryProvider implements MapperCompilerFactoryProvi
 
     private ?MapperCompilerFactory $mapperCompilerFactory = null;
 
-    private ?CodecRegistry $lastCodecRegistry = null;
+    protected readonly CodecRegistry $codecRegistry;
 
     public function __construct(
         protected readonly ?PropertyNameTransformer $propertyNameTransformer = null,
+        ?CodecRegistry $codecRegistry = null,
     )
     {
+        $this->codecRegistry = $codecRegistry ?? new CodecRegistry();
     }
 
-    public function get(?CodecRegistry $codecRegistry = null): MapperCompilerFactory
+    public function get(): MapperCompilerFactory
     {
-        if ($this->mapperCompilerFactory === null || $codecRegistry !== $this->lastCodecRegistry) {
-            $this->lastCodecRegistry = $codecRegistry;
-            $this->mapperCompilerFactory = $this->create($codecRegistry);
-        }
-
-        return $this->mapperCompilerFactory;
+        return $this->mapperCompilerFactory ??= $this->create();
     }
 
-    protected function create(?CodecRegistry $codecRegistry = null): MapperCompilerFactory
+    public function getCodecRegistry(): CodecRegistry
+    {
+        return $this->codecRegistry;
+    }
+
+    protected function create(): MapperCompilerFactory
     {
         $config = $this->createParserConfig();
         return new DefaultMapperCompilerFactory(
@@ -41,7 +43,7 @@ class DefaultMapperCompilerFactoryProvider implements MapperCompilerFactoryProvi
             $this->createPhpDocParser($config),
             [],
             $this->propertyNameTransformer,
-            $codecRegistry ?? new CodecRegistry(),
+            $this->codecRegistry,
         );
     }
 

--- a/src/Compiler/MapperFactory/DefaultMapperCompilerFactoryProvider.php
+++ b/src/Compiler/MapperFactory/DefaultMapperCompilerFactoryProvider.php
@@ -8,11 +8,14 @@ use PHPStan\PhpDocParser\Parser\PhpDocParser;
 use PHPStan\PhpDocParser\Parser\TypeParser;
 use PHPStan\PhpDocParser\ParserConfig;
 use ShipMonk\InputMapper\Compiler\PropertyNameTransformer\PropertyNameTransformer;
+use ShipMonk\InputMapper\Runtime\CodecRegistry;
 
 class DefaultMapperCompilerFactoryProvider implements MapperCompilerFactoryProvider
 {
 
     private ?MapperCompilerFactory $mapperCompilerFactory = null;
+
+    private ?CodecRegistry $lastCodecRegistry = null;
 
     public function __construct(
         protected readonly ?PropertyNameTransformer $propertyNameTransformer = null,
@@ -20,12 +23,17 @@ class DefaultMapperCompilerFactoryProvider implements MapperCompilerFactoryProvi
     {
     }
 
-    public function get(): MapperCompilerFactory
+    public function get(?CodecRegistry $codecRegistry = null): MapperCompilerFactory
     {
-        return $this->mapperCompilerFactory ??= $this->create();
+        if ($this->mapperCompilerFactory === null || $codecRegistry !== $this->lastCodecRegistry) {
+            $this->lastCodecRegistry = $codecRegistry;
+            $this->mapperCompilerFactory = $this->create($codecRegistry);
+        }
+
+        return $this->mapperCompilerFactory;
     }
 
-    protected function create(): MapperCompilerFactory
+    protected function create(?CodecRegistry $codecRegistry = null): MapperCompilerFactory
     {
         $config = $this->createParserConfig();
         return new DefaultMapperCompilerFactory(
@@ -33,6 +41,7 @@ class DefaultMapperCompilerFactoryProvider implements MapperCompilerFactoryProvi
             $this->createPhpDocParser($config),
             [],
             $this->propertyNameTransformer,
+            $codecRegistry ?? new CodecRegistry(),
         );
     }
 

--- a/src/Compiler/MapperFactory/MapperCompilerFactory.php
+++ b/src/Compiler/MapperFactory/MapperCompilerFactory.php
@@ -8,6 +8,9 @@ use ShipMonk\InputMapper\Compiler\Mapper\MapperCompilerProvider;
 interface MapperCompilerFactory
 {
 
+    public const DELEGATE_OBJECT_MAPPING = 'delegateObjectMapping';
+    public const GENERIC_PARAMETERS = 'genericParameters';
+
     /**
      * @param array<string, mixed> $options
      */

--- a/src/Compiler/MapperFactory/MapperCompilerFactoryProvider.php
+++ b/src/Compiler/MapperFactory/MapperCompilerFactoryProvider.php
@@ -2,9 +2,11 @@
 
 namespace ShipMonk\InputMapper\Compiler\MapperFactory;
 
+use ShipMonk\InputMapper\Runtime\CodecRegistry;
+
 interface MapperCompilerFactoryProvider
 {
 
-    public function get(): MapperCompilerFactory;
+    public function get(?CodecRegistry $codecRegistry = null): MapperCompilerFactory;
 
 }

--- a/src/Compiler/MapperFactory/MapperCompilerFactoryProvider.php
+++ b/src/Compiler/MapperFactory/MapperCompilerFactoryProvider.php
@@ -7,6 +7,11 @@ use ShipMonk\InputMapper\Runtime\CodecRegistry;
 interface MapperCompilerFactoryProvider
 {
 
-    public function get(?CodecRegistry $codecRegistry = null): MapperCompilerFactory;
+    public function get(): MapperCompilerFactory;
+
+    /**
+     * Returns the codec registry used by the provided factory.
+     */
+    public function getCodecRegistry(): CodecRegistry;
 
 }

--- a/src/Compiler/Php/PhpCodeBuilder.php
+++ b/src/Compiler/Php/PhpCodeBuilder.php
@@ -40,6 +40,7 @@ use PhpParser\Node\Stmt\Else_;
 use PhpParser\Node\Stmt\ElseIf_;
 use PhpParser\Node\Stmt\Expression;
 use PhpParser\Node\Stmt\For_;
+use PhpParser\Node\Stmt\Property;
 use PhpParser\Node\Stmt\Foreach_;
 use PhpParser\Node\Stmt\If_;
 use PhpParser\Node\Stmt\Nop;
@@ -106,6 +107,11 @@ class PhpCodeBuilder extends BuilderFactory
      * @var array<string, ClassMethod>
      */
     private array $methods = [];
+
+    /**
+     * @var array<string, Property>
+     */
+    private array $properties = [];
 
     /**
      * @var array<int, array<string, bool>>
@@ -471,6 +477,17 @@ class PhpCodeBuilder extends BuilderFactory
         $this->methods[$method->name->name] = $method;
     }
 
+    public function addProperty(Property $property): void
+    {
+        $name = $property->props[0]->name->name;
+
+        if (isset($this->properties[$name])) {
+            throw new LogicException('Property already exists');
+        }
+
+        $this->properties[$name] = $property;
+    }
+
     public function importClass(string $className): string
     {
         $lastBackslashOffset = strrpos($className, '\\');
@@ -643,6 +660,7 @@ class PhpCodeBuilder extends BuilderFactory
             ->setDocComment($phpDoc)
             ->implement($this->importClass(Mapper::class))
             ->addStmts($constants)
+            ->addStmts(array_values($this->properties))
             ->addStmt($mapperConstructor)
             ->addStmt($mapMethod)
             ->addStmts(array_values($this->methods));

--- a/src/Compiler/Php/PhpCodeBuilder.php
+++ b/src/Compiler/Php/PhpCodeBuilder.php
@@ -40,10 +40,10 @@ use PhpParser\Node\Stmt\Else_;
 use PhpParser\Node\Stmt\ElseIf_;
 use PhpParser\Node\Stmt\Expression;
 use PhpParser\Node\Stmt\For_;
-use PhpParser\Node\Stmt\Property;
 use PhpParser\Node\Stmt\Foreach_;
 use PhpParser\Node\Stmt\If_;
 use PhpParser\Node\Stmt\Nop;
+use PhpParser\Node\Stmt\Property;
 use PhpParser\Node\Stmt\Return_;
 use PhpParser\Node\Stmt\Use_;
 use PHPStan\PhpDocParser\Ast\Type\ArrayShapeItemNode;
@@ -398,6 +398,18 @@ class PhpCodeBuilder extends BuilderFactory
         $uniqueName = $name;
 
         while (isset($this->methods[$uniqueName])) {
+            $uniqueName = $name . ++$i;
+        }
+
+        return $uniqueName;
+    }
+
+    public function uniqPropertyName(string $name): string
+    {
+        $i = 1;
+        $uniqueName = $name;
+
+        while (isset($this->properties[$uniqueName])) {
             $uniqueName = $name . ++$i;
         }
 

--- a/src/Compiler/Type/PhpDocTypeUtils.php
+++ b/src/Compiler/Type/PhpDocTypeUtils.php
@@ -723,6 +723,10 @@ class PhpDocTypeUtils
             ));
         }
 
+        if ($type instanceof IdentifierTypeNode && !self::isKeyword($type)) {
+            return self::inferGenericParameter(new GenericTypeNode($type, []), $typeName, $parameter);
+        }
+
         if ($type instanceof GenericTypeNode) {
             if (strcasecmp($type->type->name, $typeName) === 0) {
                 return self::getGenericTypeParameter($type, $parameter);
@@ -1005,7 +1009,62 @@ class PhpDocTypeUtils
         return new GenericTypeDefinition(
             extends: $extends,
             parameters: array_values($genericParameters),
+            parameterOffsetMapping: self::deriveParameterOffsetMapping($genericParameters, $genericParameterOffsets),
         );
+    }
+
+    /**
+     * Derives which parameter offsets to use when fewer generic arguments are provided than there are parameters,
+     * based on template defaults referencing other template parameters (e.g. `@template DO = EI`).
+     *
+     * @param array<string, GenericTypeParameter> $genericParameters
+     * @param array<string, int> $genericParameterOffsets
+     * @return array<int, list<?int>>
+     */
+    private static function deriveParameterOffsetMapping(
+        array $genericParameters,
+        array $genericParameterOffsets,
+    ): array
+    {
+        $parameterList = array_values($genericParameters);
+        $totalParams = count($parameterList);
+        $parameterOffsetMapping = [];
+
+        for ($count = $totalParams - 1; $count >= 1; $count--) {
+            // all params at index >= $count must have defaults for this count to be valid
+            $allDefaultable = true;
+
+            for ($i = $count; $i < $totalParams; $i++) {
+                if ($parameterList[$i]->default === null) {
+                    $allDefaultable = false;
+                    break;
+                }
+            }
+
+            if (!$allDefaultable) {
+                break;
+            }
+
+            $mapping = [];
+
+            for ($i = 0; $i < $totalParams; $i++) {
+                if ($i < $count) {
+                    $mapping[] = $i;
+                } else {
+                    $default = $parameterList[$i]->default;
+
+                    if ($default instanceof IdentifierTypeNode && isset($genericParameterOffsets[$default->name])) {
+                        $mapping[] = $genericParameterOffsets[$default->name];
+                    } else {
+                        $mapping[] = null;
+                    }
+                }
+            }
+
+            $parameterOffsetMapping[$count] = $mapping;
+        }
+
+        return $parameterOffsetMapping;
     }
 
     private static function parsePhpDoc(string $phpDoc): PhpDocNode

--- a/src/Compiler/Type/PhpDocTypeUtils.php
+++ b/src/Compiler/Type/PhpDocTypeUtils.php
@@ -59,6 +59,7 @@ use function count;
 use function defined;
 use function get_debug_type;
 use function get_object_vars;
+use function get_parent_class;
 use function in_array;
 use function interface_exists;
 use function is_a;
@@ -701,6 +702,9 @@ class PhpDocTypeUtils
         return false;
     }
 
+    /**
+     * @throws LogicException when the type is not a subtype of the given generic type
+     */
     public static function inferGenericParameter(
         TypeNode $type,
         string $typeName,
@@ -724,7 +728,18 @@ class PhpDocTypeUtils
         }
 
         if ($type instanceof IdentifierTypeNode && !self::isKeyword($type)) {
-            return self::inferGenericParameter(new GenericTypeNode($type, []), $typeName, $parameter);
+            try {
+                return self::inferGenericParameter(new GenericTypeNode($type, []), $typeName, $parameter);
+            } catch (LogicException $e) {
+                // a class with no own @implements/@extends tags inherits the generic args of its native parent
+                $parentClassName = class_exists($type->name) ? get_parent_class($type->name) : false;
+
+                if ($parentClassName !== false) {
+                    return self::inferGenericParameter(new IdentifierTypeNode($parentClassName), $typeName, $parameter);
+                }
+
+                throw $e;
+            }
         }
 
         if ($type instanceof GenericTypeNode) {
@@ -1051,13 +1066,7 @@ class PhpDocTypeUtils
                 if ($i < $count) {
                     $mapping[] = $i;
                 } else {
-                    $default = $parameterList[$i]->default;
-
-                    if ($default instanceof IdentifierTypeNode && isset($genericParameterOffsets[$default->name])) {
-                        $mapping[] = $genericParameterOffsets[$default->name];
-                    } else {
-                        $mapping[] = null;
-                    }
+                    $mapping[] = self::resolveDefaultParameterOffset($parameterList, $genericParameterOffsets, $i, $count);
                 }
             }
 
@@ -1065,6 +1074,40 @@ class PhpDocTypeUtils
         }
 
         return $parameterOffsetMapping;
+    }
+
+    /**
+     * Follows a chain of template defaults referencing other template parameters
+     * until it reaches a parameter that is actually provided (offset < $providedCount).
+     *
+     * @param list<GenericTypeParameter> $parameterList
+     * @param array<string, int> $genericParameterOffsets
+     */
+    private static function resolveDefaultParameterOffset(
+        array $parameterList,
+        array $genericParameterOffsets,
+        int $index,
+        int $providedCount,
+    ): ?int
+    {
+        $visited = [];
+
+        while (!isset($visited[$index])) {
+            $visited[$index] = true;
+            $default = $parameterList[$index]->default;
+
+            if (!$default instanceof IdentifierTypeNode || !isset($genericParameterOffsets[$default->name])) {
+                return null;
+            }
+
+            $index = $genericParameterOffsets[$default->name];
+
+            if ($index < $providedCount) {
+                return $index;
+            }
+        }
+
+        return null;
     }
 
     private static function parsePhpDoc(string $phpDoc): PhpDocNode

--- a/src/Runtime/Codec.php
+++ b/src/Runtime/Codec.php
@@ -1,0 +1,43 @@
+<?php declare(strict_types = 1);
+
+namespace ShipMonk\InputMapper\Runtime;
+
+use ShipMonk\InputMapper\Runtime\Exception\MappingFailedException;
+
+/**
+ * Bidirectional type conversion between intermediate and domain types.
+ * The library auto-compiles the mixed -> intermediate bridge; the user implements the intermediate -> domain conversion.
+ *
+ * @template DI The intermediate type (decode input)
+ * @template EI The domain type (encode input)
+ * @template DO = EI The domain type (decode output)
+ * @template EO = DI The intermediate type (encode output)
+ */
+interface Codec
+{
+
+    /**
+     * @param DI $data
+     * @param list<string|int> $path
+     * @return DO
+     *
+     * @throws MappingFailedException
+     */
+    public function decode(
+        mixed $data,
+        array $path = [],
+    ): mixed;
+
+    /**
+     * @param EI $data
+     * @param list<string|int> $path
+     * @return EO
+     *
+     * @throws MappingFailedException
+     */
+    public function encode(
+        mixed $data,
+        array $path = [],
+    ): mixed;
+
+}

--- a/src/Runtime/CodecRegistry.php
+++ b/src/Runtime/CodecRegistry.php
@@ -1,0 +1,86 @@
+<?php declare(strict_types = 1);
+
+namespace ShipMonk\InputMapper\Runtime;
+
+use LogicException;
+
+class CodecRegistry
+{
+
+    /**
+     * @var array<class-string<Codec<*, *, *, *>>, callable(class-string, self): Codec<*, *, *, *>>
+     */
+    private array $codecFactories = [];
+
+    /**
+     * @var array<string, Codec<*, *, *, *>>
+     */
+    private array $codecs = [];
+
+    /**
+     * @param Codec<*, *, *, *> $codec
+     */
+    public function register(
+        Codec $codec,
+    ): void
+    {
+        $this->registerFactory($codec::class, static fn (): Codec => $codec);
+    }
+
+    /**
+     * @param class-string<T> $codecClassName
+     * @param callable(class-string, self): T $factory
+     *
+     * @template T of Codec<*, *, *, *>
+     */
+    public function registerFactory(
+        string $codecClassName,
+        callable $factory,
+    ): void
+    {
+        $this->codecFactories[$codecClassName] = $factory;
+    }
+
+    /**
+     * @return array<class-string<Codec<*, *, *, *>>, callable(class-string, self): Codec<*, *, *, *>>
+     */
+    public function getFactories(): array
+    {
+        return $this->codecFactories;
+    }
+
+    /**
+     * @param class-string<T> $codecClassName
+     * @param class-string $domainClassName
+     * @return T
+     *
+     * @template T of Codec<*, *, *, *>
+     */
+    public function get(
+        string $codecClassName,
+        string $domainClassName,
+    ): Codec
+    {
+        $key = $codecClassName . ':' . $domainClassName;
+
+        return $this->codecs[$key] // @phpstan-ignore return.type
+            ??= $this->createFromFactory($codecClassName, $domainClassName);
+    }
+
+    /**
+     * @param class-string<Codec<*, *, *, *>> $codecClassName
+     * @param class-string $domainClassName
+     * @return Codec<*, *, *, *>
+     */
+    private function createFromFactory(
+        string $codecClassName,
+        string $domainClassName,
+    ): Codec
+    {
+        $factory = $this->codecFactories[$codecClassName]
+            ?? throw new LogicException("No codec factory registered for '{$codecClassName}'.");
+
+        return $factory($domainClassName, $this);
+    }
+
+}

--- a/src/Runtime/CodecRegistry.php
+++ b/src/Runtime/CodecRegistry.php
@@ -3,6 +3,7 @@
 namespace ShipMonk\InputMapper\Runtime;
 
 use LogicException;
+use function str_starts_with;
 
 class CodecRegistry
 {
@@ -38,6 +39,12 @@ class CodecRegistry
         callable $factory,
     ): void
     {
+        foreach ($this->codecs as $key => $codec) {
+            if (str_starts_with($key, $codecClassName . ':')) {
+                unset($this->codecs[$key]);
+            }
+        }
+
         $this->codecFactories[$codecClassName] = $factory;
     }
 

--- a/src/Runtime/MapperProvider.php
+++ b/src/Runtime/MapperProvider.php
@@ -260,8 +260,8 @@ class MapperProvider
         $codePrinter = new PhpCodePrinter();
 
         $mapperCompiler = $direction === 'input'
-            ? $mapperCompilerFactory->create($type)->getInputMapperCompiler()
-            : $mapperCompilerFactory->create($type)->getOutputMapperCompiler();
+            ? $mapperCompilerFactory->create($type)->getInputMapperCompiler($mapperCompilerFactory, [])
+            : $mapperCompilerFactory->create($type)->getOutputMapperCompiler($mapperCompilerFactory, []);
 
         return $codePrinter->prettyPrintFile($codeBuilder->mapperFile($mapperClassName, $mapperCompiler));
     }

--- a/src/Runtime/MapperProvider.php
+++ b/src/Runtime/MapperProvider.php
@@ -15,6 +15,7 @@ use function class_implements;
 use function class_parents;
 use function count;
 use function dirname;
+use function fclose;
 use function file_put_contents;
 use function flock;
 use function fopen;
@@ -55,16 +56,12 @@ class MapperProvider
      */
     private array $outputMapperFactories = [];
 
-    private readonly CodecRegistry $codecRegistry;
-
     public function __construct(
         private readonly string $tempDir,
         private readonly bool $autoRefresh = false,
         private readonly MapperCompilerFactoryProvider $mapperCompilerFactoryProvider = new DefaultMapperCompilerFactoryProvider(),
-        ?CodecRegistry $codecRegistry = null,
     )
     {
-        $this->codecRegistry = $codecRegistry ?? new CodecRegistry();
     }
 
     /**
@@ -144,9 +141,8 @@ class MapperProvider
     /**
      * Registers a codec instance used for both input and output mapping of its domain classes.
      *
-     * Note that codecs must be registered before the first mapper is compiled and that compiled mappers
-     * are cached on disk, so with `autoRefresh: false` changing codec registrations does not invalidate
-     * previously compiled mappers.
+     * Register codecs before compiling mappers: mappers already compiled (loaded in this process,
+     * or cached on disk when `autoRefresh` is disabled) do not observe later registrations.
      *
      * @param Codec<*, *, *, *> $codec
      */
@@ -154,7 +150,7 @@ class MapperProvider
         Codec $codec,
     ): void
     {
-        $this->codecRegistry->register($codec);
+        $this->mapperCompilerFactoryProvider->getCodecRegistry()->register($codec);
     }
 
     /**
@@ -171,7 +167,7 @@ class MapperProvider
         callable $factory,
     ): void
     {
-        $this->codecRegistry->registerFactory($codecClassName, $factory);
+        $this->mapperCompilerFactoryProvider->getCodecRegistry()->registerFactory($codecClassName, $factory);
     }
 
     /**
@@ -186,7 +182,7 @@ class MapperProvider
         string $domainClassName,
     ): Codec
     {
-        return $this->codecRegistry->get($codecClassName, $domainClassName);
+        return $this->mapperCompilerFactoryProvider->getCodecRegistry()->get($codecClassName, $domainClassName);
     }
 
     /**
@@ -278,20 +274,23 @@ class MapperProvider
             throw new RuntimeException("Unable to acquire exclusive lock '$path.lock'.");
         }
 
-        if (!is_file($path) || $this->autoRefresh) {
-            $code = $this->compile($className, $mapperClassName, $direction);
+        try {
+            if (!is_file($path) || $this->autoRefresh) {
+                $code = $this->compile($className, $mapperClassName, $direction);
 
-            if (file_put_contents("$path.tmp", $code) !== strlen($code) || !rename("$path.tmp", $path)) {
-                @unlink("$path.tmp"); // @ file may not exist
-                throw new RuntimeException("Unable to create '$path'.");
+                if (file_put_contents("$path.tmp", $code) !== strlen($code) || !rename("$path.tmp", $path)) {
+                    @unlink("$path.tmp"); // @ file may not exist
+                    throw new RuntimeException("Unable to create '$path'.");
+                }
             }
-        }
 
-        if ((@include $path) === false) { // @ error escalated to exception
-            throw new RuntimeException("Unable to load '$path'.");
+            if ((@include $path) === false) { // @ error escalated to exception
+                throw new RuntimeException("Unable to load '$path'.");
+            }
+        } finally {
+            flock($handle, LOCK_UN);
+            fclose($handle);
         }
-
-        flock($handle, LOCK_UN);
     }
 
     /**
@@ -305,7 +304,7 @@ class MapperProvider
         string $direction,
     ): string
     {
-        $mapperCompilerFactory = $this->mapperCompilerFactoryProvider->get($this->codecRegistry);
+        $mapperCompilerFactory = $this->mapperCompilerFactoryProvider->get();
         $type = new IdentifierTypeNode($className);
 
         $codeBuilder = new PhpCodeBuilder();

--- a/src/Runtime/MapperProvider.php
+++ b/src/Runtime/MapperProvider.php
@@ -55,12 +55,16 @@ class MapperProvider
      */
     private array $outputMapperFactories = [];
 
+    private readonly CodecRegistry $codecRegistry;
+
     public function __construct(
         private readonly string $tempDir,
         private readonly bool $autoRefresh = false,
         private readonly MapperCompilerFactoryProvider $mapperCompilerFactoryProvider = new DefaultMapperCompilerFactoryProvider(),
+        ?CodecRegistry $codecRegistry = null,
     )
     {
+        $this->codecRegistry = $codecRegistry ?? new CodecRegistry();
     }
 
     /**
@@ -135,6 +139,54 @@ class MapperProvider
         }
 
         $this->outputMapperFactories[$className] = $mapperFactory; // @phpstan-ignore assign.propertyType
+    }
+
+    /**
+     * Registers a codec instance used for both input and output mapping of its domain classes.
+     *
+     * Note that codecs must be registered before the first mapper is compiled and that compiled mappers
+     * are cached on disk, so with `autoRefresh: false` changing codec registrations does not invalidate
+     * previously compiled mappers.
+     *
+     * @param Codec<*, *, *, *> $codec
+     */
+    public function registerCodec(
+        Codec $codec,
+    ): void
+    {
+        $this->codecRegistry->register($codec);
+    }
+
+    /**
+     * Registers a factory creating codec instances lazily, once per domain class.
+     * Useful for generic codecs that handle a family of classes (the factory receives the concrete domain class name).
+     *
+     * @param class-string<T> $codecClassName
+     * @param callable(class-string, CodecRegistry): T $factory
+     *
+     * @template T of Codec<*, *, *, *>
+     */
+    public function registerCodecFactory(
+        string $codecClassName,
+        callable $factory,
+    ): void
+    {
+        $this->codecRegistry->registerFactory($codecClassName, $factory);
+    }
+
+    /**
+     * @param class-string<T> $codecClassName
+     * @param class-string $domainClassName
+     * @return T
+     *
+     * @template T of Codec<*, *, *, *>
+     */
+    public function getCodec(
+        string $codecClassName,
+        string $domainClassName,
+    ): Codec
+    {
+        return $this->codecRegistry->get($codecClassName, $domainClassName);
     }
 
     /**
@@ -253,7 +305,7 @@ class MapperProvider
         string $direction,
     ): string
     {
-        $mapperCompilerFactory = $this->mapperCompilerFactoryProvider->get();
+        $mapperCompilerFactory = $this->mapperCompilerFactoryProvider->get($this->codecRegistry);
         $type = new IdentifierTypeNode($className);
 
         $codeBuilder = new PhpCodeBuilder();

--- a/tests/Compiler/Attribute/MapChainTest.php
+++ b/tests/Compiler/Attribute/MapChainTest.php
@@ -19,7 +19,7 @@ class MapChainTest extends InputMapperTestCase
     {
         $mapChain = new MapChain([new MapString(), new MapInt()]);
 
-        $result = $mapChain->getInputMapperCompiler();
+        $result = $mapChain->getInputMapperCompiler(self::createMapperCompilerFactory(), []);
 
         self::assertEquals(
             new ChainMapperCompiler([new StringInputMapperCompiler(), new IntInputMapperCompiler()]),
@@ -31,7 +31,7 @@ class MapChainTest extends InputMapperTestCase
     {
         $mapChain = new MapChain([new MapString(), new MapInt()]);
 
-        $result = $mapChain->getOutputMapperCompiler();
+        $result = $mapChain->getOutputMapperCompiler(self::createMapperCompilerFactory(), []);
 
         self::assertEquals(
             new ChainMapperCompiler([

--- a/tests/Compiler/Attribute/MapCodecTest.php
+++ b/tests/Compiler/Attribute/MapCodecTest.php
@@ -8,6 +8,9 @@ use ShipMonk\InputMapper\Compiler\Mapper\Codec\InlineCodecInputMapperCompiler;
 use ShipMonk\InputMapper\Compiler\Mapper\Codec\InlineCodecOutputMapperCompiler;
 use ShipMonk\InputMapperTests\Compiler\Mapper\Codec\Data\CurrencyPrefixCodec;
 use ShipMonk\InputMapperTests\Compiler\Mapper\Codec\Data\ObjectArgCodec;
+use ShipMonk\InputMapperTests\Compiler\Mapper\Codec\Data\ParentPrivatePropCodec;
+use ShipMonk\InputMapperTests\Compiler\Mapper\Codec\Data\StaticPropCodec;
+use ShipMonk\InputMapperTests\Compiler\Mapper\Codec\Data\UninitPropCodec;
 use ShipMonk\InputMapperTests\InputMapperTestCase;
 use ShipMonk\InputMapperTests\Runtime\Data\MoneyValue;
 
@@ -48,6 +51,41 @@ class MapCodecTest extends InputMapperTestCase
             'Cannot compile codec %s inline, because constructor argument $money must be a scalar or null value, got %s',
             static fn () => (new MapCodec($codec))->getInputMapperCompiler($factory, []),
         );
+    }
+
+    public function testStaticPropertyConstructorArgumentIsRejected(): void
+    {
+        $factory = self::createMapperCompilerFactory();
+        $codec = new StaticPropCodec('local');
+
+        self::assertException(
+            CannotCreateMapperCompilerException::class,
+            'Cannot compile codec %s inline, because constructor argument $mode matches a static property',
+            static fn () => (new MapCodec($codec))->getInputMapperCompiler($factory, []),
+        );
+    }
+
+    public function testUninitializedPropertyConstructorArgumentIsRejected(): void
+    {
+        $factory = self::createMapperCompilerFactory();
+        $codec = new UninitPropCodec('local');
+
+        self::assertException(
+            CannotCreateMapperCompilerException::class,
+            'Cannot compile codec %s inline, because constructor argument $mode matches an uninitialized property',
+            static fn () => (new MapCodec($codec))->getInputMapperCompiler($factory, []),
+        );
+    }
+
+    public function testPrivatePropertyOfParentClassIsExtracted(): void
+    {
+        $factory = self::createMapperCompilerFactory();
+        $mapCodec = new MapCodec(new ParentPrivatePropCodec('shh-'));
+
+        $mapperCompiler = $mapCodec->getInputMapperCompiler($factory, []);
+
+        self::assertInstanceOf(InlineCodecInputMapperCompiler::class, $mapperCompiler);
+        self::assertSame(['secret' => 'shh-'], $mapperCompiler->constructorArgs);
     }
 
 }

--- a/tests/Compiler/Attribute/MapCodecTest.php
+++ b/tests/Compiler/Attribute/MapCodecTest.php
@@ -1,0 +1,53 @@
+<?php declare(strict_types = 1);
+
+namespace ShipMonk\InputMapperTests\Compiler\Attribute;
+
+use ShipMonk\InputMapper\Compiler\Attribute\MapCodec;
+use ShipMonk\InputMapper\Compiler\Exception\CannotCreateMapperCompilerException;
+use ShipMonk\InputMapper\Compiler\Mapper\Codec\InlineCodecInputMapperCompiler;
+use ShipMonk\InputMapper\Compiler\Mapper\Codec\InlineCodecOutputMapperCompiler;
+use ShipMonk\InputMapperTests\Compiler\Mapper\Codec\Data\CurrencyPrefixCodec;
+use ShipMonk\InputMapperTests\Compiler\Mapper\Codec\Data\ObjectArgCodec;
+use ShipMonk\InputMapperTests\InputMapperTestCase;
+use ShipMonk\InputMapperTests\Runtime\Data\MoneyValue;
+
+class MapCodecTest extends InputMapperTestCase
+{
+
+    public function testGetInputMapperCompiler(): void
+    {
+        $factory = self::createMapperCompilerFactory();
+        $mapCodec = new MapCodec(new CurrencyPrefixCodec('EUR', '-'));
+
+        $mapperCompiler = $mapCodec->getInputMapperCompiler($factory, []);
+
+        self::assertInstanceOf(InlineCodecInputMapperCompiler::class, $mapperCompiler);
+        self::assertSame(CurrencyPrefixCodec::class, $mapperCompiler->codecClassName);
+        self::assertSame(['prefix' => 'EUR', 'separator' => '-'], $mapperCompiler->constructorArgs);
+    }
+
+    public function testGetOutputMapperCompiler(): void
+    {
+        $factory = self::createMapperCompilerFactory();
+        $mapCodec = new MapCodec(new CurrencyPrefixCodec('EUR', '-'));
+
+        $mapperCompiler = $mapCodec->getOutputMapperCompiler($factory, []);
+
+        self::assertInstanceOf(InlineCodecOutputMapperCompiler::class, $mapperCompiler);
+        self::assertSame(CurrencyPrefixCodec::class, $mapperCompiler->codecClassName);
+        self::assertSame(['prefix' => 'EUR', 'separator' => '-'], $mapperCompiler->constructorArgs);
+    }
+
+    public function testNonScalarConstructorArgumentIsRejected(): void
+    {
+        $factory = self::createMapperCompilerFactory();
+        $codec = new ObjectArgCodec(new MoneyValue('USD', 1));
+
+        self::assertException(
+            CannotCreateMapperCompilerException::class,
+            'Cannot compile codec %s inline, because constructor argument $money must be a scalar or null value, got %s',
+            static fn () => (new MapCodec($codec))->getInputMapperCompiler($factory, []),
+        );
+    }
+
+}

--- a/tests/Compiler/Mapper/Codec/CodecInputMapperCompilerTest.php
+++ b/tests/Compiler/Mapper/Codec/CodecInputMapperCompilerTest.php
@@ -1,0 +1,70 @@
+<?php declare(strict_types = 1);
+
+namespace ShipMonk\InputMapperTests\Compiler\Mapper\Codec;
+
+use ShipMonk\InputMapper\Compiler\Mapper\Codec\CodecInputMapperCompiler;
+use ShipMonk\InputMapper\Compiler\Mapper\Input\ArrayShapeInputMapperCompiler;
+use ShipMonk\InputMapper\Compiler\Mapper\Input\IntInputMapperCompiler;
+use ShipMonk\InputMapper\Compiler\Mapper\Input\StringInputMapperCompiler;
+use ShipMonk\InputMapper\Runtime\Exception\MappingFailedException;
+use ShipMonk\InputMapperTests\Compiler\Mapper\MapperCompilerTestCase;
+use ShipMonk\InputMapperTests\Runtime\Data\MoneyCodec;
+use ShipMonk\InputMapperTests\Runtime\Data\MoneyValue;
+
+class CodecInputMapperCompilerTest extends MapperCompilerTestCase
+{
+
+    public function testCompile(): void
+    {
+        $mapper = $this->compileInputMapper(
+            'CodecMoney',
+            new CodecInputMapperCompiler(MoneyCodec::class, $this->createIntermediateInputMapper(), MoneyValue::class),
+            codecs: [MoneyCodec::class => new MoneyCodec()],
+        );
+
+        /** @var MoneyValue $result */
+        $result = $mapper->map(['currency' => 'USD', 'cents' => 1_299]);
+
+        self::assertSame('USD', $result->currency);
+        self::assertSame(1_299, $result->cents);
+    }
+
+    public function testCompileWithInvalidInput(): void
+    {
+        $mapper = $this->compileInputMapper(
+            'CodecMoney',
+            new CodecInputMapperCompiler(MoneyCodec::class, $this->createIntermediateInputMapper(), MoneyValue::class),
+            codecs: [MoneyCodec::class => new MoneyCodec()],
+        );
+
+        self::assertException(
+            MappingFailedException::class,
+            'Failed to map data at path /: Expected array, got "invalid"',
+            static fn () => $mapper->map('invalid'),
+        );
+    }
+
+    public function testCompileWithDecodeValidation(): void
+    {
+        $mapper = $this->compileInputMapper(
+            'CodecMoney',
+            new CodecInputMapperCompiler(MoneyCodec::class, $this->createIntermediateInputMapper(), MoneyValue::class),
+            codecs: [MoneyCodec::class => new MoneyCodec()],
+        );
+
+        self::assertException(
+            MappingFailedException::class,
+            'Failed to map data at path /cents: Expected non-negative integer, got -1',
+            static fn () => $mapper->map(['currency' => 'USD', 'cents' => -1]),
+        );
+    }
+
+    private function createIntermediateInputMapper(): ArrayShapeInputMapperCompiler
+    {
+        return new ArrayShapeInputMapperCompiler([
+            ['key' => 'currency', 'mapper' => new StringInputMapperCompiler(), 'optional' => false],
+            ['key' => 'cents', 'mapper' => new IntInputMapperCompiler(), 'optional' => false],
+        ]);
+    }
+
+}

--- a/tests/Compiler/Mapper/Codec/CodecOutputMapperCompilerTest.php
+++ b/tests/Compiler/Mapper/Codec/CodecOutputMapperCompilerTest.php
@@ -1,0 +1,37 @@
+<?php declare(strict_types = 1);
+
+namespace ShipMonk\InputMapperTests\Compiler\Mapper\Codec;
+
+use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
+use ShipMonk\InputMapper\Compiler\Mapper\Codec\CodecOutputMapperCompiler;
+use ShipMonk\InputMapper\Compiler\Mapper\Output\ArrayShapeOutputMapperCompiler;
+use ShipMonk\InputMapper\Compiler\Mapper\PassthroughMapperCompiler;
+use ShipMonk\InputMapperTests\Compiler\Mapper\MapperCompilerTestCase;
+use ShipMonk\InputMapperTests\Runtime\Data\MoneyCodec;
+use ShipMonk\InputMapperTests\Runtime\Data\MoneyValue;
+
+class CodecOutputMapperCompilerTest extends MapperCompilerTestCase
+{
+
+    public function testCompile(): void
+    {
+        $mapper = $this->compileOutputMapper(
+            'CodecMoney',
+            new CodecOutputMapperCompiler(MoneyCodec::class, $this->createIntermediateOutputMapper(), MoneyValue::class),
+            codecs: [MoneyCodec::class => new MoneyCodec()],
+        );
+
+        $result = $mapper->map(new MoneyValue('EUR', 500));
+
+        self::assertSame(['currency' => 'EUR', 'cents' => 500], $result);
+    }
+
+    private function createIntermediateOutputMapper(): ArrayShapeOutputMapperCompiler
+    {
+        return new ArrayShapeOutputMapperCompiler([
+            ['key' => 'currency', 'mapper' => new PassthroughMapperCompiler(new IdentifierTypeNode('string')), 'optional' => false],
+            ['key' => 'cents', 'mapper' => new PassthroughMapperCompiler(new IdentifierTypeNode('int')), 'optional' => false],
+        ]);
+    }
+
+}

--- a/tests/Compiler/Mapper/Codec/Data/BasePrivatePropCodec.php
+++ b/tests/Compiler/Mapper/Codec/Data/BasePrivatePropCodec.php
@@ -1,0 +1,37 @@
+<?php declare(strict_types = 1);
+
+namespace ShipMonk\InputMapperTests\Compiler\Mapper\Codec\Data;
+
+use ShipMonk\InputMapper\Runtime\Codec;
+
+/**
+ * Codec base class with a private promoted constructor property.
+ *
+ * @implements Codec<string, string, string, string>
+ */
+abstract class BasePrivatePropCodec implements Codec
+{
+
+    public function __construct(
+        private readonly string $secret,
+    )
+    {
+    }
+
+    /**
+     * @param list<string|int> $path
+     */
+    public function decode(mixed $data, array $path = []): string
+    {
+        return $this->secret . $data;
+    }
+
+    /**
+     * @param list<string|int> $path
+     */
+    public function encode(mixed $data, array $path = []): string
+    {
+        return $data;
+    }
+
+}

--- a/tests/Compiler/Mapper/Codec/Data/CodecMoneyMapper.php
+++ b/tests/Compiler/Mapper/Codec/Data/CodecMoneyMapper.php
@@ -1,0 +1,88 @@
+<?php declare (strict_types=1);
+
+namespace ShipMonk\InputMapperTests\Compiler\Mapper\Codec\Data;
+
+use ShipMonk\InputMapperTests\Runtime\Data\MoneyCodec;
+use ShipMonk\InputMapperTests\Runtime\Data\MoneyValue;
+use ShipMonk\InputMapper\Compiler\Mapper\Codec\CodecInputMapperCompiler;
+use ShipMonk\InputMapper\Runtime\Exception\MappingFailedException;
+use ShipMonk\InputMapper\Runtime\Mapper;
+use ShipMonk\InputMapper\Runtime\MapperProvider;
+use function array_diff_key;
+use function array_key_exists;
+use function array_keys;
+use function count;
+use function is_array;
+use function is_int;
+use function is_string;
+
+/**
+ * Generated mapper by {@see CodecInputMapperCompiler}. Do not edit directly.
+ *
+ * @implements Mapper<mixed, MoneyValue>
+ */
+class CodecMoneyMapper implements Mapper
+{
+    public function __construct(private readonly MapperProvider $provider)
+    {
+    }
+
+    /**
+     * @param  list<string|int> $path
+     * @throws MappingFailedException
+     */
+    public function map(mixed $data, array $path = []): MoneyValue
+    {
+        if (!is_array($data)) {
+            throw MappingFailedException::incorrectType($data, $path, 'array');
+        }
+
+        $mapped = [];
+
+        if (!array_key_exists('currency', $data)) {
+            throw MappingFailedException::missingKey($path, 'currency');
+        }
+
+        $mapped['currency'] = $this->mapCurrency($data['currency'], [...$path, 'currency']);
+
+        if (!array_key_exists('cents', $data)) {
+            throw MappingFailedException::missingKey($path, 'cents');
+        }
+
+        $mapped['cents'] = $this->mapCents($data['cents'], [...$path, 'cents']);
+        $knownKeys = ['currency' => true, 'cents' => true];
+        $extraKeys = array_diff_key($data, $knownKeys);
+
+        if (count($extraKeys) > 0) {
+            throw MappingFailedException::extraKeys($path, array_keys($extraKeys));
+        }
+
+        return $this->provider->getCodec(MoneyCodec::class, MoneyValue::class)->decode($mapped, $path);
+    }
+
+    /**
+     * @param  list<string|int> $path
+     * @throws MappingFailedException
+     */
+    private function mapCurrency(mixed $data, array $path = []): string
+    {
+        if (!is_string($data)) {
+            throw MappingFailedException::incorrectType($data, $path, 'string');
+        }
+
+        return $data;
+    }
+
+    /**
+     * @param  list<string|int> $path
+     * @throws MappingFailedException
+     */
+    private function mapCents(mixed $data, array $path = []): int
+    {
+        if (!is_int($data)) {
+            throw MappingFailedException::incorrectType($data, $path, 'int');
+        }
+
+        return $data;
+    }
+}

--- a/tests/Compiler/Mapper/Codec/Data/CodecMoneyOutputMapper.php
+++ b/tests/Compiler/Mapper/Codec/Data/CodecMoneyOutputMapper.php
@@ -1,0 +1,34 @@
+<?php declare (strict_types=1);
+
+namespace ShipMonk\InputMapperTests\Compiler\Mapper\Codec\Data;
+
+use ShipMonk\InputMapperTests\Runtime\Data\MoneyCodec;
+use ShipMonk\InputMapperTests\Runtime\Data\MoneyValue;
+use ShipMonk\InputMapper\Compiler\Mapper\Codec\CodecOutputMapperCompiler;
+use ShipMonk\InputMapper\Runtime\Exception\MappingFailedException;
+use ShipMonk\InputMapper\Runtime\Mapper;
+use ShipMonk\InputMapper\Runtime\MapperProvider;
+
+/**
+ * Generated mapper by {@see CodecOutputMapperCompiler}. Do not edit directly.
+ *
+ * @implements Mapper<MoneyValue, array{currency: string, cents: int}>
+ */
+class CodecMoneyOutputMapper implements Mapper
+{
+    public function __construct(private readonly MapperProvider $provider)
+    {
+    }
+
+    /**
+     * @param  MoneyValue $data
+     * @param  list<string|int> $path
+     * @return array{currency: string, cents: int}
+     * @throws MappingFailedException
+     */
+    public function map(mixed $data, array $path = []): array
+    {
+        $encoded = $this->provider->getCodec(MoneyCodec::class, MoneyValue::class)->encode($data, $path);
+        return ['currency' => $encoded['currency'], 'cents' => $encoded['cents']];
+    }
+}

--- a/tests/Compiler/Mapper/Codec/Data/CurrencyPrefixCodec.php
+++ b/tests/Compiler/Mapper/Codec/Data/CurrencyPrefixCodec.php
@@ -1,0 +1,52 @@
+<?php declare(strict_types = 1);
+
+namespace ShipMonk\InputMapperTests\Compiler\Mapper\Codec\Data;
+
+use Attribute;
+use ShipMonk\InputMapper\Runtime\Codec;
+use ShipMonk\InputMapper\Runtime\Exception\MappingFailedException;
+use function str_starts_with;
+use function strlen;
+use function substr;
+
+/**
+ * A simple codec for testing inline codec attributes.
+ * Converts between a prefixed string (e.g. "USD:1299") and the bare value ("1299").
+ *
+ * @implements Codec<string, string, string, string>
+ */
+#[Attribute(Attribute::TARGET_PARAMETER | Attribute::TARGET_PROPERTY)]
+class CurrencyPrefixCodec implements Codec
+{
+
+    public function __construct(
+        public readonly string $prefix = 'USD',
+        public readonly string $separator = ':',
+    )
+    {
+    }
+
+    /**
+     * @param list<string|int> $path
+     * @throws MappingFailedException
+     */
+    public function decode(mixed $data, array $path = []): string
+    {
+        $expectedPrefix = $this->prefix . $this->separator;
+
+        if (!str_starts_with($data, $expectedPrefix)) {
+            throw MappingFailedException::incorrectValue($data, $path, "string starting with '{$expectedPrefix}'");
+        }
+
+        return substr($data, strlen($expectedPrefix));
+    }
+
+    /**
+     * @param list<string|int> $path
+     */
+    public function encode(mixed $data, array $path = []): string
+    {
+        return $this->prefix . $this->separator . $data;
+    }
+
+}

--- a/tests/Compiler/Mapper/Codec/Data/InlineCodecCurrencyPrefixEurMapper.php
+++ b/tests/Compiler/Mapper/Codec/Data/InlineCodecCurrencyPrefixEurMapper.php
@@ -31,7 +31,7 @@ class InlineCodecCurrencyPrefixEurMapper implements Mapper
             throw MappingFailedException::incorrectType($data, $path, 'string');
         }
 
-        $this->codec ??= new CurrencyPrefixCodec('EUR', '-');
+        $this->codec ??= new CurrencyPrefixCodec(prefix: 'EUR', separator: '-');
         return $this->codec->decode($data, $path);
     }
 }

--- a/tests/Compiler/Mapper/Codec/Data/InlineCodecCurrencyPrefixEurMapper.php
+++ b/tests/Compiler/Mapper/Codec/Data/InlineCodecCurrencyPrefixEurMapper.php
@@ -1,0 +1,37 @@
+<?php declare (strict_types=1);
+
+namespace ShipMonk\InputMapperTests\Compiler\Mapper\Codec\Data;
+
+use ShipMonk\InputMapper\Compiler\Mapper\Codec\InlineCodecInputMapperCompiler;
+use ShipMonk\InputMapper\Runtime\Exception\MappingFailedException;
+use ShipMonk\InputMapper\Runtime\Mapper;
+use ShipMonk\InputMapper\Runtime\MapperProvider;
+use function is_string;
+
+/**
+ * Generated mapper by {@see InlineCodecInputMapperCompiler}. Do not edit directly.
+ *
+ * @implements Mapper<mixed, string>
+ */
+class InlineCodecCurrencyPrefixEurMapper implements Mapper
+{
+    private ?CurrencyPrefixCodec $codec = null;
+
+    public function __construct(private readonly MapperProvider $provider)
+    {
+    }
+
+    /**
+     * @param  list<string|int> $path
+     * @throws MappingFailedException
+     */
+    public function map(mixed $data, array $path = []): string
+    {
+        if (!is_string($data)) {
+            throw MappingFailedException::incorrectType($data, $path, 'string');
+        }
+
+        $this->codec ??= new CurrencyPrefixCodec('EUR', '-');
+        return $this->codec->decode($data, $path);
+    }
+}

--- a/tests/Compiler/Mapper/Codec/Data/InlineCodecCurrencyPrefixEurOutputMapper.php
+++ b/tests/Compiler/Mapper/Codec/Data/InlineCodecCurrencyPrefixEurOutputMapper.php
@@ -1,0 +1,34 @@
+<?php declare (strict_types=1);
+
+namespace ShipMonk\InputMapperTests\Compiler\Mapper\Codec\Data;
+
+use ShipMonk\InputMapper\Compiler\Mapper\Codec\InlineCodecOutputMapperCompiler;
+use ShipMonk\InputMapper\Runtime\Exception\MappingFailedException;
+use ShipMonk\InputMapper\Runtime\Mapper;
+use ShipMonk\InputMapper\Runtime\MapperProvider;
+
+/**
+ * Generated mapper by {@see InlineCodecOutputMapperCompiler}. Do not edit directly.
+ *
+ * @implements Mapper<string, string>
+ */
+class InlineCodecCurrencyPrefixEurOutputMapper implements Mapper
+{
+    private ?CurrencyPrefixCodec $codec = null;
+
+    public function __construct(private readonly MapperProvider $provider)
+    {
+    }
+
+    /**
+     * @param  string $data
+     * @param  list<string|int> $path
+     * @throws MappingFailedException
+     */
+    public function map(mixed $data, array $path = []): string
+    {
+        $this->codec ??= new CurrencyPrefixCodec('EUR', '-');
+        $encoded = $this->codec->encode($data, $path);
+        return $encoded;
+    }
+}

--- a/tests/Compiler/Mapper/Codec/Data/InlineCodecCurrencyPrefixEurOutputMapper.php
+++ b/tests/Compiler/Mapper/Codec/Data/InlineCodecCurrencyPrefixEurOutputMapper.php
@@ -27,7 +27,7 @@ class InlineCodecCurrencyPrefixEurOutputMapper implements Mapper
      */
     public function map(mixed $data, array $path = []): string
     {
-        $this->codec ??= new CurrencyPrefixCodec('EUR', '-');
+        $this->codec ??= new CurrencyPrefixCodec(prefix: 'EUR', separator: '-');
         $encoded = $this->codec->encode($data, $path);
         return $encoded;
     }

--- a/tests/Compiler/Mapper/Codec/Data/InlineCodecCurrencyPrefixMapper.php
+++ b/tests/Compiler/Mapper/Codec/Data/InlineCodecCurrencyPrefixMapper.php
@@ -31,7 +31,7 @@ class InlineCodecCurrencyPrefixMapper implements Mapper
             throw MappingFailedException::incorrectType($data, $path, 'string');
         }
 
-        $this->codec ??= new CurrencyPrefixCodec('USD', ':');
+        $this->codec ??= new CurrencyPrefixCodec(prefix: 'USD', separator: ':');
         return $this->codec->decode($data, $path);
     }
 }

--- a/tests/Compiler/Mapper/Codec/Data/InlineCodecCurrencyPrefixMapper.php
+++ b/tests/Compiler/Mapper/Codec/Data/InlineCodecCurrencyPrefixMapper.php
@@ -1,0 +1,37 @@
+<?php declare (strict_types=1);
+
+namespace ShipMonk\InputMapperTests\Compiler\Mapper\Codec\Data;
+
+use ShipMonk\InputMapper\Compiler\Mapper\Codec\InlineCodecInputMapperCompiler;
+use ShipMonk\InputMapper\Runtime\Exception\MappingFailedException;
+use ShipMonk\InputMapper\Runtime\Mapper;
+use ShipMonk\InputMapper\Runtime\MapperProvider;
+use function is_string;
+
+/**
+ * Generated mapper by {@see InlineCodecInputMapperCompiler}. Do not edit directly.
+ *
+ * @implements Mapper<mixed, string>
+ */
+class InlineCodecCurrencyPrefixMapper implements Mapper
+{
+    private ?CurrencyPrefixCodec $codec = null;
+
+    public function __construct(private readonly MapperProvider $provider)
+    {
+    }
+
+    /**
+     * @param  list<string|int> $path
+     * @throws MappingFailedException
+     */
+    public function map(mixed $data, array $path = []): string
+    {
+        if (!is_string($data)) {
+            throw MappingFailedException::incorrectType($data, $path, 'string');
+        }
+
+        $this->codec ??= new CurrencyPrefixCodec('USD', ':');
+        return $this->codec->decode($data, $path);
+    }
+}

--- a/tests/Compiler/Mapper/Codec/Data/InlineCodecCurrencyPrefixOutputMapper.php
+++ b/tests/Compiler/Mapper/Codec/Data/InlineCodecCurrencyPrefixOutputMapper.php
@@ -27,7 +27,7 @@ class InlineCodecCurrencyPrefixOutputMapper implements Mapper
      */
     public function map(mixed $data, array $path = []): string
     {
-        $this->codec ??= new CurrencyPrefixCodec('USD', ':');
+        $this->codec ??= new CurrencyPrefixCodec(prefix: 'USD', separator: ':');
         $encoded = $this->codec->encode($data, $path);
         return $encoded;
     }

--- a/tests/Compiler/Mapper/Codec/Data/InlineCodecCurrencyPrefixOutputMapper.php
+++ b/tests/Compiler/Mapper/Codec/Data/InlineCodecCurrencyPrefixOutputMapper.php
@@ -1,0 +1,34 @@
+<?php declare (strict_types=1);
+
+namespace ShipMonk\InputMapperTests\Compiler\Mapper\Codec\Data;
+
+use ShipMonk\InputMapper\Compiler\Mapper\Codec\InlineCodecOutputMapperCompiler;
+use ShipMonk\InputMapper\Runtime\Exception\MappingFailedException;
+use ShipMonk\InputMapper\Runtime\Mapper;
+use ShipMonk\InputMapper\Runtime\MapperProvider;
+
+/**
+ * Generated mapper by {@see InlineCodecOutputMapperCompiler}. Do not edit directly.
+ *
+ * @implements Mapper<string, string>
+ */
+class InlineCodecCurrencyPrefixOutputMapper implements Mapper
+{
+    private ?CurrencyPrefixCodec $codec = null;
+
+    public function __construct(private readonly MapperProvider $provider)
+    {
+    }
+
+    /**
+     * @param  string $data
+     * @param  list<string|int> $path
+     * @throws MappingFailedException
+     */
+    public function map(mixed $data, array $path = []): string
+    {
+        $this->codec ??= new CurrencyPrefixCodec('USD', ':');
+        $encoded = $this->codec->encode($data, $path);
+        return $encoded;
+    }
+}

--- a/tests/Compiler/Mapper/Codec/Data/InputOnlyProviderCodec.php
+++ b/tests/Compiler/Mapper/Codec/Data/InputOnlyProviderCodec.php
@@ -1,0 +1,47 @@
+<?php declare(strict_types = 1);
+
+namespace ShipMonk\InputMapperTests\Compiler\Mapper\Codec\Data;
+
+use Attribute;
+use ShipMonk\InputMapper\Compiler\Attribute\MapCodec;
+use ShipMonk\InputMapper\Compiler\Mapper\InputMapperCompilerProvider;
+use ShipMonk\InputMapper\Compiler\Mapper\MapperCompiler;
+use ShipMonk\InputMapper\Compiler\MapperFactory\MapperCompilerFactory;
+use ShipMonk\InputMapper\Runtime\Codec;
+use function strrev;
+
+/**
+ * Codec implementing only the input half of the provider SPI, used to test
+ * that it still maps through MapCodec on both sides instead of being silently dropped.
+ *
+ * @implements Codec<string, string, string, string>
+ */
+#[Attribute(Attribute::TARGET_PARAMETER | Attribute::TARGET_PROPERTY)]
+class InputOnlyProviderCodec implements Codec, InputMapperCompilerProvider
+{
+
+    /**
+     * @param list<string|int> $path
+     */
+    public function decode(mixed $data, array $path = []): string
+    {
+        return strrev($data);
+    }
+
+    /**
+     * @param list<string|int> $path
+     */
+    public function encode(mixed $data, array $path = []): string
+    {
+        return strrev($data);
+    }
+
+    public function getInputMapperCompiler(
+        MapperCompilerFactory $mapperCompilerFactory,
+        array $options,
+    ): MapperCompiler
+    {
+        return (new MapCodec($this))->getInputMapperCompiler($mapperCompilerFactory, $options);
+    }
+
+}

--- a/tests/Compiler/Mapper/Codec/Data/ObjectArgCodec.php
+++ b/tests/Compiler/Mapper/Codec/Data/ObjectArgCodec.php
@@ -1,0 +1,38 @@
+<?php declare(strict_types = 1);
+
+namespace ShipMonk\InputMapperTests\Compiler\Mapper\Codec\Data;
+
+use ShipMonk\InputMapper\Runtime\Codec;
+use ShipMonk\InputMapperTests\Runtime\Data\MoneyValue;
+
+/**
+ * Codec with a non-scalar constructor argument, used to test inline compilation limits.
+ *
+ * @implements Codec<string, string, string, string>
+ */
+class ObjectArgCodec implements Codec
+{
+
+    public function __construct(
+        public readonly MoneyValue $money,
+    )
+    {
+    }
+
+    /**
+     * @param list<string|int> $path
+     */
+    public function decode(mixed $data, array $path = []): string
+    {
+        return $data;
+    }
+
+    /**
+     * @param list<string|int> $path
+     */
+    public function encode(mixed $data, array $path = []): string
+    {
+        return $data;
+    }
+
+}

--- a/tests/Compiler/Mapper/Codec/Data/ParentPrivatePropCodec.php
+++ b/tests/Compiler/Mapper/Codec/Data/ParentPrivatePropCodec.php
@@ -1,0 +1,12 @@
+<?php declare(strict_types = 1);
+
+namespace ShipMonk\InputMapperTests\Compiler\Mapper\Codec\Data;
+
+/**
+ * Codec inheriting a constructor promoting a private property on the parent class,
+ * used to test that inline compilation reads private parent properties.
+ */
+class ParentPrivatePropCodec extends BasePrivatePropCodec
+{
+
+}

--- a/tests/Compiler/Mapper/Codec/Data/StaticPropCodec.php
+++ b/tests/Compiler/Mapper/Codec/Data/StaticPropCodec.php
@@ -1,0 +1,40 @@
+<?php declare(strict_types = 1);
+
+namespace ShipMonk\InputMapperTests\Compiler\Mapper\Codec\Data;
+
+use ShipMonk\InputMapper\Runtime\Codec;
+
+/**
+ * Codec whose constructor parameter is shadowed by a static property, used to test inline compilation limits.
+ *
+ * @implements Codec<string, string, string, string>
+ */
+class StaticPropCodec implements Codec
+{
+
+    public static string $mode = 'GLOBAL_DEFAULT';
+
+    public function __construct(
+        string $mode,
+    )
+    {
+        self::$mode = $mode;
+    }
+
+    /**
+     * @param list<string|int> $path
+     */
+    public function decode(mixed $data, array $path = []): string
+    {
+        return $data;
+    }
+
+    /**
+     * @param list<string|int> $path
+     */
+    public function encode(mixed $data, array $path = []): string
+    {
+        return $data;
+    }
+
+}

--- a/tests/Compiler/Mapper/Codec/Data/SuffixCodec.php
+++ b/tests/Compiler/Mapper/Codec/Data/SuffixCodec.php
@@ -1,0 +1,48 @@
+<?php declare(strict_types = 1);
+
+namespace ShipMonk\InputMapperTests\Compiler\Mapper\Codec\Data;
+
+use Attribute;
+use ShipMonk\InputMapper\Runtime\Codec;
+use ShipMonk\InputMapper\Runtime\Exception\MappingFailedException;
+use function str_ends_with;
+use function strlen;
+use function substr;
+
+/**
+ * Converts between a suffixed string (e.g. "100!") and the bare value ("100").
+ *
+ * @implements Codec<string, string, string, string>
+ */
+#[Attribute(Attribute::TARGET_PARAMETER | Attribute::TARGET_PROPERTY)]
+class SuffixCodec implements Codec
+{
+
+    public function __construct(
+        public readonly string $suffix = '!',
+    )
+    {
+    }
+
+    /**
+     * @param list<string|int> $path
+     * @throws MappingFailedException
+     */
+    public function decode(mixed $data, array $path = []): string
+    {
+        if (!str_ends_with($data, $this->suffix)) {
+            throw MappingFailedException::incorrectValue($data, $path, "string ending with '{$this->suffix}'");
+        }
+
+        return substr($data, 0, -strlen($this->suffix));
+    }
+
+    /**
+     * @param list<string|int> $path
+     */
+    public function encode(mixed $data, array $path = []): string
+    {
+        return $data . $this->suffix;
+    }
+
+}

--- a/tests/Compiler/Mapper/Codec/Data/UninitPropCodec.php
+++ b/tests/Compiler/Mapper/Codec/Data/UninitPropCodec.php
@@ -1,0 +1,40 @@
+<?php declare(strict_types = 1);
+
+namespace ShipMonk\InputMapperTests\Compiler\Mapper\Codec\Data;
+
+use ShipMonk\InputMapper\Runtime\Codec;
+
+/**
+ * Codec whose constructor parameter has a matching property that is never assigned,
+ * used to test inline compilation limits.
+ *
+ * @implements Codec<string, string, string, string>
+ */
+class UninitPropCodec implements Codec
+{
+
+    private string $mode;
+
+    public function __construct(
+        string $mode,
+    )
+    {
+    }
+
+    /**
+     * @param list<string|int> $path
+     */
+    public function decode(mixed $data, array $path = []): string
+    {
+        return $data;
+    }
+
+    /**
+     * @param list<string|int> $path
+     */
+    public function encode(mixed $data, array $path = []): string
+    {
+        return $data;
+    }
+
+}

--- a/tests/Compiler/Mapper/Codec/InlineCodecInputMapperCompilerTest.php
+++ b/tests/Compiler/Mapper/Codec/InlineCodecInputMapperCompilerTest.php
@@ -1,0 +1,83 @@
+<?php declare(strict_types = 1);
+
+namespace ShipMonk\InputMapperTests\Compiler\Mapper\Codec;
+
+use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
+use ShipMonk\InputMapper\Compiler\Mapper\Codec\InlineCodecInputMapperCompiler;
+use ShipMonk\InputMapper\Compiler\Mapper\Input\StringInputMapperCompiler;
+use ShipMonk\InputMapper\Runtime\Exception\MappingFailedException;
+use ShipMonk\InputMapperTests\Compiler\Mapper\Codec\Data\CurrencyPrefixCodec;
+use ShipMonk\InputMapperTests\Compiler\Mapper\MapperCompilerTestCase;
+
+class InlineCodecInputMapperCompilerTest extends MapperCompilerTestCase
+{
+
+    public function testCompile(): void
+    {
+        $mapper = $this->compileInputMapper(
+            'InlineCodecCurrencyPrefix',
+            new InlineCodecInputMapperCompiler(
+                CurrencyPrefixCodec::class,
+                ['prefix' => 'USD', 'separator' => ':'],
+                new StringInputMapperCompiler(),
+                new IdentifierTypeNode('string'),
+            ),
+        );
+
+        self::assertSame('1299', $mapper->map('USD:1299'));
+    }
+
+    public function testCompileWithDifferentArgs(): void
+    {
+        $mapper = $this->compileInputMapper(
+            'InlineCodecCurrencyPrefixEur',
+            new InlineCodecInputMapperCompiler(
+                CurrencyPrefixCodec::class,
+                ['prefix' => 'EUR', 'separator' => '-'],
+                new StringInputMapperCompiler(),
+                new IdentifierTypeNode('string'),
+            ),
+        );
+
+        self::assertSame('500', $mapper->map('EUR-500'));
+    }
+
+    public function testCompileWithInvalidInput(): void
+    {
+        $mapper = $this->compileInputMapper(
+            'InlineCodecCurrencyPrefix',
+            new InlineCodecInputMapperCompiler(
+                CurrencyPrefixCodec::class,
+                ['prefix' => 'USD', 'separator' => ':'],
+                new StringInputMapperCompiler(),
+                new IdentifierTypeNode('string'),
+            ),
+        );
+
+        self::assertException(
+            MappingFailedException::class,
+            'Failed to map data at path /: Expected string, got 123',
+            static fn () => $mapper->map(123),
+        );
+    }
+
+    public function testCompileWithCodecValidation(): void
+    {
+        $mapper = $this->compileInputMapper(
+            'InlineCodecCurrencyPrefix',
+            new InlineCodecInputMapperCompiler(
+                CurrencyPrefixCodec::class,
+                ['prefix' => 'USD', 'separator' => ':'],
+                new StringInputMapperCompiler(),
+                new IdentifierTypeNode('string'),
+            ),
+        );
+
+        self::assertException(
+            MappingFailedException::class,
+            "Failed to map data at path /: Expected string starting with 'USD:', got \"EUR:500\"",
+            static fn () => $mapper->map('EUR:500'),
+        );
+    }
+
+}

--- a/tests/Compiler/Mapper/Codec/InlineCodecOutputMapperCompilerTest.php
+++ b/tests/Compiler/Mapper/Codec/InlineCodecOutputMapperCompilerTest.php
@@ -1,0 +1,44 @@
+<?php declare(strict_types = 1);
+
+namespace ShipMonk\InputMapperTests\Compiler\Mapper\Codec;
+
+use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
+use ShipMonk\InputMapper\Compiler\Mapper\Codec\InlineCodecOutputMapperCompiler;
+use ShipMonk\InputMapper\Compiler\Mapper\PassthroughMapperCompiler;
+use ShipMonk\InputMapperTests\Compiler\Mapper\Codec\Data\CurrencyPrefixCodec;
+use ShipMonk\InputMapperTests\Compiler\Mapper\MapperCompilerTestCase;
+
+class InlineCodecOutputMapperCompilerTest extends MapperCompilerTestCase
+{
+
+    public function testCompile(): void
+    {
+        $mapper = $this->compileOutputMapper(
+            'InlineCodecCurrencyPrefix',
+            new InlineCodecOutputMapperCompiler(
+                CurrencyPrefixCodec::class,
+                ['prefix' => 'USD', 'separator' => ':'],
+                new PassthroughMapperCompiler(new IdentifierTypeNode('string')),
+                new IdentifierTypeNode('string'),
+            ),
+        );
+
+        self::assertSame('USD:1299', $mapper->map('1299'));
+    }
+
+    public function testCompileWithDifferentArgs(): void
+    {
+        $mapper = $this->compileOutputMapper(
+            'InlineCodecCurrencyPrefixEur',
+            new InlineCodecOutputMapperCompiler(
+                CurrencyPrefixCodec::class,
+                ['prefix' => 'EUR', 'separator' => '-'],
+                new PassthroughMapperCompiler(new IdentifierTypeNode('string')),
+                new IdentifierTypeNode('string'),
+            ),
+        );
+
+        self::assertSame('EUR-500', $mapper->map('500'));
+    }
+
+}

--- a/tests/Compiler/Mapper/MapperCompilerTestCase.php
+++ b/tests/Compiler/Mapper/MapperCompilerTestCase.php
@@ -6,6 +6,7 @@ use ReflectionClass;
 use ShipMonk\InputMapper\Compiler\Mapper\MapperCompiler;
 use ShipMonk\InputMapper\Compiler\Php\PhpCodeBuilder;
 use ShipMonk\InputMapper\Compiler\Php\PhpCodePrinter;
+use ShipMonk\InputMapper\Runtime\Codec;
 use ShipMonk\InputMapper\Runtime\Mapper;
 use ShipMonk\InputMapper\Runtime\MapperProvider;
 use ShipMonk\InputMapperTests\InputMapperTestCase;
@@ -24,6 +25,7 @@ abstract class MapperCompilerTestCase extends InputMapperTestCase
     /**
      * @param array<class-string, MapperCompiler> $providedMapperCompilers
      * @param list<Mapper<mixed, mixed>> $genericInnerMappers
+     * @param array<class-string<Codec<*, *, *, *>>, Codec<*, *, *, *>> $codecs
      * @return Mapper<mixed, mixed>
      */
     protected function compileInputMapper(
@@ -31,14 +33,16 @@ abstract class MapperCompilerTestCase extends InputMapperTestCase
         MapperCompiler $mapperCompiler,
         array $providedMapperCompilers = [],
         array $genericInnerMappers = [],
+        array $codecs = [],
     ): Mapper
     {
-        return $this->doCompileMapper($name, 'Mapper', 'getInputMapper', $mapperCompiler, $providedMapperCompilers, $genericInnerMappers);
+        return $this->doCompileMapper($name, 'Mapper', 'getInputMapper', $mapperCompiler, $providedMapperCompilers, $genericInnerMappers, $codecs);
     }
 
     /**
      * @param array<class-string, MapperCompiler> $providedMapperCompilers
      * @param list<Mapper<mixed, mixed>> $genericInnerMappers
+     * @param array<class-string<Codec<*, *, *, *>>, Codec<*, *, *, *>> $codecs
      * @return Mapper<mixed, mixed>
      */
     protected function compileOutputMapper(
@@ -46,14 +50,16 @@ abstract class MapperCompilerTestCase extends InputMapperTestCase
         MapperCompiler $mapperCompiler,
         array $providedMapperCompilers = [],
         array $genericInnerMappers = [],
+        array $codecs = [],
     ): Mapper
     {
-        return $this->doCompileMapper($name, 'OutputMapper', 'getOutputMapper', $mapperCompiler, $providedMapperCompilers, $genericInnerMappers);
+        return $this->doCompileMapper($name, 'OutputMapper', 'getOutputMapper', $mapperCompiler, $providedMapperCompilers, $genericInnerMappers, $codecs);
     }
 
     /**
      * @param array<class-string, MapperCompiler> $providedMapperCompilers
      * @param list<Mapper<mixed, mixed>> $genericInnerMappers
+     * @param array<class-string<Codec<*, *, *, *>>, Codec<*, *, *, *>> $codecs
      * @return Mapper<mixed, mixed>
      */
     private function doCompileMapper(
@@ -63,6 +69,7 @@ abstract class MapperCompilerTestCase extends InputMapperTestCase
         MapperCompiler $mapperCompiler,
         array $providedMapperCompilers,
         array $genericInnerMappers,
+        array $codecs = [],
     ): Mapper
     {
         $testCaseReflection = new ReflectionClass($this);
@@ -89,6 +96,12 @@ abstract class MapperCompilerTestCase extends InputMapperTestCase
             function (string $inputClassName, array $genericInnerMappers = []) use ($name, $classNameSuffix, $providerMethodName, $providedMapperCompilers): Mapper {
                 /** @var list<Mapper<mixed, mixed>> $genericInnerMappers */
                 return $this->doCompileMapper($name . '__' . $this->toShortClassName($inputClassName), $classNameSuffix, $providerMethodName, $providedMapperCompilers[$inputClassName], [], $genericInnerMappers);
+            },
+        );
+
+        $mapperProvider->expects(self::any())->method('getCodec')->willReturnCallback(
+            static function (string $codecClassName) use ($codecs): Codec {
+                return $codecs[$codecClassName];
             },
         );
 

--- a/tests/Compiler/Mapper/Object/MapDateTest.php
+++ b/tests/Compiler/Mapper/Object/MapDateTest.php
@@ -14,7 +14,7 @@ class MapDateTest extends MapperCompilerTestCase
 
     public function testCompile(): void
     {
-        $mapperCompiler = (new MapDate())->getInputMapperCompiler();
+        $mapperCompiler = (new MapDate())->getInputMapperCompiler(self::createMapperCompilerFactory(), []);
 
         /** @var Mapper<mixed, DateTimeImmutable> $mapper */
         $mapper = $this->compileInputMapper('DateStandalone', $mapperCompiler);

--- a/tests/Compiler/MapperFactory/DefaultMapperCompilerFactoryTest.php
+++ b/tests/Compiler/MapperFactory/DefaultMapperCompilerFactoryTest.php
@@ -108,7 +108,7 @@ class DefaultMapperCompilerFactoryTest extends InputMapperTestCase
         $factory = self::createFactory();
         $phpDocType = self::parseType($type);
 
-        $mapperCompiler = $factory->create($phpDocType, $options)->getInputMapperCompiler();
+        $mapperCompiler = $factory->create($phpDocType, $options)->getInputMapperCompiler($factory, $options);
 
         self::assertEquals($expectedMapperCompiler, $mapperCompiler);
     }
@@ -500,7 +500,7 @@ class DefaultMapperCompilerFactoryTest extends InputMapperTestCase
         $factory = self::createFactory();
         $phpDocType = self::parseType($type);
 
-        $mapperCompiler = $factory->create($phpDocType, $options)->getOutputMapperCompiler();
+        $mapperCompiler = $factory->create($phpDocType, $options)->getOutputMapperCompiler($factory, $options);
 
         self::assertEquals($expectedMapperCompiler, $mapperCompiler);
     }

--- a/tests/Compiler/Type/Data/ChainedDefaultsType.php
+++ b/tests/Compiler/Type/Data/ChainedDefaultsType.php
@@ -1,0 +1,15 @@
+<?php declare(strict_types = 1);
+
+namespace ShipMonk\InputMapperTests\Compiler\Type\Data;
+
+/**
+ * Generic type with template defaults chained through other defaulted parameters.
+ *
+ * @template A
+ * @template B = A
+ * @template C = B
+ */
+interface ChainedDefaultsType
+{
+
+}

--- a/tests/Compiler/Type/PhpDocTypeUtilsTest.php
+++ b/tests/Compiler/Type/PhpDocTypeUtilsTest.php
@@ -34,6 +34,7 @@ use ReflectionFunction;
 use ReflectionParameter;
 use ShipMonk\InputMapper\Compiler\Type\GenericTypeParameter;
 use ShipMonk\InputMapper\Compiler\Type\PhpDocTypeUtils;
+use ShipMonk\InputMapperTests\Compiler\Type\Data\ChainedDefaultsType;
 use ShipMonk\InputMapperTests\InputMapperTestCase;
 use Traversable;
 use function array_map;
@@ -1712,6 +1713,21 @@ class PhpDocTypeUtilsTest extends InputMapperTestCase
             3,
             'string',
         ];
+    }
+
+    public function testParameterOffsetMappingResolvesChainedDefaults(): void
+    {
+        $type = new IdentifierTypeNode(ChainedDefaultsType::class);
+        $definition = PhpDocTypeUtils::getGenericTypeDefinition($type);
+
+        // with 1 arg provided, both B (= A) and C (= B = A) resolve to offset 0
+        self::assertSame([0, 0, 0], $definition->parameterOffsetMapping[1] ?? null);
+        self::assertSame([0, 1, 1], $definition->parameterOffsetMapping[2] ?? null);
+
+        self::assertEquals(
+            $this->parseType('int'),
+            PhpDocTypeUtils::inferGenericParameter($this->parseType(ChainedDefaultsType::class . '<int>'), ChainedDefaultsType::class, 2),
+        );
     }
 
     public function testParameterOffsetMappingDerivedFromTemplateDefaults(): void

--- a/tests/Compiler/Type/PhpDocTypeUtilsTest.php
+++ b/tests/Compiler/Type/PhpDocTypeUtilsTest.php
@@ -1656,6 +1656,85 @@ class PhpDocTypeUtilsTest extends InputMapperTestCase
             0,
             'Countable & Traversable',
         ];
+
+        yield 'Codec with 2 params: DI (param 0), via plain identifier type' => [
+            'ShipMonk\InputMapperTests\Runtime\Data\MoneyCodec',
+            'ShipMonk\InputMapper\Runtime\Codec',
+            0,
+            'array{currency: string, cents: int}',
+        ];
+
+        yield 'Codec with 2 params: EI (param 1)' => [
+            'ShipMonk\InputMapperTests\Runtime\Data\MoneyCodec',
+            'ShipMonk\InputMapper\Runtime\Codec',
+            1,
+            'ShipMonk\InputMapperTests\Runtime\Data\MoneyValue',
+        ];
+
+        yield 'Codec with 2 params: DO (param 2) defaults to EI' => [
+            'ShipMonk\InputMapperTests\Runtime\Data\MoneyCodec',
+            'ShipMonk\InputMapper\Runtime\Codec',
+            2,
+            'ShipMonk\InputMapperTests\Runtime\Data\MoneyValue',
+        ];
+
+        yield 'Codec with 2 params: EO (param 3) defaults to DI' => [
+            'ShipMonk\InputMapperTests\Runtime\Data\MoneyCodec',
+            'ShipMonk\InputMapper\Runtime\Codec',
+            3,
+            'array{currency: string, cents: int}',
+        ];
+
+        yield 'Asymmetric codec: DI (param 0)' => [
+            'ShipMonk\InputMapperTests\Runtime\Data\DateTimeInterfaceCodec',
+            'ShipMonk\InputMapper\Runtime\Codec',
+            0,
+            'string',
+        ];
+
+        yield 'Asymmetric codec: EI (param 1) differs from DO' => [
+            'ShipMonk\InputMapperTests\Runtime\Data\DateTimeInterfaceCodec',
+            'ShipMonk\InputMapper\Runtime\Codec',
+            1,
+            'DateTimeInterface',
+        ];
+
+        yield 'Asymmetric codec: DO (param 2)' => [
+            'ShipMonk\InputMapperTests\Runtime\Data\DateTimeInterfaceCodec',
+            'ShipMonk\InputMapper\Runtime\Codec',
+            2,
+            'DateTimeImmutable',
+        ];
+
+        yield 'Asymmetric codec: EO (param 3) explicit' => [
+            'ShipMonk\InputMapperTests\Runtime\Data\DateTimeInterfaceCodec',
+            'ShipMonk\InputMapper\Runtime\Codec',
+            3,
+            'string',
+        ];
+    }
+
+    public function testParameterOffsetMappingDerivedFromTemplateDefaults(): void
+    {
+        $codecType = new IdentifierTypeNode('ShipMonk\InputMapper\Runtime\Codec');
+        $definition = PhpDocTypeUtils::getGenericTypeDefinition($codecType);
+
+        self::assertCount(4, $definition->parameters);
+        self::assertSame('DI', $definition->parameters[0]->name);
+        self::assertSame('EI', $definition->parameters[1]->name);
+        self::assertSame('DO', $definition->parameters[2]->name);
+        self::assertSame('EO', $definition->parameters[3]->name);
+
+        // when 2 params provided: DO defaults to EI (index 1), EO defaults to DI (index 0)
+        self::assertArrayHasKey(2, $definition->parameterOffsetMapping);
+        self::assertSame([0, 1, 1, 0], $definition->parameterOffsetMapping[2]);
+
+        // when 3 params provided: EO defaults to DI (index 0)
+        self::assertArrayHasKey(3, $definition->parameterOffsetMapping);
+        self::assertSame([0, 1, 2, 0], $definition->parameterOffsetMapping[3]);
+
+        // no mapping needed for 4 params
+        self::assertArrayNotHasKey(4, $definition->parameterOffsetMapping);
     }
 
     private function parseType(string $type): TypeNode

--- a/tests/Compiler/Validator/Object/AssertDateTimeRangeTest.php
+++ b/tests/Compiler/Validator/Object/AssertDateTimeRangeTest.php
@@ -15,7 +15,7 @@ class AssertDateTimeRangeTest extends ValidatorCompilerTestCase
 
     public function testNoopDateTimeRangeValidator(): void
     {
-        $mapperCompiler = (new MapDate())->getInputMapperCompiler();
+        $mapperCompiler = (new MapDate())->getInputMapperCompiler(self::createMapperCompilerFactory(), []);
         $validatorCompiler = new AssertDateTimeRange();
         $validator = $this->compileValidator('NoopDateTimeRangeValidator', $mapperCompiler, $validatorCompiler);
 
@@ -25,7 +25,7 @@ class AssertDateTimeRangeTest extends ValidatorCompilerTestCase
 
     public function testDateTimeRangeValidatorWithInclusiveLowerBound(): void
     {
-        $mapperCompiler = (new MapDate())->getInputMapperCompiler();
+        $mapperCompiler = (new MapDate())->getInputMapperCompiler(self::createMapperCompilerFactory(), []);
         $validatorCompiler = new AssertDateTimeRange(gte: '2000-01-05');
         $validator = $this->compileValidator('DateTimeRangeValidatorWithInclusiveLowerBound', $mapperCompiler, $validatorCompiler);
 
@@ -41,7 +41,7 @@ class AssertDateTimeRangeTest extends ValidatorCompilerTestCase
 
     public function testDateTimeRangeValidatorWithExclusiveLowerBound(): void
     {
-        $mapperCompiler = (new MapDate())->getInputMapperCompiler();
+        $mapperCompiler = (new MapDate())->getInputMapperCompiler(self::createMapperCompilerFactory(), []);
         $validatorCompiler = new AssertDateTimeRange(gt: '2000-01-05');
         $validator = $this->compileValidator('DateTimeRangeValidatorWithExclusiveLowerBound', $mapperCompiler, $validatorCompiler);
 
@@ -56,7 +56,7 @@ class AssertDateTimeRangeTest extends ValidatorCompilerTestCase
 
     public function testDateTimeRangeValidatorWithInclusiveUpperBound(): void
     {
-        $mapperCompiler = (new MapDate())->getInputMapperCompiler();
+        $mapperCompiler = (new MapDate())->getInputMapperCompiler(self::createMapperCompilerFactory(), []);
         $validatorCompiler = new AssertDateTimeRange(lte: '2000-01-05');
         $validator = $this->compileValidator('DateTimeRangeValidatorWithInclusiveUpperBound', $mapperCompiler, $validatorCompiler);
 
@@ -72,7 +72,7 @@ class AssertDateTimeRangeTest extends ValidatorCompilerTestCase
 
     public function testDateTimeRangeValidatorWithExclusiveUpperBound(): void
     {
-        $mapperCompiler = (new MapDate())->getInputMapperCompiler();
+        $mapperCompiler = (new MapDate())->getInputMapperCompiler(self::createMapperCompilerFactory(), []);
         $validatorCompiler = new AssertDateTimeRange(lt: '2000-01-05');
         $validator = $this->compileValidator('DateTimeRangeValidatorWithExclusiveUpperBound', $mapperCompiler, $validatorCompiler);
 
@@ -87,7 +87,7 @@ class AssertDateTimeRangeTest extends ValidatorCompilerTestCase
 
     public function testDateTimeRangeValidatorWithInclusiveLowerAndUpperBound(): void
     {
-        $mapperCompiler = (new MapDate())->getInputMapperCompiler();
+        $mapperCompiler = (new MapDate())->getInputMapperCompiler(self::createMapperCompilerFactory(), []);
         $validatorCompiler = new AssertDateTimeRange(gte: '2000-01-05', lte: '2000-01-10');
         $validator = $this->compileValidator('DateTimeRangeValidatorWithInclusiveLowerAndUpperBound', $mapperCompiler, $validatorCompiler);
 

--- a/tests/InputMapperTestCase.php
+++ b/tests/InputMapperTestCase.php
@@ -5,12 +5,19 @@ namespace ShipMonk\InputMapperTests;
 use Nette\Utils\FileSystem;
 use PHPUnit\Framework\Constraint\Exception as ExceptionConstraint;
 use PHPUnit\Framework\TestCase;
+use ShipMonk\InputMapper\Compiler\MapperFactory\DefaultMapperCompilerFactoryProvider;
+use ShipMonk\InputMapper\Compiler\MapperFactory\MapperCompilerFactory;
 use Throwable;
 use function getenv;
 use function is_file;
 
 abstract class InputMapperTestCase extends TestCase
 {
+
+    protected static function createMapperCompilerFactory(): MapperCompilerFactory
+    {
+        return (new DefaultMapperCompilerFactoryProvider())->get();
+    }
 
     protected static function assertSnapshot(
         string $snapshotPath,

--- a/tests/Runtime/CamelToSnakeCaseMapperTest.php
+++ b/tests/Runtime/CamelToSnakeCaseMapperTest.php
@@ -8,7 +8,6 @@ use ShipMonk\InputMapper\Compiler\MapperFactory\DefaultMapperCompilerFactoryProv
 use ShipMonk\InputMapper\Compiler\MapperFactory\MapperCompilerFactory;
 use ShipMonk\InputMapper\Compiler\PropertyNameTransformer\CamelToSnakeCasePropertyNameTransformer;
 use ShipMonk\InputMapper\Compiler\PropertyNameTransformer\PropertyNameTransformer;
-use ShipMonk\InputMapper\Runtime\CodecRegistry;
 use ShipMonk\InputMapper\Runtime\MapperProvider;
 use ShipMonk\InputMapperTests\InputMapperTestCase;
 use ShipMonk\InputMapperTests\Runtime\Data\AcronymCasedInput;
@@ -176,7 +175,7 @@ class CamelToSnakeCaseMapperTest extends InputMapperTestCase
     {
         $compilerFactoryProvider = new class (new CamelToSnakeCasePropertyNameTransformer()) extends DefaultMapperCompilerFactoryProvider {
 
-            protected function create(?CodecRegistry $codecRegistry = null): MapperCompilerFactory
+            protected function create(): MapperCompilerFactory
             {
                 $config = $this->createParserConfig();
 
@@ -185,7 +184,7 @@ class CamelToSnakeCaseMapperTest extends InputMapperTestCase
                     $this->createPhpDocParser($config),
                     [],
                     $this->propertyNameTransformer,
-                    $codecRegistry ?? new CodecRegistry(),
+                    $this->codecRegistry,
                 );
             }
 

--- a/tests/Runtime/CamelToSnakeCaseMapperTest.php
+++ b/tests/Runtime/CamelToSnakeCaseMapperTest.php
@@ -8,6 +8,7 @@ use ShipMonk\InputMapper\Compiler\MapperFactory\DefaultMapperCompilerFactoryProv
 use ShipMonk\InputMapper\Compiler\MapperFactory\MapperCompilerFactory;
 use ShipMonk\InputMapper\Compiler\PropertyNameTransformer\CamelToSnakeCasePropertyNameTransformer;
 use ShipMonk\InputMapper\Compiler\PropertyNameTransformer\PropertyNameTransformer;
+use ShipMonk\InputMapper\Runtime\CodecRegistry;
 use ShipMonk\InputMapper\Runtime\MapperProvider;
 use ShipMonk\InputMapperTests\InputMapperTestCase;
 use ShipMonk\InputMapperTests\Runtime\Data\AcronymCasedInput;
@@ -175,7 +176,7 @@ class CamelToSnakeCaseMapperTest extends InputMapperTestCase
     {
         $compilerFactoryProvider = new class (new CamelToSnakeCasePropertyNameTransformer()) extends DefaultMapperCompilerFactoryProvider {
 
-            protected function create(): MapperCompilerFactory
+            protected function create(?CodecRegistry $codecRegistry = null): MapperCompilerFactory
             {
                 $config = $this->createParserConfig();
 
@@ -184,6 +185,7 @@ class CamelToSnakeCaseMapperTest extends InputMapperTestCase
                     $this->createPhpDocParser($config),
                     [],
                     $this->propertyNameTransformer,
+                    $codecRegistry ?? new CodecRegistry(),
                 );
             }
 

--- a/tests/Runtime/CodecTest.php
+++ b/tests/Runtime/CodecTest.php
@@ -4,6 +4,8 @@ namespace ShipMonk\InputMapperTests\Runtime;
 
 use DateTimeImmutable;
 use LogicException;
+use ShipMonk\InputMapper\Compiler\MapperFactory\DefaultMapperCompilerFactory;
+use ShipMonk\InputMapper\Compiler\MapperFactory\DefaultMapperCompilerFactoryProvider;
 use ShipMonk\InputMapper\Runtime\CodecRegistry;
 use ShipMonk\InputMapper\Runtime\Exception\MappingFailedException;
 use ShipMonk\InputMapper\Runtime\MapperProvider;
@@ -13,14 +15,21 @@ use ShipMonk\InputMapperTests\Runtime\Data\AlternativeMoneyCodec;
 use ShipMonk\InputMapperTests\Runtime\Data\CodecConflictProbeInput;
 use ShipMonk\InputMapperTests\Runtime\Data\Duration;
 use ShipMonk\InputMapperTests\Runtime\Data\DurationCodec;
+use ShipMonk\InputMapperTests\Runtime\Data\EmptyInput;
+use ShipMonk\InputMapperTests\Runtime\Data\FactoryProbeInput;
 use ShipMonk\InputMapperTests\Runtime\Data\FixedDuration;
+use ShipMonk\InputMapperTests\Runtime\Data\HexColor;
+use ShipMonk\InputMapperTests\Runtime\Data\InheritedHexColorCodec;
 use ShipMonk\InputMapperTests\Runtime\Data\LegacyPaymentInput;
 use ShipMonk\InputMapperTests\Runtime\Data\MoneyCodec;
 use ShipMonk\InputMapperTests\Runtime\Data\MoneyValue;
 use ShipMonk\InputMapperTests\Runtime\Data\OrderId;
 use ShipMonk\InputMapperTests\Runtime\Data\OrderInput;
+use ShipMonk\InputMapperTests\Runtime\Data\PrefixedSuffixedInput;
+use ShipMonk\InputMapperTests\Runtime\Data\ReversedTokenInput;
 use ShipMonk\InputMapperTests\Runtime\Data\SpecialRequirementsDatesInput;
 use ShipMonk\InputMapperTests\Runtime\Data\TypedIdCodec;
+use ShipMonk\InputMapperTests\Runtime\Data\UnboundGenericCodec;
 use function sys_get_temp_dir;
 
 class CodecTest extends InputMapperTestCase
@@ -273,6 +282,117 @@ class CodecTest extends InputMapperTestCase
 
         self::assertNull($resultWithNull->refund);
         self::assertSame($dataWithNull, $outputMapper->map($resultWithNull));
+    }
+
+    public function testCodecRegisteredAfterUnrelatedCompileIsPickedUp(): void
+    {
+        $mapperProvider = new MapperProvider(sys_get_temp_dir(), autoRefresh: true);
+        $mapperProvider->getInputMapper(EmptyInput::class);
+
+        $mapperProvider->registerCodecFactory(TypedIdCodec::class, TypedIdCodec::create(...));
+
+        $result = $mapperProvider->getInputMapper(AccountId::class)->map('abc-123');
+        self::assertSame('abc-123', $result->value);
+    }
+
+    public function testConflictingCodecRegistrationsThrowDeterministically(): void
+    {
+        $mapperProvider = new MapperProvider(sys_get_temp_dir(), autoRefresh: true);
+        $mapperProvider->registerCodec(new MoneyCodec());
+        $mapperProvider->registerCodec(new AlternativeMoneyCodec());
+
+        $expectedMessage = "Multiple codecs registered for domain class 'ShipMonk\InputMapperTests\Runtime\Data\MoneyValue': ShipMonk\InputMapperTests\Runtime\Data\MoneyCodec, ShipMonk\InputMapperTests\Runtime\Data\AlternativeMoneyCodec.";
+
+        self::assertException(
+            LogicException::class,
+            $expectedMessage,
+            static fn () => $mapperProvider->getInputMapper(CodecConflictProbeInput::class),
+        );
+
+        // retry after a caught conflict must fail the same way, not silently succeed with a partial codec map
+        self::assertException(
+            LogicException::class,
+            $expectedMessage,
+            static fn () => $mapperProvider->getOutputMapper(CodecConflictProbeInput::class),
+        );
+    }
+
+    public function testCodecWithoutInferableDomainClassIsRejected(): void
+    {
+        $mapperProvider = new MapperProvider(sys_get_temp_dir(), autoRefresh: true);
+        $mapperProvider->registerCodec(new UnboundGenericCodec());
+
+        self::assertException(
+            LogicException::class,
+            "Codec 'ShipMonk\InputMapperTests\Runtime\Data\UnboundGenericCodec' does not declare any class or interface as its domain type, check its @implements annotation.",
+            static fn () => $mapperProvider->getInputMapper(CodecConflictProbeInput::class),
+        );
+    }
+
+    public function testCodecInheritingImplementsFromParentClass(): void
+    {
+        $mapperProvider = new MapperProvider(sys_get_temp_dir(), autoRefresh: true);
+        $mapperProvider->registerCodec(new InheritedHexColorCodec());
+
+        $inputMapper = $mapperProvider->getInputMapper(HexColor::class);
+        $outputMapper = $mapperProvider->getOutputMapper(HexColor::class);
+
+        self::assertSame('#ff0000', $outputMapper->map($inputMapper->map('#ff0000')));
+    }
+
+    public function testTwoCodecAttributesOnPromotedParameterRoundTrip(): void
+    {
+        $inputMapper = $this->mapperProvider->getInputMapper(PrefixedSuffixedInput::class);
+        $outputMapper = $this->mapperProvider->getOutputMapper(PrefixedSuffixedInput::class);
+
+        $data = ['amount' => 'USD:100!'];
+        /** @var PrefixedSuffixedInput $result */
+        $result = $inputMapper->map($data);
+
+        self::assertSame('100', $result->amount);
+        self::assertSame($data, $outputMapper->map($result));
+    }
+
+    public function testInputOnlyProviderCodecAttributeIsNotDropped(): void
+    {
+        $inputMapper = $this->mapperProvider->getInputMapper(ReversedTokenInput::class);
+        $outputMapper = $this->mapperProvider->getOutputMapper(ReversedTokenInput::class);
+
+        /** @var ReversedTokenInput $result */
+        $result = $inputMapper->map(['token' => 'abc']);
+
+        self::assertSame('cba', $result->token);
+        self::assertSame(['token' => 'abc'], $outputMapper->map($result));
+    }
+
+    public function testFactoryConfiguredBeforeMapperProviderIsPreserved(): void
+    {
+        $factoryProvider = new DefaultMapperCompilerFactoryProvider();
+        $factory = $factoryProvider->get();
+        self::assertInstanceOf(DefaultMapperCompilerFactory::class, $factory);
+        $factory->setMapperCompilerFactory(FactoryProbeInput::class, static fn () => throw new LogicException('custom factory used'));
+
+        $mapperProvider = new MapperProvider(sys_get_temp_dir(), autoRefresh: true, mapperCompilerFactoryProvider: $factoryProvider);
+        $mapperProvider->registerCodec(new MoneyCodec());
+
+        self::assertException(
+            LogicException::class,
+            'custom factory used',
+            static fn () => $mapperProvider->getInputMapper(FactoryProbeInput::class),
+        );
+    }
+
+    public function testCodecRegistryReRegistrationReplacesCachedInstances(): void
+    {
+        $registry = new CodecRegistry();
+        $registry->register(new MoneyCodec());
+        $first = $registry->get(MoneyCodec::class, MoneyValue::class);
+
+        $replacement = new MoneyCodec();
+        $registry->register($replacement);
+
+        self::assertSame($replacement, $registry->get(MoneyCodec::class, MoneyValue::class));
+        self::assertNotSame($first, $replacement);
     }
 
 }

--- a/tests/Runtime/CodecTest.php
+++ b/tests/Runtime/CodecTest.php
@@ -1,0 +1,278 @@
+<?php declare(strict_types = 1);
+
+namespace ShipMonk\InputMapperTests\Runtime;
+
+use DateTimeImmutable;
+use LogicException;
+use ShipMonk\InputMapper\Runtime\CodecRegistry;
+use ShipMonk\InputMapper\Runtime\Exception\MappingFailedException;
+use ShipMonk\InputMapper\Runtime\MapperProvider;
+use ShipMonk\InputMapperTests\InputMapperTestCase;
+use ShipMonk\InputMapperTests\Runtime\Data\AccountId;
+use ShipMonk\InputMapperTests\Runtime\Data\AlternativeMoneyCodec;
+use ShipMonk\InputMapperTests\Runtime\Data\CodecConflictProbeInput;
+use ShipMonk\InputMapperTests\Runtime\Data\Duration;
+use ShipMonk\InputMapperTests\Runtime\Data\DurationCodec;
+use ShipMonk\InputMapperTests\Runtime\Data\FixedDuration;
+use ShipMonk\InputMapperTests\Runtime\Data\LegacyPaymentInput;
+use ShipMonk\InputMapperTests\Runtime\Data\MoneyCodec;
+use ShipMonk\InputMapperTests\Runtime\Data\MoneyValue;
+use ShipMonk\InputMapperTests\Runtime\Data\OrderId;
+use ShipMonk\InputMapperTests\Runtime\Data\OrderInput;
+use ShipMonk\InputMapperTests\Runtime\Data\SpecialRequirementsDatesInput;
+use ShipMonk\InputMapperTests\Runtime\Data\TypedIdCodec;
+use function sys_get_temp_dir;
+
+class CodecTest extends InputMapperTestCase
+{
+
+    private MapperProvider $mapperProvider;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->mapperProvider = new MapperProvider(sys_get_temp_dir(), autoRefresh: true);
+        $this->mapperProvider->registerCodec(new MoneyCodec());
+        $this->mapperProvider->registerCodec(new DurationCodec());
+    }
+
+    public function testCodecInputMapping(): void
+    {
+        $mapper = $this->mapperProvider->getInputMapper(MoneyValue::class);
+        /** @var MoneyValue $result */
+        $result = $mapper->map(['currency' => 'USD', 'cents' => 1_299]);
+
+        self::assertSame('USD', $result->currency);
+        self::assertSame(1_299, $result->cents);
+    }
+
+    public function testCodecOutputMapping(): void
+    {
+        $mapper = $this->mapperProvider->getOutputMapper(MoneyValue::class);
+        $result = $mapper->map(new MoneyValue('EUR', 500));
+
+        self::assertSame(['currency' => 'EUR', 'cents' => 500], $result);
+    }
+
+    public function testCodecRoundTrip(): void
+    {
+        $data = ['currency' => 'USD', 'cents' => 1_299];
+        $inputMapper = $this->mapperProvider->getInputMapper(MoneyValue::class);
+        $outputMapper = $this->mapperProvider->getOutputMapper(MoneyValue::class);
+
+        $object = $inputMapper->map($data);
+        $result = $outputMapper->map($object);
+
+        self::assertSame($data, $result);
+    }
+
+    public function testCodecInputMappingWithInvalidIntermediateType(): void
+    {
+        $mapper = $this->mapperProvider->getInputMapper(MoneyValue::class);
+
+        self::assertException(
+            MappingFailedException::class,
+            'Failed to map data at path /: Expected array, got "not an array"',
+            static fn () => $mapper->map('not an array'),
+        );
+    }
+
+    public function testCodecInputMappingWithMissingField(): void
+    {
+        $mapper = $this->mapperProvider->getInputMapper(MoneyValue::class);
+
+        self::assertException(
+            MappingFailedException::class,
+            null,
+            static fn () => $mapper->map(['currency' => 'USD']),
+        );
+    }
+
+    public function testCodecDecodeValidation(): void
+    {
+        $mapper = $this->mapperProvider->getInputMapper(MoneyValue::class);
+
+        self::assertException(
+            MappingFailedException::class,
+            'Failed to map data at path /cents: Expected non-negative integer, got -100',
+            static fn () => $mapper->map(['currency' => 'USD', 'cents' => -100]),
+        );
+    }
+
+    public function testCodecAsFieldInObject(): void
+    {
+        $inputMapper = $this->mapperProvider->getInputMapper(OrderInput::class);
+        $outputMapper = $this->mapperProvider->getOutputMapper(OrderInput::class);
+
+        $data = ['id' => 42, 'total' => ['currency' => 'USD', 'cents' => 1_299]];
+        /** @var OrderInput $order */
+        $order = $inputMapper->map($data);
+
+        self::assertSame(42, $order->id);
+        self::assertSame('USD', $order->total->currency);
+        self::assertSame(1_299, $order->total->cents);
+
+        $result = $outputMapper->map($order);
+        self::assertSame($data, $result);
+    }
+
+    public function testCodecRegistryGetUnregistered(): void
+    {
+        $registry = new CodecRegistry();
+
+        self::assertException(
+            LogicException::class,
+            "No codec factory registered for 'ShipMonk\InputMapperTests\Runtime\Data\MoneyCodec'.",
+            static fn () => $registry->get(MoneyCodec::class, MoneyValue::class),
+        );
+    }
+
+    public function testCodecFactoryInputMapping(): void
+    {
+        $mapperProvider = new MapperProvider(sys_get_temp_dir(), autoRefresh: true);
+        $mapperProvider->registerCodecFactory(TypedIdCodec::class, TypedIdCodec::create(...));
+
+        $result = $mapperProvider->getInputMapper(AccountId::class)->map('abc-123');
+        self::assertSame('abc-123', $result->value);
+    }
+
+    public function testCodecFactoryOutputMapping(): void
+    {
+        $mapperProvider = new MapperProvider(sys_get_temp_dir(), autoRefresh: true);
+        $mapperProvider->registerCodecFactory(TypedIdCodec::class, TypedIdCodec::create(...));
+
+        $result = $mapperProvider->getOutputMapper(AccountId::class)->map(new AccountId('abc-123'));
+        self::assertSame('abc-123', $result);
+    }
+
+    public function testCodecFactoryDifferentSubclasses(): void
+    {
+        $mapperProvider = new MapperProvider(sys_get_temp_dir(), autoRefresh: true);
+        $mapperProvider->registerCodecFactory(TypedIdCodec::class, TypedIdCodec::create(...));
+
+        $accountId = $mapperProvider->getInputMapper(AccountId::class)->map('acc-1');
+        self::assertSame('acc-1', $accountId->value);
+
+        $orderId = $mapperProvider->getInputMapper(OrderId::class)->map('ord-2');
+        self::assertSame('ord-2', $orderId->value);
+    }
+
+    public function testCodecFactoryRoundTrip(): void
+    {
+        $mapperProvider = new MapperProvider(sys_get_temp_dir(), autoRefresh: true);
+        $mapperProvider->registerCodecFactory(TypedIdCodec::class, TypedIdCodec::create(...));
+
+        $inputMapper = $mapperProvider->getInputMapper(AccountId::class);
+        $outputMapper = $mapperProvider->getOutputMapper(AccountId::class);
+
+        $object = $inputMapper->map('abc-123');
+        $result = $outputMapper->map($object);
+
+        self::assertSame('abc-123', $result);
+    }
+
+    public function testAsymmetricCodecInputMapping(): void
+    {
+        $mapper = $this->mapperProvider->getInputMapper(FixedDuration::class);
+        $result = $mapper->map(90);
+
+        self::assertSame(90, $result->toSeconds());
+    }
+
+    public function testAsymmetricCodecOutputMapping(): void
+    {
+        $mapper = $this->mapperProvider->getOutputMapper(Duration::class);
+        $result = $mapper->map(new FixedDuration(90));
+
+        self::assertSame(90, $result);
+    }
+
+    public function testConflictingCodecRegistrationsThrow(): void
+    {
+        $mapperProvider = new MapperProvider(sys_get_temp_dir(), autoRefresh: true);
+        $mapperProvider->registerCodec(new MoneyCodec());
+        $mapperProvider->registerCodec(new AlternativeMoneyCodec());
+
+        self::assertException(
+            LogicException::class,
+            "Multiple codecs registered for domain class 'ShipMonk\InputMapperTests\Runtime\Data\MoneyValue': ShipMonk\InputMapperTests\Runtime\Data\MoneyCodec, ShipMonk\InputMapperTests\Runtime\Data\AlternativeMoneyCodec.",
+            static fn () => $mapperProvider->getInputMapper(CodecConflictProbeInput::class),
+        );
+    }
+
+    public function testInlineCodecAttribute(): void
+    {
+        $inputMapper = $this->mapperProvider->getInputMapper(SpecialRequirementsDatesInput::class);
+
+        /** @var SpecialRequirementsDatesInput $result */
+        $result = $inputMapper->map([
+            'deadline' => '2024-02-29',
+            'earliest' => '2024-01-15T10:30:00+00:00',
+        ]);
+
+        self::assertSame('2024-02-29', $result->deadline->format('Y-m-d'));
+        self::assertNotNull($result->earliest);
+        self::assertSame('2024-01-15T10:30:00+00:00', $result->earliest->format('Y-m-d\TH:i:sP'));
+    }
+
+    public function testInlineCodecAttributeWithNullAndAbsentValues(): void
+    {
+        $inputMapper = $this->mapperProvider->getInputMapper(SpecialRequirementsDatesInput::class);
+
+        /** @var SpecialRequirementsDatesInput $resultWithNull */
+        $resultWithNull = $inputMapper->map(['deadline' => '2024-02-29', 'earliest' => null]);
+        self::assertNull($resultWithNull->earliest);
+
+        /** @var SpecialRequirementsDatesInput $resultWithAbsent */
+        $resultWithAbsent = $inputMapper->map(['deadline' => '2024-02-29']);
+        self::assertNull($resultWithAbsent->earliest);
+    }
+
+    public function testInlineCodecAttributeWithInvalidValue(): void
+    {
+        $inputMapper = $this->mapperProvider->getInputMapper(SpecialRequirementsDatesInput::class);
+
+        self::assertException(
+            MappingFailedException::class,
+            "Failed to map data at path /deadline: Expected date-time string in format 'Y-m-d', got \"whatever\"",
+            static fn () => $inputMapper->map(['deadline' => 'whatever']),
+        );
+    }
+
+    public function testInlineCodecAttributeOutputMapping(): void
+    {
+        $outputMapper = $this->mapperProvider->getOutputMapper(SpecialRequirementsDatesInput::class);
+
+        $result = $outputMapper->map(new SpecialRequirementsDatesInput(
+            deadline: new DateTimeImmutable('2024-02-29'),
+            earliest: new DateTimeImmutable('2024-01-15T10:30:00+00:00'),
+        ));
+
+        self::assertSame(['deadline' => '2024-02-29', 'earliest' => '2024-01-15T10:30:00+00:00'], $result);
+
+        $resultWithNull = $outputMapper->map(new SpecialRequirementsDatesInput(deadline: new DateTimeImmutable('2024-02-29')));
+        self::assertSame(['deadline' => '2024-02-29', 'earliest' => null], $resultWithNull);
+    }
+
+    public function testMapCodecWrapperAttribute(): void
+    {
+        $inputMapper = $this->mapperProvider->getInputMapper(LegacyPaymentInput::class);
+        $outputMapper = $this->mapperProvider->getOutputMapper(LegacyPaymentInput::class);
+
+        $data = ['amount' => 'USD:1299', 'refund' => 'EUR-500'];
+        /** @var LegacyPaymentInput $result */
+        $result = $inputMapper->map($data);
+
+        self::assertSame('1299', $result->amount);
+        self::assertSame('500', $result->refund);
+        self::assertSame($data, $outputMapper->map($result));
+
+        $dataWithNull = ['amount' => 'USD:1299', 'refund' => null];
+        /** @var LegacyPaymentInput $resultWithNull */
+        $resultWithNull = $inputMapper->map($dataWithNull);
+
+        self::assertNull($resultWithNull->refund);
+        self::assertSame($dataWithNull, $outputMapper->map($resultWithNull));
+    }
+
+}

--- a/tests/Runtime/Data/AccountId.php
+++ b/tests/Runtime/Data/AccountId.php
@@ -1,0 +1,8 @@
+<?php declare(strict_types = 1);
+
+namespace ShipMonk\InputMapperTests\Runtime\Data;
+
+class AccountId extends TypedId
+{
+
+}

--- a/tests/Runtime/Data/AlternativeMoneyCodec.php
+++ b/tests/Runtime/Data/AlternativeMoneyCodec.php
@@ -1,0 +1,32 @@
+<?php declare(strict_types = 1);
+
+namespace ShipMonk\InputMapperTests\Runtime\Data;
+
+use ShipMonk\InputMapper\Runtime\Codec;
+
+/**
+ * Second codec claiming MoneyValue, used to test conflicting codec registrations.
+ *
+ * @implements Codec<string, MoneyValue, MoneyValue, string>
+ */
+class AlternativeMoneyCodec implements Codec
+{
+
+    /**
+     * @param list<string|int> $path
+     */
+    public function decode(mixed $data, array $path = []): MoneyValue
+    {
+        [$currency, $cents] = explode(' ', $data);
+        return new MoneyValue($currency, (int) $cents);
+    }
+
+    /**
+     * @param list<string|int> $path
+     */
+    public function encode(mixed $data, array $path = []): string
+    {
+        return "{$data->currency} {$data->cents}";
+    }
+
+}

--- a/tests/Runtime/Data/CodecConflictProbeInput.php
+++ b/tests/Runtime/Data/CodecConflictProbeInput.php
@@ -1,0 +1,14 @@
+<?php declare(strict_types = 1);
+
+namespace ShipMonk\InputMapperTests\Runtime\Data;
+
+class CodecConflictProbeInput
+{
+
+    public function __construct(
+        public readonly int $id,
+    )
+    {
+    }
+
+}

--- a/tests/Runtime/Data/DateTimeFormatCodec.php
+++ b/tests/Runtime/Data/DateTimeFormatCodec.php
@@ -1,0 +1,70 @@
+<?php declare(strict_types = 1);
+
+namespace ShipMonk\InputMapperTests\Runtime\Data;
+
+use Attribute;
+use DateTimeImmutable;
+use DateTimeInterface;
+use ShipMonk\InputMapper\Compiler\Attribute\MapCodec;
+use ShipMonk\InputMapper\Compiler\Mapper\MapperCompiler;
+use ShipMonk\InputMapper\Compiler\Mapper\MapperCompilerProvider;
+use ShipMonk\InputMapper\Compiler\MapperFactory\MapperCompilerFactory;
+use ShipMonk\InputMapper\Runtime\Codec;
+use ShipMonk\InputMapper\Runtime\Exception\MappingFailedException;
+
+/**
+ * Codec usable directly as an attribute and composable with other mapper attributes,
+ * e.g. `#[MapNullable(new DateTimeFormatCodec('Y-m-d'))]`.
+ *
+ * @implements Codec<string, DateTimeInterface, DateTimeImmutable, string>
+ */
+#[Attribute(Attribute::TARGET_PARAMETER | Attribute::TARGET_PROPERTY)]
+class DateTimeFormatCodec implements Codec, MapperCompilerProvider
+{
+
+    public function __construct(
+        public readonly string $format = DateTimeInterface::ATOM,
+    )
+    {
+    }
+
+    /**
+     * @param list<string|int> $path
+     * @throws MappingFailedException
+     */
+    public function decode(mixed $data, array $path = []): DateTimeImmutable
+    {
+        $result = DateTimeImmutable::createFromFormat($this->format, $data);
+
+        if ($result === false) {
+            throw MappingFailedException::incorrectValue($data, $path, "date-time string in format '{$this->format}'");
+        }
+
+        return $result;
+    }
+
+    /**
+     * @param list<string|int> $path
+     */
+    public function encode(mixed $data, array $path = []): string
+    {
+        return $data->format($this->format);
+    }
+
+    public function getInputMapperCompiler(
+        MapperCompilerFactory $mapperCompilerFactory,
+        array $options,
+    ): MapperCompiler
+    {
+        return (new MapCodec($this))->getInputMapperCompiler($mapperCompilerFactory, $options);
+    }
+
+    public function getOutputMapperCompiler(
+        MapperCompilerFactory $mapperCompilerFactory,
+        array $options,
+    ): MapperCompiler
+    {
+        return (new MapCodec($this))->getOutputMapperCompiler($mapperCompilerFactory, $options);
+    }
+
+}

--- a/tests/Runtime/Data/DateTimeInterfaceCodec.php
+++ b/tests/Runtime/Data/DateTimeInterfaceCodec.php
@@ -1,0 +1,33 @@
+<?php declare(strict_types = 1);
+
+namespace ShipMonk\InputMapperTests\Runtime\Data;
+
+use DateTimeImmutable;
+use DateTimeInterface;
+use ShipMonk\InputMapper\Runtime\Codec;
+use ShipMonk\InputMapper\Runtime\Exception\MappingFailedException;
+
+/**
+ * @implements Codec<string, DateTimeInterface, DateTimeImmutable, string>
+ */
+class DateTimeInterfaceCodec implements Codec
+{
+
+    /**
+     * @param list<string|int> $path
+     * @throws MappingFailedException
+     */
+    public function decode(mixed $data, array $path = []): DateTimeImmutable
+    {
+        return new DateTimeImmutable($data);
+    }
+
+    /**
+     * @param list<string|int> $path
+     */
+    public function encode(mixed $data, array $path = []): string
+    {
+        return $data->format('c');
+    }
+
+}

--- a/tests/Runtime/Data/Duration.php
+++ b/tests/Runtime/Data/Duration.php
@@ -1,0 +1,10 @@
+<?php declare(strict_types = 1);
+
+namespace ShipMonk\InputMapperTests\Runtime\Data;
+
+interface Duration
+{
+
+    public function toSeconds(): int;
+
+}

--- a/tests/Runtime/Data/DurationCodec.php
+++ b/tests/Runtime/Data/DurationCodec.php
@@ -1,0 +1,37 @@
+<?php declare(strict_types = 1);
+
+namespace ShipMonk\InputMapperTests\Runtime\Data;
+
+use ShipMonk\InputMapper\Runtime\Codec;
+use ShipMonk\InputMapper\Runtime\Exception\MappingFailedException;
+
+/**
+ * Asymmetric codec: decodes into the concrete FixedDuration, but encodes any Duration implementation.
+ *
+ * @implements Codec<int, Duration, FixedDuration, int>
+ */
+class DurationCodec implements Codec
+{
+
+    /**
+     * @param list<string|int> $path
+     * @throws MappingFailedException
+     */
+    public function decode(mixed $data, array $path = []): FixedDuration
+    {
+        if ($data < 0) {
+            throw MappingFailedException::incorrectValue($data, $path, 'non-negative duration in seconds');
+        }
+
+        return new FixedDuration($data);
+    }
+
+    /**
+     * @param list<string|int> $path
+     */
+    public function encode(mixed $data, array $path = []): int
+    {
+        return $data->toSeconds();
+    }
+
+}

--- a/tests/Runtime/Data/FactoryProbeInput.php
+++ b/tests/Runtime/Data/FactoryProbeInput.php
@@ -1,0 +1,12 @@
+<?php declare(strict_types = 1);
+
+namespace ShipMonk\InputMapperTests\Runtime\Data;
+
+class FactoryProbeInput
+{
+
+    public function __construct()
+    {
+    }
+
+}

--- a/tests/Runtime/Data/FixedDuration.php
+++ b/tests/Runtime/Data/FixedDuration.php
@@ -1,0 +1,19 @@
+<?php declare(strict_types = 1);
+
+namespace ShipMonk\InputMapperTests\Runtime\Data;
+
+class FixedDuration implements Duration
+{
+
+    public function __construct(
+        private readonly int $seconds,
+    )
+    {
+    }
+
+    public function toSeconds(): int
+    {
+        return $this->seconds;
+    }
+
+}

--- a/tests/Runtime/Data/HexColor.php
+++ b/tests/Runtime/Data/HexColor.php
@@ -1,0 +1,14 @@
+<?php declare(strict_types = 1);
+
+namespace ShipMonk\InputMapperTests\Runtime\Data;
+
+class HexColor
+{
+
+    public function __construct(
+        public readonly string $hex,
+    )
+    {
+    }
+
+}

--- a/tests/Runtime/Data/HexColorCodec.php
+++ b/tests/Runtime/Data/HexColorCodec.php
@@ -1,0 +1,36 @@
+<?php declare(strict_types = 1);
+
+namespace ShipMonk\InputMapperTests\Runtime\Data;
+
+use ShipMonk\InputMapper\Runtime\Codec;
+use ShipMonk\InputMapper\Runtime\Exception\MappingFailedException;
+use function str_starts_with;
+
+/**
+ * @implements Codec<string, HexColor>
+ */
+class HexColorCodec implements Codec
+{
+
+    /**
+     * @param list<string|int> $path
+     * @throws MappingFailedException
+     */
+    public function decode(mixed $data, array $path = []): HexColor
+    {
+        if (!str_starts_with($data, '#')) {
+            throw MappingFailedException::incorrectValue($data, $path, 'hex color string');
+        }
+
+        return new HexColor($data);
+    }
+
+    /**
+     * @param list<string|int> $path
+     */
+    public function encode(mixed $data, array $path = []): string
+    {
+        return $data->hex;
+    }
+
+}

--- a/tests/Runtime/Data/InheritedHexColorCodec.php
+++ b/tests/Runtime/Data/InheritedHexColorCodec.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types = 1);
+
+namespace ShipMonk\InputMapperTests\Runtime\Data;
+
+/**
+ * Codec inheriting its Codec generic arguments from the parent class, without own @extends annotation.
+ */
+class InheritedHexColorCodec extends HexColorCodec
+{
+
+}

--- a/tests/Runtime/Data/LegacyPaymentInput.php
+++ b/tests/Runtime/Data/LegacyPaymentInput.php
@@ -1,0 +1,21 @@
+<?php declare(strict_types = 1);
+
+namespace ShipMonk\InputMapperTests\Runtime\Data;
+
+use ShipMonk\InputMapper\Compiler\Attribute\MapCodec;
+use ShipMonk\InputMapper\Compiler\Attribute\MapNullable;
+use ShipMonk\InputMapperTests\Compiler\Mapper\Codec\Data\CurrencyPrefixCodec;
+
+class LegacyPaymentInput
+{
+
+    public function __construct(
+        #[CurrencyPrefixCodec(prefix: 'USD')]
+        public readonly string $amount,
+        #[MapNullable(new MapCodec(new CurrencyPrefixCodec(prefix: 'EUR', separator: '-')))]
+        public readonly ?string $refund,
+    )
+    {
+    }
+
+}

--- a/tests/Runtime/Data/MoneyCodec.php
+++ b/tests/Runtime/Data/MoneyCodec.php
@@ -1,0 +1,38 @@
+<?php declare(strict_types = 1);
+
+namespace ShipMonk\InputMapperTests\Runtime\Data;
+
+use ShipMonk\InputMapper\Runtime\Codec;
+use ShipMonk\InputMapper\Runtime\Exception\MappingFailedException;
+
+/**
+ * @implements Codec<array{currency: string, cents: int}, MoneyValue, MoneyValue, array{currency: string, cents: int}>
+ */
+class MoneyCodec implements Codec
+{
+
+    /**
+     * @param list<string|int> $path
+     * @throws MappingFailedException
+     */
+    public function decode(mixed $data, array $path = []): MoneyValue
+    {
+        if ($data['cents'] < 0) {
+            throw MappingFailedException::incorrectValue($data['cents'], [...$path, 'cents'], 'non-negative integer');
+        }
+
+        return new MoneyValue($data['currency'], $data['cents']);
+    }
+
+    /**
+     * @param list<string|int> $path
+     */
+    public function encode(mixed $data, array $path = []): array
+    {
+        return [
+            'currency' => $data->currency,
+            'cents' => $data->cents,
+        ];
+    }
+
+}

--- a/tests/Runtime/Data/MoneyValue.php
+++ b/tests/Runtime/Data/MoneyValue.php
@@ -1,0 +1,15 @@
+<?php declare(strict_types = 1);
+
+namespace ShipMonk\InputMapperTests\Runtime\Data;
+
+class MoneyValue
+{
+
+    public function __construct(
+        public readonly string $currency,
+        public readonly int $cents,
+    )
+    {
+    }
+
+}

--- a/tests/Runtime/Data/OrderId.php
+++ b/tests/Runtime/Data/OrderId.php
@@ -1,0 +1,8 @@
+<?php declare(strict_types = 1);
+
+namespace ShipMonk\InputMapperTests\Runtime\Data;
+
+class OrderId extends TypedId
+{
+
+}

--- a/tests/Runtime/Data/OrderInput.php
+++ b/tests/Runtime/Data/OrderInput.php
@@ -1,0 +1,15 @@
+<?php declare(strict_types = 1);
+
+namespace ShipMonk\InputMapperTests\Runtime\Data;
+
+class OrderInput
+{
+
+    public function __construct(
+        public readonly int $id,
+        public readonly MoneyValue $total,
+    )
+    {
+    }
+
+}

--- a/tests/Runtime/Data/PrefixedSuffixedInput.php
+++ b/tests/Runtime/Data/PrefixedSuffixedInput.php
@@ -1,0 +1,19 @@
+<?php declare(strict_types = 1);
+
+namespace ShipMonk\InputMapperTests\Runtime\Data;
+
+use ShipMonk\InputMapperTests\Compiler\Mapper\Codec\Data\CurrencyPrefixCodec;
+use ShipMonk\InputMapperTests\Compiler\Mapper\Codec\Data\SuffixCodec;
+
+class PrefixedSuffixedInput
+{
+
+    public function __construct(
+        #[CurrencyPrefixCodec(prefix: 'USD')]
+        #[SuffixCodec(suffix: '!')]
+        public readonly string $amount,
+    )
+    {
+    }
+
+}

--- a/tests/Runtime/Data/ReversedTokenInput.php
+++ b/tests/Runtime/Data/ReversedTokenInput.php
@@ -1,0 +1,17 @@
+<?php declare(strict_types = 1);
+
+namespace ShipMonk\InputMapperTests\Runtime\Data;
+
+use ShipMonk\InputMapperTests\Compiler\Mapper\Codec\Data\InputOnlyProviderCodec;
+
+class ReversedTokenInput
+{
+
+    public function __construct(
+        #[InputOnlyProviderCodec]
+        public readonly string $token,
+    )
+    {
+    }
+
+}

--- a/tests/Runtime/Data/SpecialRequirementsDatesInput.php
+++ b/tests/Runtime/Data/SpecialRequirementsDatesInput.php
@@ -1,0 +1,22 @@
+<?php declare(strict_types = 1);
+
+namespace ShipMonk\InputMapperTests\Runtime\Data;
+
+use DateTimeImmutable;
+use ShipMonk\InputMapper\Compiler\Attribute\MapNullable;
+use ShipMonk\InputMapper\Compiler\Attribute\Optional;
+
+class SpecialRequirementsDatesInput
+{
+
+    public function __construct(
+        #[DateTimeFormatCodec(format: 'Y-m-d')]
+        public readonly DateTimeImmutable $deadline,
+        #[Optional]
+        #[MapNullable(new DateTimeFormatCodec(format: 'Y-m-d\TH:i:sP'))]
+        public readonly ?DateTimeImmutable $earliest = null,
+    )
+    {
+    }
+
+}

--- a/tests/Runtime/Data/TypedId.php
+++ b/tests/Runtime/Data/TypedId.php
@@ -1,0 +1,19 @@
+<?php declare(strict_types = 1);
+
+namespace ShipMonk\InputMapperTests\Runtime\Data;
+
+abstract class TypedId
+{
+
+    public function __construct(
+        public readonly string $value,
+    )
+    {
+    }
+
+    public function toString(): string
+    {
+        return $this->value;
+    }
+
+}

--- a/tests/Runtime/Data/TypedIdCodec.php
+++ b/tests/Runtime/Data/TypedIdCodec.php
@@ -1,0 +1,52 @@
+<?php declare(strict_types = 1);
+
+namespace ShipMonk\InputMapperTests\Runtime\Data;
+
+use ShipMonk\InputMapper\Runtime\Codec;
+use ShipMonk\InputMapper\Runtime\CodecRegistry;
+
+/**
+ * @template T of TypedId
+ * @implements Codec<string, T, T, string>
+ */
+class TypedIdCodec implements Codec
+{
+
+    /**
+     * @param class-string<T> $className
+     */
+    public function __construct(
+        private readonly string $className,
+    )
+    {
+    }
+
+    /**
+     * @param class-string $className
+     * @return self<TypedId>
+     */
+    public static function create(string $className, CodecRegistry $registry): self
+    {
+        return new self($className); // @phpstan-ignore argument.type
+    }
+
+    /**
+     * @param string $data
+     * @param list<string|int> $path
+     * @return T
+     */
+    public function decode(mixed $data, array $path = []): TypedId
+    {
+        return new ($this->className)($data);
+    }
+
+    /**
+     * @param T $data
+     * @param list<string|int> $path
+     */
+    public function encode(mixed $data, array $path = []): string
+    {
+        return $data->toString();
+    }
+
+}

--- a/tests/Runtime/Data/UnboundGenericCodec.php
+++ b/tests/Runtime/Data/UnboundGenericCodec.php
@@ -1,0 +1,35 @@
+<?php declare(strict_types = 1);
+
+namespace ShipMonk\InputMapperTests\Runtime\Data;
+
+use ShipMonk\InputMapper\Runtime\Codec;
+
+/**
+ * Codec without any inferable domain class (unbound template parameter), must be rejected on registration.
+ *
+ * @template T
+ * @implements Codec<string, T, T, string>
+ */
+class UnboundGenericCodec implements Codec
+{
+
+    /**
+     * @param string $data
+     * @param list<string|int> $path
+     * @return T
+     */
+    public function decode(mixed $data, array $path = []): mixed
+    {
+        return $data; // @phpstan-ignore return.type
+    }
+
+    /**
+     * @param T $data
+     * @param list<string|int> $path
+     */
+    public function encode(mixed $data, array $path = []): string
+    {
+        return (string) $data; // @phpstan-ignore cast.string
+    }
+
+}

--- a/tests/Runtime/InputMapperProviderTest.php
+++ b/tests/Runtime/InputMapperProviderTest.php
@@ -130,7 +130,7 @@ class InputMapperProviderTest extends InputMapperTestCase
 
             $factoryProvider = new DefaultMapperCompilerFactoryProvider();
             $factory = $factoryProvider->get();
-            $mapperCompiler = $factory->create(new IdentifierTypeNode($className))->getInputMapperCompiler();
+            $mapperCompiler = $factory->create(new IdentifierTypeNode($className))->getInputMapperCompiler($factory, []);
 
             $codeBuilder = new PhpCodeBuilder();
             $codePrinter = new PhpCodePrinter();


### PR DESCRIPTION
Revives and completes the codec design from the archived local `codec` branch (WIP `662eee4`), rebuilt on current master.

## What are codecs

A codec converts between an **intermediate wire type** (auto-compiled by the library, including all validation) and a **domain type** (implemented by the user in `decode()`/`encode()`). The user never touches `mixed`.

```php
/** @implements Codec<array{currency: string, cents: int}, Money> */
class MoneyCodec implements Codec { ... }

$mapperProvider->registerCodec(new MoneyCodec());
$money = $mapperProvider->getInputMapper(Money::class)->map(['currency' => 'USD', 'cents' => 1299]);
```

- `Codec<DI, EI, DO = EI, EO = DI>` — 4 generic parameters with template defaults enable asymmetric conversion (e.g. decode into `DateTimeImmutable`, encode from `DateTimeInterface`)
- `registerCodec()` for instances, `registerCodecFactory()` for parameterized codecs handling class families (e.g. all `TypedId` subclasses)
- Codecs can also be applied **per property as attributes** (inline mode — the codec is re-instantiated inside the generated mapper from its scalar constructor args) and **compose with other mapper attributes**: `#[MapNullable(new MapCodec(new DateTimeFormatCodec('Y-m-d')))]`, or directly `#[MapNullable(new DateTimeFormatCodec('Y-m-d'))]` when the codec implements `MapperCompilerProvider`

## SPI change (BC break, see UPGRADING.md)

Composable codec attributes must compile a mapper for their intermediate type at provide-time, so both provider methods now receive the factory and options:

```php
public function getInputMapperCompiler(MapperCompilerFactory $mapperCompilerFactory, array $options): MapperCompiler;
```

This is the route the previous attempt died on mid-refactor; with the provider-based factory from #111 it now lands cleanly (PHPStan level 9, no ignores in src). Additionally `MapperCompilerFactoryProvider` gains `getCodecRegistry()` — the factory provider owns the codec registry, so compiled mappers and the runtime codec lookup always share one registry (`get()` keeps its 2.x signature).

## Other changes

- `GenericTypeDefinition::parameterOffsetMapping` is now auto-derived from `@template` defaults referencing other template parameters (`@template DO = EI`), and `PhpDocTypeUtils::inferGenericParameter()` accepts plain identifier types
- `PhpCodeBuilder` supports class properties (`addProperty()`/`uniqPropertyName()`) for lazily initialized inline codecs
- Codec resolution walks the domain class hierarchy most-specific-first; codecs win over type-based factories at equal depth; conflicting registrations for the same domain class throw
- Known limitation (documented): mappers already compiled (in-process or cached on disk without `autoRefresh`) do not observe later codec registrations — same pre-existing behavior as `PropertyNameTransformer`; codecs registered late are picked up for classes not compiled yet

## Post-review hardening

The follow-up commit addresses findings from an adversarial review pass (4 reviewer agents + Copilot): atomic codec domain-map building with loud errors for unresolvable/conflicting codec declarations, `@implements` inheritance from parent codec classes, transitive `@template` default resolution, codec attributes implementing half of the provider SPI no longer silently dropped, multiple codec attributes on one promoted property chaining instead of erroring, `MapCodec` constructor-arg extraction hardening (static/uninitialized/private-parent properties), named arguments in generated inline codec instantiation, file-lock release on compile failure, and 12 new regression tests.

Asana: https://app.asana.com/1/34185869488047/project/1200120071742677/task/1216261530337856

Co-Authored-By: Claude Code

https://claude.ai/code/session_01KqyAVZqbvJ3wb8tD9ZwFU7
