### PR TITLE
Respect #[SensitiveParameter] when reporting mapping failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,36 @@ class Person
 }
 ```
 
+### Redacting sensitive values from error messages
+
+Mapping failures normally embed the offending value in the exception message, e.g.
+`Failed to map data at path /password: Expected non-empty string, got "hunter2"`. Since these messages
+typically end up in logs and in API error responses, mark credentials and other secrets with the native
+`#[SensitiveParameter]` attribute:
+
+```php
+use SensitiveParameter;
+use ShipMonk\InputMapper\Compiler\Validator\String\AssertStringNonEmpty;
+
+class LoginInput
+{
+    public function __construct(
+        public readonly string $login,
+
+        #[SensitiveParameter]
+        #[AssertStringNonEmpty]
+        public readonly string $password,
+    ) {}
+}
+```
+
+Any mapping or validation failure below such a parameter reports the type only:
+`Failed to map data at path /password: Expected non-empty string, got string (redacted)`.
+Keys, paths and the expectation itself are kept, only the value is dropped.
+
+`#[SensitiveParameter]` requires PHP 8.2. On PHP 8.1, use `#[MapSensitive(new MapString())]` instead,
+which has the same effect and lets you pick the inner mapper explicitly.
+
 ### Renaming keys
 
 If the input keys do not match the property names, you can use the `#[SourceKey]` attribute to specify the key name:

--- a/src/Compiler/Attribute/MapSensitive.php
+++ b/src/Compiler/Attribute/MapSensitive.php
@@ -1,0 +1,33 @@
+<?php declare(strict_types = 1);
+
+namespace ShipMonk\InputMapper\Compiler\Attribute;
+
+use Attribute;
+use ShipMonk\InputMapper\Compiler\Mapper\Input\SensitiveInputMapperCompiler;
+use ShipMonk\InputMapper\Compiler\Mapper\MapperCompiler;
+use ShipMonk\InputMapper\Compiler\Mapper\MapperCompilerProvider;
+
+#[Attribute(Attribute::TARGET_PARAMETER | Attribute::TARGET_PROPERTY)]
+class MapSensitive implements MapperCompilerProvider
+{
+
+    public function __construct(
+        public readonly MapperCompilerProvider $innerMapperCompilerProvider,
+    )
+    {
+    }
+
+    public function getInputMapperCompiler(): MapperCompiler
+    {
+        return new SensitiveInputMapperCompiler($this->innerMapperCompilerProvider->getInputMapperCompiler());
+    }
+
+    /**
+     * Output mapping starts from an already validated object, so there is nothing to redact
+     */
+    public function getOutputMapperCompiler(): MapperCompiler
+    {
+        return $this->innerMapperCompilerProvider->getOutputMapperCompiler();
+    }
+
+}

--- a/src/Compiler/Mapper/Input/SensitiveInputMapperCompiler.php
+++ b/src/Compiler/Mapper/Input/SensitiveInputMapperCompiler.php
@@ -1,0 +1,53 @@
+<?php declare(strict_types = 1);
+
+namespace ShipMonk\InputMapper\Compiler\Mapper\Input;
+
+use PhpParser\Node\Expr;
+use PHPStan\PhpDocParser\Ast\Type\TypeNode;
+use ShipMonk\InputMapper\Compiler\CompiledExpr;
+use ShipMonk\InputMapper\Compiler\Mapper\MapperCompiler;
+use ShipMonk\InputMapper\Compiler\Php\PhpCodeBuilder;
+use ShipMonk\InputMapper\Runtime\Exception\MappingFailedException;
+
+class SensitiveInputMapperCompiler implements MapperCompiler
+{
+
+    public function __construct(
+        public readonly MapperCompiler $mapperCompiler,
+    )
+    {
+    }
+
+    public function compile(
+        Expr $value,
+        Expr $path,
+        PhpCodeBuilder $builder,
+    ): CompiledExpr
+    {
+        $mapper = $this->mapperCompiler->compile($value, $path, $builder);
+        $mappedVariable = $builder->var($builder->uniqVariableName('mapped'));
+        $exceptionVariable = $builder->var($builder->uniqVariableName('e'));
+
+        $exceptionClassName = $builder->importClass(MappingFailedException::class);
+
+        $statement = $builder->tryCatch(
+            [...$mapper->statements, $builder->assign($mappedVariable, $mapper->expr)],
+            $exceptionClassName,
+            $exceptionVariable,
+            [$builder->throw($builder->staticCall($exceptionClassName, 'redact', [$exceptionVariable]))],
+        );
+
+        return new CompiledExpr($mappedVariable, [$statement]);
+    }
+
+    public function getInputType(): TypeNode
+    {
+        return $this->mapperCompiler->getInputType();
+    }
+
+    public function getOutputType(): TypeNode
+    {
+        return $this->mapperCompiler->getOutputType();
+    }
+
+}

