### PR TITLE
Update coverage-guard to 1.1.0, ignore LogicException throws in coverage

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "phpunit/phpunit": "^10.5.63",
         "shipmonk/coding-standard": "^0.2.4",
         "shipmonk/composer-dependency-analyser": "^1.8.4",
-        "shipmonk/coverage-guard": "^1.0",
+        "shipmonk/coverage-guard": "^1.1.0",
         "shipmonk/dead-code-detector": "^1.1",
         "shipmonk/name-collision-detector": "^2.1.1",
         "shipmonk/phpstan-rules": "^4.4.0"

--- a/coverage-guard.php
+++ b/coverage-guard.php
@@ -1,6 +1,7 @@
 <?php
 
 use ShipMonk\CoverageGuard\Config;
+use ShipMonk\CoverageGuard\Excluder\IgnoreThrowNewExceptionLineExcluder;
 use ShipMonk\CoverageGuard\Rule\EnforceCoverageForMethodsRule;
 
 $config = new Config();
@@ -8,5 +9,6 @@ $config->addRule(new EnforceCoverageForMethodsRule(
     requiredCoveragePercentage: 70,
     minExecutableLines: 5,
 ));
+$config->addExecutableLineExcluder(new IgnoreThrowNewExceptionLineExcluder([LogicException::class]));
 
 return $config;


### PR DESCRIPTION
Updates `shipmonk/coverage-guard` to `^1.1.0` and adopts the new native `ExecutableLineExcluder` introduced in that release:

- `throw new LogicException(...)` lines are no longer counted as executable for coverage enforcement (`IgnoreThrowNewExceptionLineExcluder`)

Verified locally: `composer check:coverage` passes.

Co-Authored-By: Claude Code

https://claude.ai/code/session_01YBrus7vYD8XFs8BXtoW6Eo
