### PR TITLE
Add CompositeMapperCompilerProvider for typed provider graph traversal

### DIFF
--- a/src/Compiler/Attribute/MapArray.php
+++ b/src/Compiler/Attribute/MapArray.php
@@ -3,13 +3,14 @@
 namespace ShipMonk\InputMapper\Compiler\Attribute;
 
 use Attribute;
+use ShipMonk\InputMapper\Compiler\Mapper\CompositeMapperCompilerProvider;
 use ShipMonk\InputMapper\Compiler\Mapper\Input\ArrayInputMapperCompiler;
 use ShipMonk\InputMapper\Compiler\Mapper\MapperCompiler;
 use ShipMonk\InputMapper\Compiler\Mapper\MapperCompilerProvider;
 use ShipMonk\InputMapper\Compiler\Mapper\Output\ArrayOutputMapperCompiler;
 
 #[Attribute(Attribute::TARGET_PARAMETER | Attribute::TARGET_PROPERTY)]
-class MapArray implements MapperCompilerProvider
+class MapArray implements CompositeMapperCompilerProvider, MapperCompilerProvider
 {
 
     public function __construct(
@@ -33,6 +34,14 @@ class MapArray implements MapperCompilerProvider
             $this->keyMapperCompilerProvider->getOutputMapperCompiler(),
             $this->valueMapperCompilerProvider->getOutputMapperCompiler(),
         );
+    }
+
+    /**
+     * @return list<MapperCompilerProvider>
+     */
+    public function getInnerMapperCompilerProviders(): array
+    {
+        return [$this->keyMapperCompilerProvider, $this->valueMapperCompilerProvider];
     }
 
 }

--- a/src/Compiler/Attribute/MapArrayShape.php
+++ b/src/Compiler/Attribute/MapArrayShape.php
@@ -3,13 +3,15 @@
 namespace ShipMonk\InputMapper\Compiler\Attribute;
 
 use Attribute;
+use ShipMonk\InputMapper\Compiler\Mapper\CompositeMapperCompilerProvider;
 use ShipMonk\InputMapper\Compiler\Mapper\Input\ArrayShapeInputMapperCompiler;
 use ShipMonk\InputMapper\Compiler\Mapper\MapperCompiler;
 use ShipMonk\InputMapper\Compiler\Mapper\MapperCompilerProvider;
 use ShipMonk\InputMapper\Compiler\Mapper\Output\ArrayShapeOutputMapperCompiler;
+use function array_map;
 
 #[Attribute(Attribute::TARGET_PARAMETER | Attribute::TARGET_PROPERTY)]
-class MapArrayShape implements MapperCompilerProvider
+class MapArrayShape implements CompositeMapperCompilerProvider, MapperCompilerProvider
 {
 
     /**
@@ -42,6 +44,14 @@ class MapArrayShape implements MapperCompilerProvider
         }
 
         return new ArrayShapeOutputMapperCompiler($compilerItems, $this->sealed);
+    }
+
+    /**
+     * @return list<MapperCompilerProvider>
+     */
+    public function getInnerMapperCompilerProviders(): array
+    {
+        return array_map(static fn (ArrayShapeItemMapping $item): MapperCompilerProvider => $item->mapper, $this->items);
     }
 
 }

--- a/src/Compiler/Attribute/MapChain.php
+++ b/src/Compiler/Attribute/MapChain.php
@@ -2,13 +2,14 @@
 
 namespace ShipMonk\InputMapper\Compiler\Attribute;
 
+use ShipMonk\InputMapper\Compiler\Mapper\CompositeMapperCompilerProvider;
 use ShipMonk\InputMapper\Compiler\Mapper\Input\ChainMapperCompiler;
 use ShipMonk\InputMapper\Compiler\Mapper\MapperCompiler;
 use ShipMonk\InputMapper\Compiler\Mapper\MapperCompilerProvider;
 use function array_map;
 use function array_reverse;
 
-class MapChain implements MapperCompilerProvider
+class MapChain implements CompositeMapperCompilerProvider, MapperCompilerProvider
 {
 
     /**
@@ -38,6 +39,14 @@ class MapChain implements MapperCompilerProvider
                 array_reverse($this->providers),
             ),
         );
+    }
+
+    /**
+     * @return list<MapperCompilerProvider>
+     */
+    public function getInnerMapperCompilerProviders(): array
+    {
+        return $this->providers;
     }
 
 }