--- a/src/Compiler/MapperFactory/DefaultMapperCompilerFactory.php
+++ b/src/Compiler/MapperFactory/DefaultMapperCompilerFactory.php
@@ -27,6 +27,7 @@ use ReflectionEnum;
 use ReflectionMethod;
 use ReflectionParameter;
 use ReflectionProperty;
+use SensitiveParameter;
 use ShipMonk\InputMapper\Compiler\Attribute\AllowExtraKeys;
 use ShipMonk\InputMapper\Compiler\Attribute\ArrayShapeItemMapping;
 use ShipMonk\InputMapper\Compiler\Attribute\Discriminator;
@@ -46,6 +47,7 @@ use ShipMonk\InputMapper\Compiler\Attribute\MapMixed;
 use ShipMonk\InputMapper\Compiler\Attribute\MapNullable;
 use ShipMonk\InputMapper\Compiler\Attribute\MapObject;
 use ShipMonk\InputMapper\Compiler\Attribute\MapOptional;
+use ShipMonk\InputMapper\Compiler\Attribute\MapSensitive;
 use ShipMonk\InputMapper\Compiler\Attribute\MapString;
 use ShipMonk\InputMapper\Compiler\Attribute\MapValidated;
 use ShipMonk\InputMapper\Compiler\Attribute\Optional as OptionalAttribute;
@@ -546,6 +548,10 @@ class DefaultMapperCompilerFactory implements MapperCompilerFactory
             $provider = $this->addValidatorProvider($provider, $validator);
         }
 
+        if (!$provider instanceof MapSensitive && count($parameterReflection->getAttributes(SensitiveParameter::class)) > 0) {
+            $provider = new MapSensitive($provider);
+        }
+
         foreach ($parameterReflection->getAttributes(OptionalAttribute::class, ReflectionAttribute::IS_INSTANCEOF) as $attribute) {
             $provider = new MapDefaultValue($provider, $attribute->newInstance()->default);
         }
@@ -608,6 +614,12 @@ class DefaultMapperCompilerFactory implements MapperCompilerFactory
 
         if ($provider instanceof MapNullable) {
             return new MapNullable(
+                $this->addValidatorProvider($provider->innerMapperCompilerProvider, $validatorCompiler),
+            );
+        }
+
+        if ($provider instanceof MapSensitive) {
+            return new MapSensitive(
                 $this->addValidatorProvider($provider->innerMapperCompilerProvider, $validatorCompiler),
             );
         }

--- a/src/Compiler/Php/PhpCodeBuilder.php
+++ b/src/Compiler/Php/PhpCodeBuilder.php
@@ -30,9 +30,11 @@ use PhpParser\Node\Expr\Match_;
 use PhpParser\Node\Expr\PreInc;
 use PhpParser\Node\Expr\Ternary;
 use PhpParser\Node\Expr\Throw_;
+use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\MatchArm;
 use PhpParser\Node\Name;
 use PhpParser\Node\Stmt;
+use PhpParser\Node\Stmt\Catch_;
 use PhpParser\Node\Stmt\ClassConst;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Declare_;
@@ -44,6 +46,7 @@ use PhpParser\Node\Stmt\Foreach_;
 use PhpParser\Node\Stmt\If_;
 use PhpParser\Node\Stmt\Nop;
 use PhpParser\Node\Stmt\Return_;
+use PhpParser\Node\Stmt\TryCatch;
 use PhpParser\Node\Stmt\Use_;
 use PHPStan\PhpDocParser\Ast\Type\ArrayShapeItemNode;
 use PHPStan\PhpDocParser\Ast\Type\ArrayShapeNode;
