### PR TITLE
Add MapperProvider::pregenerate() — native mapper pre-generation

### DIFF
--- a/src/Compiler/Mapper/AbstractDelegateMapperCompiler.php
+++ b/src/Compiler/Mapper/AbstractDelegateMapperCompiler.php
@@ -98,6 +98,7 @@ abstract class AbstractDelegateMapperCompiler implements MapperCompiler
     ): Expr
     {
         if ($innerMapperCompiler instanceof static && count($innerMapperCompiler->innerMapperCompilers) === 0) {
+            $builder->addDelegatedClassName($innerMapperCompiler->className);
             $provider = $builder->propertyFetch($builder->var('this'), 'provider');
             $innerClassExpr = $builder->classConstFetch($builder->importClass($innerMapperCompiler->className), 'class');
             return $builder->methodCall($provider, $this->getProviderMethodName(), [$innerClassExpr]);
@@ -120,6 +121,8 @@ abstract class AbstractDelegateMapperCompiler implements MapperCompiler
                 return new CompiledExpr($innerMapper);
             }
         }
+
+        $builder->addDelegatedClassName($this->className);
 
         $statements = [];
         $classNameExpr = $builder->classConstFetch($builder->importClass($this->className), 'class');

--- a/src/Compiler/Php/PhpCodeBuilder.php
+++ b/src/Compiler/Php/PhpCodeBuilder.php
@@ -63,6 +63,7 @@ use ShipMonk\InputMapper\Runtime\MapperProvider;
 use function array_column;
 use function array_fill_keys;
 use function array_filter;
+use function array_keys;
 use function array_pop;
 use function array_slice;
 use function array_values;
@@ -111,6 +112,11 @@ class PhpCodeBuilder extends BuilderFactory
      * @var array<int, array<string, bool>>
      */
     private array $variables = [];