--- a/src/Compiler/Attribute/MapDefaultValue.php
+++ b/src/Compiler/Attribute/MapDefaultValue.php
@@ -3,12 +3,13 @@
 namespace ShipMonk\InputMapper\Compiler\Attribute;
 
 use Attribute;
+use ShipMonk\InputMapper\Compiler\Mapper\CompositeMapperCompilerProvider;
 use ShipMonk\InputMapper\Compiler\Mapper\Input\DefaultValueInputMapperCompiler;
 use ShipMonk\InputMapper\Compiler\Mapper\MapperCompiler;
 use ShipMonk\InputMapper\Compiler\Mapper\MapperCompilerProvider;
 
 #[Attribute(Attribute::TARGET_PARAMETER | Attribute::TARGET_PROPERTY)]
-class MapDefaultValue implements MapperCompilerProvider
+class MapDefaultValue implements CompositeMapperCompilerProvider, MapperCompilerProvider
 {
 
     public function __construct(
@@ -26,6 +27,14 @@ class MapDefaultValue implements MapperCompilerProvider
     public function getOutputMapperCompiler(): MapperCompiler
     {
         return $this->mapperCompilerProvider->getOutputMapperCompiler();
+    }
+
+    /**
+     * @return list<MapperCompilerProvider>
+     */
+    public function getInnerMapperCompilerProviders(): array
+    {
+        return [$this->mapperCompilerProvider];
     }
 
 }

--- a/src/Compiler/Attribute/MapDelegate.php
+++ b/src/Compiler/Attribute/MapDelegate.php
@@ -3,6 +3,7 @@
 namespace ShipMonk\InputMapper\Compiler\Attribute;
 
 use Attribute;
+use ShipMonk\InputMapper\Compiler\Mapper\CompositeMapperCompilerProvider;
 use ShipMonk\InputMapper\Compiler\Mapper\Input\DelegateInputMapperCompiler;
 use ShipMonk\InputMapper\Compiler\Mapper\MapperCompiler;
 use ShipMonk\InputMapper\Compiler\Mapper\MapperCompilerProvider;
@@ -10,7 +11,7 @@ use ShipMonk\InputMapper\Compiler\Mapper\Output\DelegateOutputMapperCompiler;
 use function array_map;
 
 #[Attribute(Attribute::TARGET_PARAMETER | Attribute::TARGET_PROPERTY)]
-class MapDelegate implements MapperCompilerProvider
+class MapDelegate implements CompositeMapperCompilerProvider, MapperCompilerProvider
 {
 
     /**
@@ -38,6 +39,14 @@ class MapDelegate implements MapperCompilerProvider
             $this->className,
             array_map(static fn (MapperCompilerProvider $p): MapperCompiler => $p->getOutputMapperCompiler(), $this->innerMapperCompilerProviders),
         );
+    }
+
+    /**
+     * @return list<MapperCompilerProvider>
+     */
+    public function getInnerMapperCompilerProviders(): array
+    {
+        return $this->innerMapperCompilerProviders;
     }
 
 }

--- a/src/Compiler/Attribute/MapDiscriminatedObject.php
+++ b/src/Compiler/Attribute/MapDiscriminatedObject.php
@@ -2,17 +2,19 @@
 
 namespace ShipMonk\InputMapper\Compiler\Attribute;
 
+use ShipMonk\InputMapper\Compiler\Mapper\CompositeMapperCompilerProvider;
 use ShipMonk\InputMapper\Compiler\Mapper\Input\DiscriminatedObjectInputMapperCompiler;
 use ShipMonk\InputMapper\Compiler\Mapper\MapperCompiler;
 use ShipMonk\InputMapper\Compiler\Mapper\MapperCompilerProvider;
 use ShipMonk\InputMapper\Compiler\Mapper\Output\DiscriminatedObjectOutputMapperCompiler;
 use ShipMonk\InputMapper\Compiler\Type\GenericTypeParameter;
 use function array_map;
+use function array_values;
 
 /**
  * @template T of object
  */
-class MapDiscriminatedObject implements MapperCompilerProvider
+class MapDiscriminatedObject implements CompositeMapperCompilerProvider, MapperCompilerProvider
 {
 
     /**
@@ -52,6 +54,14 @@ class MapDiscriminatedObject implements MapperCompilerProvider
             ),
             $this->genericParameters,
         );
+    }
+
+    /**
+     * @return list<MapperCompilerProvider>
+     */
+    public function getInnerMapperCompilerProviders(): array
+    {
+        return array_values($this->subtypeProviders);
     }
 
 }

--- a/src/Compiler/Attribute/MapEnum.php
+++ b/src/Compiler/Attribute/MapEnum.php
@@ -4,6 +4,7 @@ namespace ShipMonk\InputMapper\Compiler\Attribute;
 
 use Attribute;
 use BackedEnum;
+use ShipMonk\InputMapper\Compiler\Mapper\CompositeMapperCompilerProvider;
 use ShipMonk\InputMapper\Compiler\Mapper\Input\EnumInputMapperCompiler;
 use ShipMonk\InputMapper\Compiler\Mapper\InputMapperCompilerProvider;
 use ShipMonk\InputMapper\Compiler\Mapper\MapperCompiler;
@@ -11,7 +12,7 @@ use ShipMonk\InputMapper\Compiler\Mapper\MapperCompilerProvider;
 use ShipMonk\InputMapper\Compiler\Mapper\Output\EnumOutputMapperCompiler;
 
 #[Attribute(Attribute::TARGET_PARAMETER | Attribute::TARGET_PROPERTY)]
-class MapEnum implements MapperCompilerProvider
+class MapEnum implements CompositeMapperCompilerProvider, MapperCompilerProvider
 {
 
     /**
@@ -32,6 +33,14 @@ class MapEnum implements MapperCompilerProvider
     public function getOutputMapperCompiler(): MapperCompiler
     {
         return new EnumOutputMapperCompiler($this->enumName);
+    }
+
+    /**
+     * @return list<InputMapperCompilerProvider>
+     */
+    public function getInnerMapperCompilerProviders(): array
+    {
+        return [$this->backingValueMapperCompilerProvider];
     }
 
 }

--- a/src/Compiler/Attribute/MapList.php
+++ b/src/Compiler/Attribute/MapList.php
@@ -3,13 +3,14 @@
 namespace ShipMonk\InputMapper\Compiler\Attribute;
 
 use Attribute;
+use ShipMonk\InputMapper\Compiler\Mapper\CompositeMapperCompilerProvider;
 use ShipMonk\InputMapper\Compiler\Mapper\Input\ListInputMapperCompiler;
 use ShipMonk\InputMapper\Compiler\Mapper\MapperCompiler;
 use ShipMonk\InputMapper\Compiler\Mapper\MapperCompilerProvider;
 use ShipMonk\InputMapper\Compiler\Mapper\Output\ListOutputMapperCompiler;
 
 #[Attribute(Attribute::TARGET_PARAMETER | Attribute::TARGET_PROPERTY)]
-class MapList implements MapperCompilerProvider
+class MapList implements CompositeMapperCompilerProvider, MapperCompilerProvider
 {
 
     public function __construct(
@@ -26,6 +27,14 @@ class MapList implements MapperCompilerProvider
     public function getOutputMapperCompiler(): MapperCompiler
     {
         return new ListOutputMapperCompiler($this->itemMapperCompilerProvider->getOutputMapperCompiler());
+    }
+
+    /**
+     * @return list<MapperCompilerProvider>
+     */
+    public function getInnerMapperCompilerProviders(): array
+    {
+        return [$this->itemMapperCompilerProvider];
     }
 
 }

--- a/src/Compiler/Attribute/MapNullable.php
+++ b/src/Compiler/Attribute/MapNullable.php
@@ -3,13 +3,14 @@
 namespace ShipMonk\InputMapper\Compiler\Attribute;
 
 use Attribute;
+use ShipMonk\InputMapper\Compiler\Mapper\CompositeMapperCompilerProvider;
 use ShipMonk\InputMapper\Compiler\Mapper\Input\NullableInputMapperCompiler;
 use ShipMonk\InputMapper\Compiler\Mapper\MapperCompiler;
 use ShipMonk\InputMapper\Compiler\Mapper\MapperCompilerProvider;
 use ShipMonk\InputMapper\Compiler\Mapper\Output\NullableOutputMapperCompiler;
 
 #[Attribute(Attribute::TARGET_PARAMETER | Attribute::TARGET_PROPERTY)]
-class MapNullable implements MapperCompilerProvider
+class MapNullable implements CompositeMapperCompilerProvider, MapperCompilerProvider
 {
 
     public function __construct(
@@ -26,6 +27,14 @@ class MapNullable implements MapperCompilerProvider
     public function getOutputMapperCompiler(): MapperCompiler
     {
         return new NullableOutputMapperCompiler($this->innerMapperCompilerProvider->getOutputMapperCompiler());
+    }
+
+    /**
+     * @return list<MapperCompilerProvider>
+     */
+    public function getInnerMapperCompilerProviders(): array
+    {
+        return [$this->innerMapperCompilerProvider];
     }
 
 }

--- a/src/Compiler/Attribute/MapObject.php
+++ b/src/Compiler/Attribute/MapObject.php
@@ -2,6 +2,7 @@
 
 namespace ShipMonk\InputMapper\Compiler\Attribute;
 
+use ShipMonk\InputMapper\Compiler\Mapper\CompositeMapperCompilerProvider;
 use ShipMonk\InputMapper\Compiler\Mapper\Input\ObjectInputMapperCompiler;
 use ShipMonk\InputMapper\Compiler\Mapper\InputMapperCompilerProvider;
 use ShipMonk\InputMapper\Compiler\Mapper\MapperCompiler;
@@ -9,9 +10,11 @@ use ShipMonk\InputMapper\Compiler\Mapper\MapperCompilerProvider;
 use ShipMonk\InputMapper\Compiler\Mapper\Output\ObjectOutputMapperCompiler;
 use ShipMonk\InputMapper\Compiler\Mapper\OutputMapperCompilerProvider;
 use ShipMonk\InputMapper\Compiler\Type\GenericTypeParameter;
+use function array_column;
 use function array_map;
+use function array_values;
 
-class MapObject implements MapperCompilerProvider
+class MapObject implements CompositeMapperCompilerProvider, MapperCompilerProvider
 {
 
     /**
@@ -53,6 +56,17 @@ class MapObject implements MapperCompilerProvider
             ),
             $this->genericParameters,
         );
+    }
+
+    /**
+     * @return list<InputMapperCompilerProvider|OutputMapperCompilerProvider>
+     */
+    public function getInnerMapperCompilerProviders(): array
+    {
+        return [
+            ...array_values($this->constructorArgsProviders),
+            ...array_column($this->propertyProviders, 1),
+        ];
     }
 
 }

--- a/src/Compiler/Attribute/MapOptional.php
+++ b/src/Compiler/Attribute/MapOptional.php
@@ -3,13 +3,14 @@
 namespace ShipMonk\InputMapper\Compiler\Attribute;
 
 use Attribute;
+use ShipMonk\InputMapper\Compiler\Mapper\CompositeMapperCompilerProvider;
 use ShipMonk\InputMapper\Compiler\Mapper\Input\OptionalInputMapperCompiler;
 use ShipMonk\InputMapper\Compiler\Mapper\MapperCompiler;
 use ShipMonk\InputMapper\Compiler\Mapper\MapperCompilerProvider;
 use ShipMonk\InputMapper\Compiler\Mapper\Output\OptionalOutputMapperCompiler;
 
 #[Attribute(Attribute::TARGET_PARAMETER | Attribute::TARGET_PROPERTY)]
-class MapOptional implements MapperCompilerProvider
+class MapOptional implements CompositeMapperCompilerProvider, MapperCompilerProvider
 {
 
     public function __construct(
@@ -26,6 +27,14 @@ class MapOptional implements MapperCompilerProvider
     public function getOutputMapperCompiler(): MapperCompiler
     {
         return new OptionalOutputMapperCompiler($this->mapperCompilerProvider->getOutputMapperCompiler());
+    }
+
+    /**
+     * @return list<MapperCompilerProvider>
+     */
+    public function getInnerMapperCompilerProviders(): array
+    {
+        return [$this->mapperCompilerProvider];
     }
 
 }

--- a/src/Compiler/Attribute/MapValidated.php
+++ b/src/Compiler/Attribute/MapValidated.php
@@ -3,13 +3,14 @@
 namespace ShipMonk\InputMapper\Compiler\Attribute;
 
 use Attribute;
+use ShipMonk\InputMapper\Compiler\Mapper\CompositeMapperCompilerProvider;
 use ShipMonk\InputMapper\Compiler\Mapper\Input\ValidatedInputMapperCompiler;
 use ShipMonk\InputMapper\Compiler\Mapper\MapperCompiler;
 use ShipMonk\InputMapper\Compiler\Mapper\MapperCompilerProvider;
 use ShipMonk\InputMapper\Compiler\Validator\ValidatorCompiler;
 
 #[Attribute(Attribute::TARGET_PARAMETER | Attribute::TARGET_PROPERTY)]
-class MapValidated implements MapperCompilerProvider
+class MapValidated implements CompositeMapperCompilerProvider, MapperCompilerProvider
 {
 
     /**
@@ -33,6 +34,14 @@ class MapValidated implements MapperCompilerProvider
     public function getOutputMapperCompiler(): MapperCompiler
     {
         return $this->mapperCompilerProvider->getOutputMapperCompiler();
+    }
+
+    /**
+     * @return list<MapperCompilerProvider>
+     */
+    public function getInnerMapperCompilerProviders(): array
+    {
+        return [$this->mapperCompilerProvider];
     }
 
 }

--- a/src/Compiler/Mapper/CompositeMapperCompilerProvider.php
+++ b/src/Compiler/Mapper/CompositeMapperCompilerProvider.php
@@ -1,0 +1,22 @@
+<?php declare(strict_types = 1);
+
+namespace ShipMonk\InputMapper\Compiler\Mapper;
+
+/**
+ * Implemented by mapper compiler providers that are composed of other providers.
+ *
+ * Allows typed traversal of a provider graph without reflecting over provider internals,
+ * e.g. to discover all delegated classes (@see MapperCompilerProviderUtils::iterate()).
+ *
+ * Every provider holding other providers should implement this interface and expose them,
+ * no matter how deep in its properties they are stored.
+ */
+interface CompositeMapperCompilerProvider
+{
+
+    /**
+     * @return list<InputMapperCompilerProvider|OutputMapperCompilerProvider>
+     */
+    public function getInnerMapperCompilerProviders(): array;
+
+}

--- a/src/Compiler/Mapper/MapperCompilerProviderUtils.php
+++ b/src/Compiler/Mapper/MapperCompilerProviderUtils.php
@@ -1,0 +1,31 @@
+<?php declare(strict_types = 1);
+
+namespace ShipMonk\InputMapper\Compiler\Mapper;
+
+use function array_pop;
+
+class MapperCompilerProviderUtils
+{
+
+    /**
+     * Yields the given provider and all providers transitively nested in composite providers.
+     *
+     * @return iterable<InputMapperCompilerProvider|OutputMapperCompilerProvider>
+     */
+    public static function iterate(InputMapperCompilerProvider|OutputMapperCompilerProvider $provider): iterable
+    {
+        $stack = [$provider];
+
+        while ($stack !== []) {
+            $current = array_pop($stack);
+            yield $current;
+
+            if ($current instanceof CompositeMapperCompilerProvider) {
+                foreach ($current->getInnerMapperCompilerProviders() as $innerProvider) {
+                    $stack[] = $innerProvider;
+                }
+            }
+        }
+    }
+
+}

--- a/tests/Compiler/Mapper/CompositeMapperCompilerProviderTest.php
+++ b/tests/Compiler/Mapper/CompositeMapperCompilerProviderTest.php
@@ -1,0 +1,167 @@
+<?php declare(strict_types = 1);
+
+namespace ShipMonk\InputMapperTests\Compiler\Mapper;
+
+use ReflectionClass;
+use ReflectionObject;
+use ShipMonk\InputMapper\Compiler\Attribute\ArrayShapeItemMapping;
+use ShipMonk\InputMapper\Compiler\Attribute\MapArray;
+use ShipMonk\InputMapper\Compiler\Attribute\MapArrayShape;
+use ShipMonk\InputMapper\Compiler\Attribute\MapBool;
+use ShipMonk\InputMapper\Compiler\Attribute\MapChain;
+use ShipMonk\InputMapper\Compiler\Attribute\MapDate;
+use ShipMonk\InputMapper\Compiler\Attribute\MapDateTimeImmutable;
+use ShipMonk\InputMapper\Compiler\Attribute\MapDefaultValue;
+use ShipMonk\InputMapper\Compiler\Attribute\MapDelegate;
+use ShipMonk\InputMapper\Compiler\Attribute\MapDiscriminatedObject;
+use ShipMonk\InputMapper\Compiler\Attribute\MapEnum;
+use ShipMonk\InputMapper\Compiler\Attribute\MapFloat;
+use ShipMonk\InputMapper\Compiler\Attribute\MapInt;
+use ShipMonk\InputMapper\Compiler\Attribute\MapList;
+use ShipMonk\InputMapper\Compiler\Attribute\MapMixed;
+use ShipMonk\InputMapper\Compiler\Attribute\MapNullable;
+use ShipMonk\InputMapper\Compiler\Attribute\MapObject;
+use ShipMonk\InputMapper\Compiler\Attribute\MapOptional;
+use ShipMonk\InputMapper\Compiler\Attribute\MapString;
+use ShipMonk\InputMapper\Compiler\Attribute\MapValidated;
+use ShipMonk\InputMapper\Compiler\Mapper\InputMapperCompilerProvider;
+use ShipMonk\InputMapper\Compiler\Mapper\MapperCompilerProvider;
+use ShipMonk\InputMapper\Compiler\Mapper\MapperCompilerProviderUtils;
+use ShipMonk\InputMapper\Compiler\Mapper\OutputMapperCompilerProvider;
+use ShipMonk\InputMapper\Compiler\Type\GenericTypeParameter;
+use ShipMonk\InputMapper\Compiler\Validator\Array\AssertListLength;
+use ShipMonk\InputMapperTests\Compiler\Mapper\Object\Data\SuitEnum;
+use ShipMonk\InputMapperTests\InputMapperTestCase;
+use stdClass;
+use function array_diff_key;
+use function array_map;
+use function basename;
+use function get_debug_type;
+use function glob;
+use function is_array;
+use function is_object;
+use function spl_object_id;
+
+class CompositeMapperCompilerProviderTest extends InputMapperTestCase
+{
+
+    /**
+     * Guards that no provider nested anywhere in provider properties is missed
+     * by a CompositeMapperCompilerProvider::getInnerMapperCompilerProviders() implementation.
+     */
+    public function testTypedTraversalMatchesReflectiveTraversal(): void
+    {
+        $root = self::createProviderGraph();
+
+        $typed = [];
+
+        foreach (MapperCompilerProviderUtils::iterate($root) as $provider) {
+            $typed[spl_object_id($provider)] = $provider;
+        }
+
+        $reflective = [];
+        $visited = [];
+        self::collectProvidersReflectively($root, $reflective, $visited);
+
+        $missed = array_map(get_debug_type(...), array_diff_key($reflective, $typed));
+        self::assertSame([], $missed, 'Some providers are reachable via reflection, but not exposed through CompositeMapperCompilerProvider::getInnerMapperCompilerProviders()');
+    }
+
+    public function testProviderGraphContainsAllAttributeProviders(): void
+    {
+        $classesInGraph = [];
+
+        foreach (MapperCompilerProviderUtils::iterate(self::createProviderGraph()) as $provider) {
+            $classesInGraph[$provider::class] = true;
+        }
+
+        $attributeFiles = glob(__DIR__ . '/../../../src/Compiler/Attribute/*.php');
+        self::assertNotFalse($attributeFiles);
+        self::assertNotSame([], $attributeFiles);
+
+        foreach ($attributeFiles as $file) {
+            /** @var class-string $className */
+            $className = 'ShipMonk\\InputMapper\\Compiler\\Attribute\\' . basename($file, '.php');
+            $reflection = new ReflectionClass($className);
+
+            if (
+                !$reflection->implementsInterface(InputMapperCompilerProvider::class)
+                && !$reflection->implementsInterface(OutputMapperCompilerProvider::class)
+            ) {
+                continue;
+            }
+
+            self::assertArrayHasKey($className, $classesInGraph, "Add {$className} to the provider graph in this test, so that its inner providers are verified");
+        }
+    }
+
+    private static function createProviderGraph(): MapperCompilerProvider
+    {
+        return new MapChain([
+            new MapArray(new MapString(), new MapMixed()),
+            new MapArrayShape(
+                items: [
+                    new ArrayShapeItemMapping(key: 'size', mapper: new MapInt()),
+                    new ArrayShapeItemMapping(key: 'input', mapper: new MapDelegate(stdClass::class), optional: true),
+                ],
+            ),
+            new MapBool(),
+            new MapDate(),
+            new MapDateTimeImmutable(),
+            new MapDefaultValue(new MapFloat(), defaultValue: 1.5),
+            new MapDiscriminatedObject(
+                className: stdClass::class,
+                discriminatorKeyName: 'type',
+                subtypeProviders: ['a' => new MapDelegate(stdClass::class, [new MapMixed()])],
+                genericParameters: [new GenericTypeParameter('T')],
+            ),
+            new MapObject(
+                className: stdClass::class,
+                constructorArgsProviders: ['foo' => new MapOptional(new MapNullable(new MapList(new MapEnum(SuitEnum::class, new MapString()))))],
+                allowExtraKeys: true,
+                propertyProviders: ['bar' => ['bar', new MapValidated(new MapString(), [new AssertListLength(min: 1)])]],
+                genericParameters: [new GenericTypeParameter('V')],
+            ),
+        ]);
+    }
+
+    /**
+     * @param array<int, InputMapperCompilerProvider|OutputMapperCompilerProvider> $found
+     * @param array<int, true> $visited
+     */
+    private static function collectProvidersReflectively(
+        mixed $value,
+        array &$found,
+        array &$visited,
+    ): void
+    {
+        if (is_array($value)) {
+            foreach ($value as $item) {
+                self::collectProvidersReflectively($item, $found, $visited);
+            }
+
+            return;
+        }
+
+        if (!is_object($value) || isset($visited[spl_object_id($value)])) {
+            return;
+        }
+
+        $visited[spl_object_id($value)] = true;
+
+        if ($value instanceof InputMapperCompilerProvider || $value instanceof OutputMapperCompilerProvider) {
+            $found[spl_object_id($value)] = $value;
+        }
+
+        for ($class = new ReflectionObject($value); $class !== false; $class = $class->getParentClass()) {
+            foreach ($class->getProperties() as $property) {
+                if ($property->isStatic()) {
+                    continue;
+                }
+
+                self::collectProvidersReflectively($property->getValue($value), $found, $visited);
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
## Motivation

Consumers that pre-generate mappers (e.g. a Symfony command compiling input + output mappers for every `*Input` class and everything reachable from it) need to walk a provider graph to discover all transitively referenced classes — every reachable `MapDelegate`. Until now that required reflecting over provider internals (`get_mangled_object_vars()` over a plain `object`), which static analysis cannot attribute to any class: `shipmonk/dead-code-detector` reports it as an *unknown read over unknown type* and it degrades dead-code analysis of the whole consumer project.

## What this adds

- **`CompositeMapperCompilerProvider`** — implemented by providers composed of other providers, exposing them via `getInnerMapperCompilerProviders(): list<InputMapperCompilerProvider|OutputMapperCompilerProvider>`. Implemented on all 12 composite attributes; notably `MapArrayShape` exposes the mappers wrapped in `ArrayShapeItemMapping` and `MapObject` exposes both constructor-arg and property providers.
- **`MapperCompilerProviderUtils::iterate()`** — yields a provider and all transitively nested providers, using only the interface. Consumers can then e.g. filter for `MapDelegate` without any reflection.

## Completeness is enforced mechanically

Two tests keep implementations honest:

1. `testTypedTraversalMatchesReflectiveTraversal` compares the typed traversal against a reflective property walk over a graph exercising every attribute provider — forgetting a nested provider in any implementation fails the test naming the missed provider.
2. `testProviderGraphContainsAllAttributeProviders` globs `src/Compiler/Attribute` and forces every current and future provider attribute into that test graph — a new composite attribute cannot ship without exposing its inner providers.

## Direction / follow-up

This is intended as a building block: input-mapper should ideally support mapper pre-generation natively. A follow-up could add e.g. a `MapperPregenerator` that takes root classes, expands `MapDelegate` dependencies via this traversal, and compiles input + output mappers for all of them — so consumer applications just call it from their console command instead of owning the discovery logic.

Backward compatible: purely additive, custom providers opt in by implementing the interface.

Co-Authored-By: Claude Code

*Drafted by Claude*