@@ -348,6 +351,20 @@ class PhpCodeBuilder extends BuilderFactory
     public function throwExpr(Expr $expr): Throw_
     {
         return new Throw_($expr);
+    }
+
+    /**
+     * @param list<Stmt> $statements
+     * @param list<Stmt> $catchStatements
+     */
+    public function tryCatch(
+        array $statements,
+        string $caughtClassName,
+        Variable $caughtVariable,
+        array $catchStatements,
+    ): TryCatch
+    {
+        return new TryCatch($statements, [new Catch_([new Name($caughtClassName)], $caughtVariable, $catchStatements)]);
     }
 
     public function assign(

--- a/src/Runtime/Exception/MappingFailedException.php
+++ b/src/Runtime/Exception/MappingFailedException.php
@@ -38,6 +38,7 @@ class MappingFailedException extends RuntimeException
     private function __construct(
         private readonly array $path,
         string $reason,
+        private readonly string $redactedReason,
         ?Throwable $previous = null,
     )
     {
@@ -54,6 +55,19 @@ class MappingFailedException extends RuntimeException
     }
 
     /**
+     * Returns an equivalent exception with the offending value stripped from the message,
+     * so that it can be logged or sent to the client without leaking sensitive data.
+     *
+     * The given exception is intentionally not kept as previous, as its message contains the value.
+     */
+    public static function redact(self $exception): self
+    {
+        $previous = $exception->getPrevious();
+        $redactedPrevious = $previous instanceof self ? self::redact($previous) : null;
+        return new self($exception->path, $exception->redactedReason, $exception->redactedReason, $redactedPrevious);
+    }
+
+    /**
      * @param list<string|int> $path
      */
     public static function incorrectType(
@@ -64,8 +78,10 @@ class MappingFailedException extends RuntimeException
     ): self
     {
         $describedValue = self::describeValue($data);
+        $redactedValue = self::describeValueType($data);
         $reason = "Expected {$expectedType}, got {$describedValue}";
-        return new self($path, $reason, $previous);
+        $redactedReason = "Expected {$expectedType}, got {$redactedValue}";
+        return new self($path, $reason, $redactedReason, $previous);
     }
 
     /**
@@ -79,8 +95,10 @@ class MappingFailedException extends RuntimeException
     ): self
     {
         $describedValue = self::describeValue($data);
+        $redactedValue = self::describeValueType($data);
         $reason = "Expected {$expectedValueDescription}, got {$describedValue}";
-        return new self($path, $reason, $previous);
+        $redactedReason = "Expected {$expectedValueDescription}, got {$redactedValue}";
+        return new self($path, $reason, $redactedReason, $previous);
     }
 
     /**
@@ -94,8 +112,10 @@ class MappingFailedException extends RuntimeException
     ): self
     {
         $describedValue = self::describeValue($data);
+        $redactedValue = self::describeValueType($data);
         $reason = "Expected {$expectedValueDescription}, got {$describedValue} multiple times";
-        return new self($path, $reason, $previous);
+        $redactedReason = "Expected {$expectedValueDescription}, got {$redactedValue} multiple times";
+        return new self($path, $reason, $redactedReason, $previous);
     }
 
     /**
@@ -109,7 +129,7 @@ class MappingFailedException extends RuntimeException
     {
         $missingKeyDescription = self::describeValue($missingKey);
         $reason = "Missing required key {$missingKeyDescription}";
-        return new self($path, $reason, $previous);
+        return new self($path, $reason, $reason, $previous);
     }
 
     /**
@@ -124,7 +144,7 @@ class MappingFailedException extends RuntimeException
     {
         $keyLabel = count($extraKeys) > 1 ? 'keys' : 'key';
         $reason = "Unrecognized {$keyLabel} " . self::humanImplode(array_map(self::describeValue(...), $extraKeys));
-        return new self($path, $reason, $previous);
+        return new self($path, $reason, $reason, $previous);
     }
 
     /**
@@ -143,6 +163,11 @@ class MappingFailedException extends RuntimeException
     private static function toJsonPointer(array $path): string
     {
         return '/' . implode('/', $path);
+    }
+
+    private static function describeValueType(mixed $value): string
+    {
+        return get_debug_type($value) . ' (redacted)';
     }
 
     private static function describeValue(mixed $value): string

--- a/tests/Compiler/Mapper/Wrapper/Data/SensitiveNonEmptyStringMapper.php
+++ b/tests/Compiler/Mapper/Wrapper/Data/SensitiveNonEmptyStringMapper.php
@@ -1,0 +1,45 @@
+<?php declare (strict_types=1);
+
+namespace ShipMonk\InputMapperTests\Compiler\Mapper\Wrapper\Data;
+
+use ShipMonk\InputMapper\Compiler\Mapper\Input\SensitiveInputMapperCompiler;
+use ShipMonk\InputMapper\Runtime\Exception\MappingFailedException;
+use ShipMonk\InputMapper\Runtime\Mapper;
+use ShipMonk\InputMapper\Runtime\MapperProvider;
+use function is_string;
+use function preg_match;
+
+/**
+ * Generated mapper by {@see SensitiveInputMapperCompiler}. Do not edit directly.
+ *
+ * @implements Mapper<mixed, non-empty-string>
+ */
+class SensitiveNonEmptyStringMapper implements Mapper
+{
+    public function __construct(private readonly MapperProvider $provider)
+    {
+    }
+
+    /**
+     * @param  list<string|int> $path
+     * @return non-empty-string
+     * @throws MappingFailedException
+     */
+    public function map(mixed $data, array $path = []): string
+    {
+        try {
+            if (!is_string($data)) {
+                throw MappingFailedException::incorrectType($data, $path, 'string');
+            }
+
+            if ($data === '' || preg_match('#\S#', $data) !== 1) {
+                throw MappingFailedException::incorrectValue($data, $path, 'non-empty string');
+            }
+
+            $mapped = $data;
+        } catch (MappingFailedException $e) {
+            throw MappingFailedException::redact($e);
+        }
+        return $mapped;
+    }
+}

--- a/tests/Compiler/Mapper/Wrapper/Data/SensitiveStringListMapper.php
+++ b/tests/Compiler/Mapper/Wrapper/Data/SensitiveStringListMapper.php
@@ -1,0 +1,52 @@
+<?php declare (strict_types=1);
+
+namespace ShipMonk\InputMapperTests\Compiler\Mapper\Wrapper\Data;
+
+use ShipMonk\InputMapper\Compiler\Mapper\Input\SensitiveInputMapperCompiler;
+use ShipMonk\InputMapper\Runtime\Exception\MappingFailedException;
+use ShipMonk\InputMapper\Runtime\Mapper;
+use ShipMonk\InputMapper\Runtime\MapperProvider;
+use function array_is_list;
+use function is_array;
+use function is_string;
+
+/**
+ * Generated mapper by {@see SensitiveInputMapperCompiler}. Do not edit directly.
+ *
+ * @implements Mapper<mixed, list<string>>
+ */
+class SensitiveStringListMapper implements Mapper
+{
+    public function __construct(private readonly MapperProvider $provider)
+    {
+    }
+
+    /**
+     * @param  list<string|int> $path
+     * @return list<string>
+     * @throws MappingFailedException
+     */
+    public function map(mixed $data, array $path = []): array
+    {
+        try {
+            if (!is_array($data) || !array_is_list($data)) {
+                throw MappingFailedException::incorrectType($data, $path, 'list');
+            }
+
+            $mapped = [];
+
+            foreach ($data as $index => $item) {
+                if (!is_string($item)) {
+                    throw MappingFailedException::incorrectType($item, [...$path, $index], 'string');
+                }
+
+                $mapped[] = $item;
+            }
+
+            $mapped2 = $mapped;
+        } catch (MappingFailedException $e) {
+            throw MappingFailedException::redact($e);
+        }
+        return $mapped2;
+    }
+}

--- a/tests/Compiler/Mapper/Wrapper/Data/SensitiveStringMapper.php
+++ b/tests/Compiler/Mapper/Wrapper/Data/SensitiveStringMapper.php
@@ -1,0 +1,39 @@
+<?php declare (strict_types=1);
+
+namespace ShipMonk\InputMapperTests\Compiler\Mapper\Wrapper\Data;
+
+use ShipMonk\InputMapper\Compiler\Mapper\Input\SensitiveInputMapperCompiler;
+use ShipMonk\InputMapper\Runtime\Exception\MappingFailedException;
+use ShipMonk\InputMapper\Runtime\Mapper;
+use ShipMonk\InputMapper\Runtime\MapperProvider;
+use function is_string;
+
+/**
+ * Generated mapper by {@see SensitiveInputMapperCompiler}. Do not edit directly.
+ *
+ * @implements Mapper<mixed, string>
+ */
+class SensitiveStringMapper implements Mapper
+{
+    public function __construct(private readonly MapperProvider $provider)
+    {
+    }
+
+    /**
+     * @param  list<string|int> $path
+     * @throws MappingFailedException
+     */
+    public function map(mixed $data, array $path = []): string
+    {
+        try {
+            if (!is_string($data)) {
+                throw MappingFailedException::incorrectType($data, $path, 'string');
+            }
+
+            $mapped = $data;
+        } catch (MappingFailedException $e) {
+            throw MappingFailedException::redact($e);
+        }
+        return $mapped;
+    }
+}

--- a/tests/Compiler/Mapper/Wrapper/SensitiveInputMapperCompilerTest.php
+++ b/tests/Compiler/Mapper/Wrapper/SensitiveInputMapperCompilerTest.php
@@ -1,0 +1,61 @@
+<?php declare(strict_types = 1);
+
+namespace ShipMonk\InputMapperTests\Compiler\Mapper\Wrapper;
+
+use ShipMonk\InputMapper\Compiler\Mapper\Input\ListInputMapperCompiler;
+use ShipMonk\InputMapper\Compiler\Mapper\Input\SensitiveInputMapperCompiler;
+use ShipMonk\InputMapper\Compiler\Mapper\Input\StringInputMapperCompiler;
+use ShipMonk\InputMapper\Compiler\Mapper\Input\ValidatedInputMapperCompiler;
+use ShipMonk\InputMapper\Compiler\Validator\String\AssertStringNonEmpty;
+use ShipMonk\InputMapper\Runtime\Exception\MappingFailedException;
+use ShipMonk\InputMapperTests\Compiler\Mapper\MapperCompilerTestCase;
+
+class SensitiveInputMapperCompilerTest extends MapperCompilerTestCase
+{
+
+    public function testCompile(): void
+    {
+        $mapperCompiler = new SensitiveInputMapperCompiler(new StringInputMapperCompiler());
+        $mapper = $this->compileInputMapper('SensitiveString', $mapperCompiler);
+
+        self::assertSame('secret', $mapper->map('secret'));
+
+        self::assertException(
+            MappingFailedException::class,
+            'Failed to map data at path /: Expected string, got int (redacted)',
+            static fn () => $mapper->map(12_345),
+        );
+    }
+
+    public function testCompileWithValidator(): void
+    {
+        $mapperCompiler = new SensitiveInputMapperCompiler(
+            new ValidatedInputMapperCompiler(new StringInputMapperCompiler(), [new AssertStringNonEmpty()]),
+        );
+
+        $mapper = $this->compileInputMapper('SensitiveNonEmptyString', $mapperCompiler);
+
+        self::assertSame('secret', $mapper->map('secret'));
+
+        self::assertException(
+            MappingFailedException::class,
+            'Failed to map data at path /: Expected non-empty string, got string (redacted)',
+            static fn () => $mapper->map(' '),
+        );
+    }
+
+    public function testCompileWithNestedMapper(): void
+    {
+        $mapperCompiler = new SensitiveInputMapperCompiler(new ListInputMapperCompiler(new StringInputMapperCompiler()));
+        $mapper = $this->compileInputMapper('SensitiveStringList', $mapperCompiler);
+
+        self::assertSame(['secret'], $mapper->map(['secret']));
+
+        self::assertException(
+            MappingFailedException::class,
+            'Failed to map data at path /0: Expected string, got int (redacted)',
+            static fn () => $mapper->map([12_345]),
+        );
+    }
+
+}

--- a/tests/Compiler/MapperFactory/Data/InputWithMapSensitive.php
+++ b/tests/Compiler/MapperFactory/Data/InputWithMapSensitive.php
@@ -1,0 +1,25 @@
+<?php declare(strict_types = 1);
+
+namespace ShipMonk\InputMapperTests\Compiler\MapperFactory\Data;
+
+use SensitiveParameter;
+use ShipMonk\InputMapper\Compiler\Attribute\MapSensitive;
+use ShipMonk\InputMapper\Compiler\Attribute\MapString;
+use ShipMonk\InputMapper\Compiler\Validator\String\AssertStringNonEmpty;
+
+class InputWithMapSensitive
+{
+
+    public function __construct(
+        #[MapSensitive(new MapString())]
+        #[AssertStringNonEmpty]
+        public readonly string $password,
+
+        #[SensitiveParameter]
+        #[MapSensitive(new MapString())]
+        public readonly string $token,
+    )
+    {
+    }
+
+}

--- a/tests/Compiler/MapperFactory/Data/InputWithSensitiveParameter.php
+++ b/tests/Compiler/MapperFactory/Data/InputWithSensitiveParameter.php
@@ -1,0 +1,26 @@
+<?php declare(strict_types = 1);
+
+namespace ShipMonk\InputMapperTests\Compiler\MapperFactory\Data;
+
+use SensitiveParameter;
+use ShipMonk\InputMapper\Compiler\Attribute\Optional;
+use ShipMonk\InputMapper\Compiler\Validator\String\AssertStringLength;
+
+class InputWithSensitiveParameter
+{
+
+    public function __construct(
+        #[SensitiveParameter]
+        #[AssertStringLength(max: 64)]
+        public readonly string $password,
+
+        #[SensitiveParameter]
+        #[Optional(default: '')]
+        public readonly string $token,
+
+        public readonly string $login,
+    )
+    {
+    }
+
+}

--- a/tests/Compiler/MapperFactory/DefaultMapperCompilerFactoryTest.php
+++ b/tests/Compiler/MapperFactory/DefaultMapperCompilerFactoryTest.php
@@ -31,6 +31,7 @@ use ShipMonk\InputMapper\Compiler\Mapper\Input\MixedInputMapperCompiler;
 use ShipMonk\InputMapper\Compiler\Mapper\Input\NullableInputMapperCompiler;
 use ShipMonk\InputMapper\Compiler\Mapper\Input\ObjectInputMapperCompiler;
 use ShipMonk\InputMapper\Compiler\Mapper\Input\OptionalInputMapperCompiler;
+use ShipMonk\InputMapper\Compiler\Mapper\Input\SensitiveInputMapperCompiler;
 use ShipMonk\InputMapper\Compiler\Mapper\Input\StringInputMapperCompiler;
 use ShipMonk\InputMapper\Compiler\Mapper\Input\ValidatedInputMapperCompiler;
 use ShipMonk\InputMapper\Compiler\Mapper\MapperCompiler;
@@ -84,9 +85,11 @@ use ShipMonk\InputMapperTests\Compiler\MapperFactory\Data\InputWithDate;
 use ShipMonk\InputMapperTests\Compiler\MapperFactory\Data\InputWithIncompatibleDefaultValue;
 use ShipMonk\InputMapperTests\Compiler\MapperFactory\Data\InputWithIncompatibleMapperCompiler;
 use ShipMonk\InputMapperTests\Compiler\MapperFactory\Data\InputWithIncompatibleValidator;
+use ShipMonk\InputMapperTests\Compiler\MapperFactory\Data\InputWithMapSensitive;
 use ShipMonk\InputMapperTests\Compiler\MapperFactory\Data\InputWithoutConstructor;
 use ShipMonk\InputMapperTests\Compiler\MapperFactory\Data\InputWithPrivateConstructor;
 use ShipMonk\InputMapperTests\Compiler\MapperFactory\Data\InputWithRenamedSourceKey;
+use ShipMonk\InputMapperTests\Compiler\MapperFactory\Data\InputWithSensitiveParameter;
 use ShipMonk\InputMapperTests\Compiler\MapperFactory\Data\InputWithSourceKeyCollidingWithPlainProperty;
 use ShipMonk\InputMapperTests\Compiler\MapperFactory\Data\InputWithTransformerCollidingKeys;
 use ShipMonk\InputMapperTests\Compiler\MapperFactory\Data\IntRangeLimit;
@@ -288,6 +291,38 @@ class DefaultMapperCompilerFactoryTest extends InputMapperTestCase
                 constructorArgsMapperCompilers: [
                     'old_value' => new IntInputMapperCompiler(),
                     'new_value' => new IntInputMapperCompiler(),
+                ],
+            ),
+        ];
+
+        yield 'InputWithMapSensitive' => [
+            InputWithMapSensitive::class,
+            [],
+            new ObjectInputMapperCompiler(
+                className: InputWithMapSensitive::class,
+                constructorArgsMapperCompilers: [
+                    'password' => new SensitiveInputMapperCompiler(
+                        new ValidatedInputMapperCompiler(new StringInputMapperCompiler(), [new AssertStringNonEmpty()]),
+                    ),
+                    'token' => new SensitiveInputMapperCompiler(new StringInputMapperCompiler()),
+                ],
+            ),
+        ];
+
+        yield 'InputWithSensitiveParameter' => [
+            InputWithSensitiveParameter::class,
+            [],
+            new ObjectInputMapperCompiler(
+                className: InputWithSensitiveParameter::class,
+                constructorArgsMapperCompilers: [
+                    'password' => new SensitiveInputMapperCompiler(
+                        new ValidatedInputMapperCompiler(new StringInputMapperCompiler(), [new AssertStringLength(max: 64)]),
+                    ),
+                    'token' => new DefaultValueInputMapperCompiler(
+                        new SensitiveInputMapperCompiler(new StringInputMapperCompiler()),
+                        '',
+                    ),
+                    'login' => new StringInputMapperCompiler(),
                 ],
             ),
         ];