+
+    /**
+     * @var array<string, true>
+     */
+    private array $delegatedClassNames = [];
 
     /**
      * @param array<ArrayItem> $items
@@ -750,6 +756,21 @@ class PhpCodeBuilder extends BuilderFactory
     public function getGenericParameters(): array
     {
         return $this->genericParameters;
+    }
+
+    public function addDelegatedClassName(string $className): void
+    {
+        $this->delegatedClassNames[$className] = true;
+    }
+
+    /**
+     * Class names the generated mapper fetches from MapperProvider at runtime.
+     *
+     * @return list<string>
+     */
+    public function getDelegatedClassNames(): array
+    {
+        return array_keys($this->delegatedClassNames);
     }
 
     /**

--- a/src/Runtime/MapperProvider.php
+++ b/src/Runtime/MapperProvider.php
@@ -9,7 +9,9 @@ use ShipMonk\InputMapper\Compiler\MapperFactory\DefaultMapperCompilerFactoryProv
 use ShipMonk\InputMapper\Compiler\MapperFactory\MapperCompilerFactoryProvider;
 use ShipMonk\InputMapper\Compiler\Php\PhpCodeBuilder;
 use ShipMonk\InputMapper\Compiler\Php\PhpCodePrinter;
+use function array_keys;
 use function array_map;
+use function array_pop;
 use function class_exists;
 use function class_implements;
 use function class_parents;
@@ -102,6 +104,57 @@ class MapperProvider
     }
 
     /**
+     * Generates input & output mapper files for the given classes and for all classes
+     * their mappers fetch from this provider at runtime, transitively.
+     *
+     * Existing mapper files are not overwritten (unless auto refresh is enabled),
+     * but they are recompiled in memory to discover their delegated classes.
+     *
+     * Classes covered by a factory registered via registerInputFactory() / registerOutputFactory()
+     * are skipped in the respective direction, no file is generated for them.
+     *
+     * @param iterable<class-string> $classNames
+     * @return list<class-string> classes for which at least one mapper file was generated
+     */
+    public function pregenerate(iterable $classNames): array
+    {
+        $queue = [];
+        $visited = [];
+        $generated = [];
+
+        foreach ($classNames as $className) {
+            $queue[] = [$className, 'input'];
+            $queue[] = [$className, 'output'];
+        }
+
+        while ($queue !== []) {
+            [$className, $direction] = array_pop($queue);
+
+            if (isset($visited[$direction][$className])) {
+                continue;
+            }
+
+            $visited[$direction][$className] = true;
+            $factories = $direction === 'input' ? $this->inputMapperFactories : $this->outputMapperFactories;
+
+            if ($this->findMapperFactory($className, $factories) !== null) {
+                continue;
+            }
+
+            $mapperClassName = $this->getMapperClass($className, $direction);
+            $generated[$className] = true;
+
+            foreach ($this->generateMapperFile($className, $mapperClassName, $direction) as $delegatedClassName) {
+                if (class_exists($delegatedClassName)) {
+                    $queue[] = [$delegatedClassName, $direction];
+                }
+            }
+        }
+
+        return array_keys($generated);
+    }
+
+    /**
      * @param class-string<T> $className
      * @param callable(class-string<T>, list<Mapper<mixed, mixed>>, self): Mapper<mixed, T> $mapperFactory
      *
@@ -170,6 +223,30 @@ class MapperProvider
         string $direction,
     ): Mapper
     {
+        $factory = $this->findMapperFactory($className, $factories);
+
+        if ($factory !== null) {
+            return $factory($className, $genericInnerMappers, $this);
+        }
+
+        $mapperClassName = $this->getMapperClass($className, $direction);
+
+        if (!class_exists($mapperClassName, autoload: false)) {
+            $this->load($className, $mapperClassName, $direction);
+        }
+
+        return new $mapperClassName($this, $genericInnerMappers);
+    }
+
+    /**
+     * @param array<class-string, callable(class-string, list<Mapper<*, *>>, self): Mapper<mixed, mixed>> $factories
+     * @return (callable(class-string, list<Mapper<*, *>>, self): Mapper<mixed, mixed>)|null
+     */
+    private function findMapperFactory(
+        string $className,
+        array $factories,
+    ): ?callable
+    {
         $classParents = class_parents($className);
         $classImplements = class_implements($className);
 
@@ -181,18 +258,11 @@ class MapperProvider
 
         foreach ($classLikeNames as $classLikeName => $true) {
             if (isset($factories[$classLikeName])) {
-                $factory = $factories[$classLikeName];
-                return $factory($className, $genericInnerMappers, $this);
+                return $factories[$classLikeName];
             }
         }
 
-        $mapperClassName = $this->getMapperClass($className, $direction);
-
-        if (!class_exists($mapperClassName, autoload: false)) {
-            $this->load($className, $mapperClassName, $direction);
-        }
-
-        return new $mapperClassName($this, $genericInnerMappers);
+        return null;
     }
 
     /**
@@ -212,6 +282,29 @@ class MapperProvider
             return;
         }
 
+        $this->generateMapperFile($className, $mapperClassName, $direction);
+
+        if ((@include $path) === false) { // @ error escalated to exception
+            throw new RuntimeException("Unable to load '$path'.");
+        }
+    }
+
+    /**
+     * Compiles the mapper and writes its file (unless already present), returns delegated class names.
+     *
+     * @param class-string $className
+     * @param class-string<Mapper<mixed, mixed>> $mapperClassName
+     * @param 'input'|'output' $direction
+     * @return list<string>
+     */
+    private function generateMapperFile(
+        string $className,
+        string $mapperClassName,
+        string $direction,
+    ): array
+    {
+        $path = $this->getMapperPath($mapperClassName);
+
         if (!is_dir(dirname($path))) {
             @mkdir(dirname($path)); // @ directory may already exist
         }
@@ -226,20 +319,19 @@ class MapperProvider
             throw new RuntimeException("Unable to acquire exclusive lock '$path.lock'.");
         }
 
-        if (!is_file($path) || $this->autoRefresh) {
-            $code = $this->compile($className, $mapperClassName, $direction);
+        $codeBuilder = new PhpCodeBuilder();
+        $code = $this->compile($className, $mapperClassName, $direction, $codeBuilder);
 
+        if (!is_file($path) || $this->autoRefresh) {
             if (file_put_contents("$path.tmp", $code) !== strlen($code) || !rename("$path.tmp", $path)) {
                 @unlink("$path.tmp"); // @ file may not exist
                 throw new RuntimeException("Unable to create '$path'.");
             }
         }
 
-        if ((@include $path) === false) { // @ error escalated to exception
-            throw new RuntimeException("Unable to load '$path'.");
-        }
-
         flock($handle, LOCK_UN);
+
+        return $codeBuilder->getDelegatedClassNames();
     }
 
     /**
@@ -251,12 +343,12 @@ class MapperProvider
         string $className,
         string $mapperClassName,
         string $direction,
+        PhpCodeBuilder $codeBuilder,
     ): string
     {
         $mapperCompilerFactory = $this->mapperCompilerFactoryProvider->get();
         $type = new IdentifierTypeNode($className);
 
-        $codeBuilder = new PhpCodeBuilder();
         $codePrinter = new PhpCodePrinter();
 
         $mapperCompiler = $direction === 'input'

--- a/tests/Runtime/Data/Pregeneration/AddressInput.php
+++ b/tests/Runtime/Data/Pregeneration/AddressInput.php
@@ -1,0 +1,14 @@
+<?php declare(strict_types = 1);
+
+namespace ShipMonk\InputMapperTests\Runtime\Data\Pregeneration;
+
+class AddressInput
+{
+
+    public function __construct(
+        public readonly string $city,
+    )
+    {
+    }
+
+}

--- a/tests/Runtime/Data/Pregeneration/CustomerInput.php
+++ b/tests/Runtime/Data/Pregeneration/CustomerInput.php
@@ -1,0 +1,15 @@
+<?php declare(strict_types = 1);
+
+namespace ShipMonk\InputMapperTests\Runtime\Data\Pregeneration;
+
+class CustomerInput
+{
+
+    public function __construct(
+        public readonly string $name,
+        public readonly AddressInput $address,
+    )
+    {
+    }
+
+}

--- a/tests/Runtime/Data/Pregeneration/ItemInput.php
+++ b/tests/Runtime/Data/Pregeneration/ItemInput.php
@@ -1,0 +1,15 @@
+<?php declare(strict_types = 1);
+
+namespace ShipMonk\InputMapperTests\Runtime\Data\Pregeneration;
+
+class ItemInput
+{
+
+    public function __construct(
+        public readonly string $name,
+        public readonly PriceInput $price,
+    )
+    {
+    }
+
+}

--- a/tests/Runtime/Data/Pregeneration/OrderInput.php
+++ b/tests/Runtime/Data/Pregeneration/OrderInput.php
@@ -1,0 +1,18 @@
+<?php declare(strict_types = 1);
+
+namespace ShipMonk\InputMapperTests\Runtime\Data\Pregeneration;
+
+class OrderInput
+{
+
+    /**
+     * @param list<ItemInput> $items
+     */
+    public function __construct(
+        public readonly CustomerInput $customer,
+        public readonly array $items,
+    )
+    {
+    }
+
+}

--- a/tests/Runtime/Data/Pregeneration/PriceInput.php
+++ b/tests/Runtime/Data/Pregeneration/PriceInput.php
@@ -1,0 +1,15 @@
+<?php declare(strict_types = 1);
+
+namespace ShipMonk\InputMapperTests\Runtime\Data\Pregeneration;
+
+class PriceInput
+{
+
+    public function __construct(
+        public readonly int $amount,
+        public readonly string $currency,
+    )
+    {
+    }
+
+}