--- a/tests/Runtime/Data/SensitiveInput.php
+++ b/tests/Runtime/Data/SensitiveInput.php
@@ -1,0 +1,18 @@
+<?php declare(strict_types = 1);
+
+namespace ShipMonk\InputMapperTests\Runtime\Data;
+
+use SensitiveParameter;
+
+class SensitiveInput
+{
+
+    public function __construct(
+        public readonly string $login,
+        #[SensitiveParameter]
+        public readonly string $password,
+    )
+    {
+    }
+
+}

--- a/tests/Runtime/Exception/MappingFailedExceptionTest.php
+++ b/tests/Runtime/Exception/MappingFailedExceptionTest.php
@@ -4,6 +4,7 @@ namespace ShipMonk\InputMapperTests\Runtime\Exception;
 
 use DateTimeImmutable;
 use DateTimeZone;
+use LogicException;
 use PHPUnit\Framework\Attributes\DataProvider;
 use ShipMonk\InputMapper\Runtime\Exception\MappingFailedException;
 use ShipMonk\InputMapperTests\InputMapperTestCase;
@@ -27,6 +28,79 @@ class MappingFailedExceptionTest extends InputMapperTestCase
     {
         self::assertSame($expectedMessage, $exception->getMessage());
         self::assertSame($path, $exception->getPath());
+    }
+
+    /**
+     * @param list<string|int> $path
+     */
+    #[DataProvider('provideRedactedMessagesData')]
+    public function testRedactedMessages(
+        MappingFailedException $exception,
+        string $expectedMessage,
+        array $path,
+    ): void
+    {
+        $redacted = MappingFailedException::redact($exception);
+        self::assertSame($expectedMessage, $redacted->getMessage());
+        self::assertSame($path, $redacted->getPath());
+    }
+
+    /**
+     * @return iterable<string, array{MappingFailedException, string, list<string|int>}>
+     */
+    public static function provideRedactedMessagesData(): iterable
+    {
+        yield 'incorrect type' => [
+            MappingFailedException::incorrectType('hunter2', ['foo'], 'int'),
+            'Failed to map data at path /foo: Expected int, got string (redacted)',
+            ['foo'],
+        ];
+
+        yield 'incorrect value' => [
+            MappingFailedException::incorrectValue(123, ['foo'], 'positive int'),
+            'Failed to map data at path /foo: Expected positive int, got int (redacted)',
+            ['foo'],
+        ];
+
+        yield 'duplicate value' => [
+            MappingFailedException::duplicateValue('hunter2', ['foo'], 'unique string'),
+            'Failed to map data at path /foo: Expected unique string, got string (redacted) multiple times',
+            ['foo'],
+        ];
+
+        yield 'missing key' => [
+            MappingFailedException::missingKey(['foo'], 'bar'),
+            'Failed to map data at path /foo: Missing required key "bar"',
+            ['foo'],
+        ];
+
+        yield 'extra keys' => [
+            MappingFailedException::extraKeys(['foo'], ['bar']),
+            'Failed to map data at path /foo: Unrecognized key "bar"',
+            ['foo'],
+        ];
+
+        yield 'object' => [
+            MappingFailedException::incorrectValue(new stdClass(), ['foo'], 'int'),
+            'Failed to map data at path /foo: Expected int, got stdClass (redacted)',
+            ['foo'],
+        ];
+    }
+
+    public function testRedactedDropsUnrelatedPreviousException(): void
+    {
+        $exception = MappingFailedException::incorrectValue('hunter2', ['foo'], 'int', new LogicException('hunter2'));
+        self::assertNull(MappingFailedException::redact($exception)->getPrevious());
+    }
+
+    public function testRedactedRedactsPreviousMappingFailure(): void
+    {
+        $previous = MappingFailedException::incorrectType('hunter2', ['foo', 'bar'], 'int');
+        $exception = MappingFailedException::incorrectValue('hunter2', ['foo'], 'int', $previous);
+        $redactedPrevious = MappingFailedException::redact($exception)->getPrevious();
+
+        self::assertInstanceOf(MappingFailedException::class, $redactedPrevious);
+        self::assertSame('Failed to map data at path /foo/bar: Expected int, got string (redacted)', $redactedPrevious->getMessage());
     }
 
     /**

--- a/tests/Runtime/InputMapperProviderTest.php
+++ b/tests/Runtime/InputMapperProviderTest.php
@@ -20,6 +20,7 @@ use ShipMonk\InputMapperTests\Runtime\Data\InterfaceImplementationInput;
 use ShipMonk\InputMapperTests\Runtime\Data\MkdirTestInput;
 use ShipMonk\InputMapperTests\Runtime\Data\Optional\OptionalNotNullInput;
 use ShipMonk\InputMapperTests\Runtime\Data\Optional\OptionalNullableInput;
+use ShipMonk\InputMapperTests\Runtime\Data\SensitiveInput;
 use function getmypid;
 use function md5;
 use function mkdir;
@@ -72,6 +73,29 @@ class InputMapperProviderTest extends InputMapperTestCase
 
         self::assertSame($myCustomMapper, $mapperProvider->getInputMapper(InterfaceImplementationInput::class));
         self::assertSame($myCustomMapper, $mapperProvider->getInputMapper(InterfaceImplementationInput::class));
+    }
+
+    public function testMapperForSensitiveInput(): void
+    {
+        $mapperProvider = $this->createMapperProvider();
+        $mapper = $mapperProvider->getInputMapper(SensitiveInput::class);
+        self::assertEquals(new SensitiveInput('joe', 'hunter2'), $mapper->map(['login' => 'joe', 'password' => 'hunter2']));
+
+        self::assertException(
+            MappingFailedException::class,
+            'Failed to map data at path /login: Expected string, got 12345',
+            static function () use ($mapper): void {
+                $mapper->map(['login' => 12_345, 'password' => 'hunter2']);
+            },
+        );
+
+        self::assertException(
+            MappingFailedException::class,
+            'Failed to map data at path /password: Expected string, got int (redacted)',
+            static function () use ($mapper): void {
+                $mapper->map(['login' => 'joe', 'password' => 12_345]);
+            },
+        );
     }
 
     public function testMapperForOptionalNotNullInput(): void


### PR DESCRIPTION
Mapping failures embed the offending value in the exception message (`Expected non-empty string, got "hunter2"`), and those messages typically end up in logs and in API error responses. PHP applies `#[SensitiveParameter]` only to stack-trace arguments, so credentials mapped through an input DTO leaked verbatim.

```php
public function __construct(
    public readonly string $login,

    #[SensitiveParameter]
    #[AssertStringNonEmpty]
    public readonly string $password,
) {}
```

`/password` now fails with `Expected non-empty string, got string (redacted)`, while `/login` keeps reporting its value as before. Path, keys and the expectation itself are preserved — only the value is dropped.

### How

* `MappingFailedException` builds a second, value-free reason alongside the current one; `MappingFailedException::redact($e)` returns an equivalent exception built from it. `missingKey`/`extraKeys` are unchanged, as keys are structural rather than data. The source exception is deliberately **not** kept as `previous` (its message holds the value); a `previous` that is itself a `MappingFailedException` is redacted recursively.
* `SensitiveInputMapperCompiler` wraps the whole subtree in `try { … } catch (MappingFailedException $e) { throw MappingFailedException::redact($e); }`. This covers nested mappers and any third-party `Assert*` validator without touching the ~36 `MappingFailedException::incorrect*` call sites. Required one new `PhpCodeBuilder::tryCatch()` helper.
* `DefaultMapperCompilerFactory` wraps the parameter's provider **after** validators but **before** `Optional`/`MapDefaultValue`, so an optional sensitive parameter keeps its `UndefinedAwareMapperCompiler` behaviour — wrapping it on the outside would have silently made the key required. `addValidatorProvider()` also pushes validators inside `MapSensitive`, so the explicit attribute behaves identically to the native one.

### Notes

* `redact()` is a static factory rather than an instance method: `$e->redacted()` trips `shipmonk.missingPreviousException` in every generated mapper, whereas passing the caught exception as an argument satisfies that rule honestly and matches the existing static-factory style of the class.
* `#[SensitiveParameter]` is PHP 8.2+, and this package supports 8.1. Detection is by attribute name, so nothing breaks on 8.1 — the attribute just cannot be written there, hence the `#[MapSensitive(new MapString())]` fallback documented in the README.
* Not addressed here: `ObjectInputMapperCompiler` dumps the whole payload when the input is not an array, before any per-parameter mapper runs.

Co-Authored-By: Claude Code