--- a/tests/Runtime/MapperPregenerationTest.php
+++ b/tests/Runtime/MapperPregenerationTest.php
@@ -1,0 +1,113 @@
+<?php declare(strict_types = 1);
+
+namespace ShipMonk\InputMapperTests\Runtime;
+
+use Nette\Utils\FileSystem;
+use ShipMonk\InputMapper\Runtime\MapperProvider;
+use ShipMonk\InputMapperTests\InputMapperTestCase;
+use ShipMonk\InputMapperTests\Runtime\Data\DummyMapper;
+use ShipMonk\InputMapperTests\Runtime\Data\Pregeneration\AddressInput;
+use ShipMonk\InputMapperTests\Runtime\Data\Pregeneration\CustomerInput;
+use ShipMonk\InputMapperTests\Runtime\Data\Pregeneration\ItemInput;
+use ShipMonk\InputMapperTests\Runtime\Data\Pregeneration\OrderInput;
+use ShipMonk\InputMapperTests\Runtime\Data\Pregeneration\PriceInput;
+use function getmypid;
+use function md5;
+use function strrpos;
+use function substr;
+use function sys_get_temp_dir;
+
+class MapperPregenerationTest extends InputMapperTestCase
+{
+
+    public function testPregenerateGeneratesMappersForAllDelegatedClasses(): void
+    {
+        $tempDir = self::createTempDir(__FUNCTION__);
+
+        try {
+            $provider = new MapperProvider($tempDir);
+            $generated = $provider->pregenerate([OrderInput::class]);
+
+            self::assertEqualsCanonicalizing(
+                [OrderInput::class, CustomerInput::class, ItemInput::class, AddressInput::class, PriceInput::class],
+                $generated,
+            );
+
+            foreach ($generated as $className) {
+                self::assertFileExists(self::getMapperPath($tempDir, $className, 'input'));
+                self::assertFileExists(self::getMapperPath($tempDir, $className, 'output'));
+            }
+
+            $order = $provider->getInputMapper(OrderInput::class)->map([
+                'customer' => ['name' => 'John', 'address' => ['city' => 'Prague']],
+                'items' => [['name' => 'Socks', 'price' => ['amount' => 5, 'currency' => 'EUR']]],
+            ]);
+
+            self::assertSame('Prague', $order->customer->address->city);
+            self::assertSame('EUR', $order->items[0]->price->currency);
+        } finally {
+            FileSystem::delete($tempDir);
+        }
+    }
+
+    public function testPregenerateDiscoversDelegatedClassesEvenWithWarmCache(): void
+    {
+        $tempDir = self::createTempDir(__FUNCTION__);
+
+        try {
+            $coldGenerated = (new MapperProvider($tempDir))->pregenerate([OrderInput::class]);
+            $warmGenerated = (new MapperProvider($tempDir))->pregenerate([OrderInput::class]);
+
+            self::assertEqualsCanonicalizing($coldGenerated, $warmGenerated);
+        } finally {
+            FileSystem::delete($tempDir);
+        }
+    }
+
+    public function testPregenerateSkipsClassesWithRegisteredFactory(): void
+    {
+        $tempDir = self::createTempDir(__FUNCTION__);
+
+        try {
+            $provider = new MapperProvider($tempDir);
+            $provider->registerInputFactory(PriceInput::class, static fn () => new DummyMapper());
+            $provider->registerOutputFactory(PriceInput::class, static fn () => new DummyMapper());
+
+            $generated = $provider->pregenerate([OrderInput::class]);
+
+            self::assertEqualsCanonicalizing(
+                [OrderInput::class, CustomerInput::class, ItemInput::class, AddressInput::class],
+                $generated,
+            );
+
+            self::assertFileDoesNotExist(self::getMapperPath($tempDir, PriceInput::class, 'input'));
+            self::assertFileDoesNotExist(self::getMapperPath($tempDir, PriceInput::class, 'output'));
+        } finally {
+            FileSystem::delete($tempDir);
+        }
+    }
+
+    private static function createTempDir(string $testName): string
+    {
+        return sys_get_temp_dir() . '/input-mapper-test-pregeneration-' . $testName . '-' . getmypid();
+    }
+
+    /**
+     * @param class-string $className
+     * @param 'input'|'output' $direction
+     */
+    private static function getMapperPath(
+        string $tempDir,
+        string $className,
+        string $direction,
+    ): string
+    {
+        $pos = strrpos($className, '\\');
+        $shortName = $pos === false ? $className : substr($className, $pos + 1);
+        $hash = substr(md5($className), 0, 8);
+        $suffix = $direction === 'input' ? 'Mapper' : 'OutputMapper';
+
+        return "{$tempDir}/{$shortName}{$suffix}_{$hash}.php";
+    }
+
+}


### PR DESCRIPTION
Alternative to #126, based on the review feedback there — instead of exposing the provider/compiler graph for consumers to traverse, the library records delegated classes where the truth is decided and offers pre-generation natively.

## Motivation

Consumers pre-generating mappers at deploy time (e.g. a console command compiling mappers for every API input class) so far had to discover transitively referenced classes themselves — by reflecting over provider internals (`get_mangled_object_vars()` over plain `object`), which is fragile and reported by `shipmonk/dead-code-detector` as an *unknown read over unknown type*.

## Design: record at the emission point

A pre-generation dependency is *"a class the generated code will call `$provider->get{Input,Output}Mapper()` for at runtime"*. That is decided during compilation, at a single funnel: `AbstractDelegateMapperCompiler` either emits a provider call (runtime dependency) or inlines the inner mapper as a `CallbackMapper` method (no standalone dependency — and its own delegates are emitted, hence recorded, within the same compilation). `PhpCodeBuilder` now records class names at those two emission points — ground truth by construction, nothing to keep in sync, no interface churn.

`MapperProvider::pregenerate(iterable $classNames): list<class-string>` then runs a compile-as-you-discover fixpoint: compile the seeds, enqueue recorded delegations, repeat until nothing new appears. Each iteration is work that had to happen anyway, discovery is a free byproduct.

Properties:

- **per-direction precision** — dependencies discovered while compiling an input mapper are only pre-generated as input mappers (and vice versa), so e.g. an enum's backing mapper unused on the output side generates nothing there
- **runtime factories respected** — classes covered by `register{Input,Output}Factory()` are skipped in that direction
- **warm-cache safe** — existing files are not overwritten, but are recompiled in memory so discovery still sees their delegations
- generated code is byte-identical to before (recording is side-band), so no snapshot changes

## Consumer story

The application command reduces to seed discovery + one call:

```php
$inputClasses = ...; // Finder over src/**/*Input.php — app-specific
$mapperProvider->pregenerate($inputClasses);
```

If this direction is preferred, #126 (`CompositeMapperCompilerProvider`) becomes unnecessary for the pre-generation use case and can be closed — a graph-traversal API would only be worth keeping for hypothetical static analyses that must not compile.

Co-Authored-By: Claude Code

*Drafted by Claude*