### PR TITLE
Describe arrays by shape and size in mapping failure messages

### DIFF
--- a/src/Runtime/Exception/MappingFailedException.php
+++ b/src/Runtime/Exception/MappingFailedException.php
@@ -192,7 +192,7 @@ class MappingFailedException extends RuntimeException
             $count = count($value);
 
             if ($count === 0) {
-                return 'empty array';
+                return 'empty list';
             }
 
             $kind = array_is_list($value) ? 'list' : 'array';

--- a/src/Runtime/Exception/MappingFailedException.php
+++ b/src/Runtime/Exception/MappingFailedException.php
@@ -4,12 +4,14 @@ namespace ShipMonk\InputMapper\Runtime\Exception;
 
 use DateTimeInterface;
 use Throwable;
+use function array_is_list;
 use function array_map;
 use function array_slice;
 use function count;
 use function extension_loaded;
 use function get_debug_type;
 use function implode;
+use function is_array;
 use function is_bool;
 use function is_finite;
 use function is_float;
@@ -184,6 +186,18 @@ class MappingFailedException extends RuntimeException
             if ($printable) {
                 return json_encode($value, self::JSON_ENCODE_OPTIONS) . ($truncated ? ' (truncated)' : '');
             }
+        }
+
+        if (is_array($value)) {
+            $count = count($value);
+
+            if ($count === 0) {
+                return 'empty array';
+            }
+
+            $kind = array_is_list($value) ? 'list' : 'array';
+            $unit = $count === 1 ? 'item' : 'items';
+            return "{$kind} with {$count} {$unit}";
         }
 
         if ($value instanceof DateTimeInterface) {

--- a/tests/Compiler/Mapper/MapRuntimeTest.php
+++ b/tests/Compiler/Mapper/MapRuntimeTest.php
@@ -30,7 +30,7 @@ class MapRuntimeTest extends MapperCompilerTestCase
 
         self::assertException(
             MappingFailedException::class,
-            'Failed to map data at path /: Expected int, got empty array',
+            'Failed to map data at path /: Expected int, got empty list',
             static fn () => $mapper->map([]),
         );
     }

--- a/tests/Compiler/Mapper/MapRuntimeTest.php
+++ b/tests/Compiler/Mapper/MapRuntimeTest.php
@@ -30,7 +30,7 @@ class MapRuntimeTest extends MapperCompilerTestCase
 
         self::assertException(
             MappingFailedException::class,
-            'Failed to map data at path /: Expected int, got array',
+            'Failed to map data at path /: Expected int, got empty array',
             static fn () => $mapper->map([]),
         );
     }

--- a/tests/Compiler/Mapper/Scalar/MapBoolTest.php
+++ b/tests/Compiler/Mapper/Scalar/MapBoolTest.php
@@ -31,7 +31,7 @@ class MapBoolTest extends MapperCompilerTestCase
 
         self::assertException(
             MappingFailedException::class,
-            'Failed to map data at path /: Expected bool, got array',
+            'Failed to map data at path /: Expected bool, got empty array',
             static fn () => $mapper->map([]),
         );
     }

--- a/tests/Compiler/Mapper/Scalar/MapBoolTest.php
+++ b/tests/Compiler/Mapper/Scalar/MapBoolTest.php
@@ -31,7 +31,7 @@ class MapBoolTest extends MapperCompilerTestCase
 
         self::assertException(
             MappingFailedException::class,
-            'Failed to map data at path /: Expected bool, got empty array',
+            'Failed to map data at path /: Expected bool, got empty list',
             static fn () => $mapper->map([]),
         );
     }

--- a/tests/Compiler/Mapper/Scalar/MapFloatTest.php
+++ b/tests/Compiler/Mapper/Scalar/MapFloatTest.php
@@ -34,7 +34,7 @@ class MapFloatTest extends MapperCompilerTestCase
 
         self::assertException(
             MappingFailedException::class,
-            'Failed to map data at path /: Expected float, got empty array',
+            'Failed to map data at path /: Expected float, got empty list',
             static fn () => $mapper->map([]),
         );
 

--- a/tests/Compiler/Mapper/Scalar/MapFloatTest.php
+++ b/tests/Compiler/Mapper/Scalar/MapFloatTest.php
@@ -34,7 +34,7 @@ class MapFloatTest extends MapperCompilerTestCase
 
         self::assertException(
             MappingFailedException::class,
-            'Failed to map data at path /: Expected float, got array',
+            'Failed to map data at path /: Expected float, got empty array',
             static fn () => $mapper->map([]),
         );
 

--- a/tests/Compiler/Mapper/Scalar/MapIntTest.php
+++ b/tests/Compiler/Mapper/Scalar/MapIntTest.php
@@ -31,7 +31,7 @@ class MapIntTest extends MapperCompilerTestCase
 
         self::assertException(
             MappingFailedException::class,
-            'Failed to map data at path /: Expected int, got empty array',
+            'Failed to map data at path /: Expected int, got empty list',
             static fn () => $mapper->map([]),
         );
     }

--- a/tests/Compiler/Mapper/Scalar/MapIntTest.php
+++ b/tests/Compiler/Mapper/Scalar/MapIntTest.php
@@ -31,7 +31,7 @@ class MapIntTest extends MapperCompilerTestCase
 
         self::assertException(
             MappingFailedException::class,
-            'Failed to map data at path /: Expected int, got array',
+            'Failed to map data at path /: Expected int, got empty array',
             static fn () => $mapper->map([]),
         );
     }

--- a/tests/Compiler/Mapper/Scalar/MapStringTest.php
+++ b/tests/Compiler/Mapper/Scalar/MapStringTest.php
@@ -31,7 +31,7 @@ class MapStringTest extends MapperCompilerTestCase
 
         self::assertException(
             MappingFailedException::class,
-            'Failed to map data at path /: Expected string, got empty array',
+            'Failed to map data at path /: Expected string, got empty list',
             static fn () => $mapper->map([]),
         );
     }

--- a/tests/Compiler/Mapper/Scalar/MapStringTest.php
+++ b/tests/Compiler/Mapper/Scalar/MapStringTest.php
@@ -31,7 +31,7 @@ class MapStringTest extends MapperCompilerTestCase
 
         self::assertException(
             MappingFailedException::class,
-            'Failed to map data at path /: Expected string, got array',
+            'Failed to map data at path /: Expected string, got empty array',
             static fn () => $mapper->map([]),
         );
     }

--- a/tests/Compiler/Mapper/Wrapper/MapNullableTest.php
+++ b/tests/Compiler/Mapper/Wrapper/MapNullableTest.php
@@ -28,7 +28,7 @@ class MapNullableTest extends MapperCompilerTestCase
 
         self::assertException(
             MappingFailedException::class,
-            'Failed to map data at path /: Expected int, got empty array',
+            'Failed to map data at path /: Expected int, got empty list',
             static fn () => $mapper->map([]),
         );
     }

--- a/tests/Compiler/Mapper/Wrapper/MapNullableTest.php
+++ b/tests/Compiler/Mapper/Wrapper/MapNullableTest.php
@@ -28,7 +28,7 @@ class MapNullableTest extends MapperCompilerTestCase
 
         self::assertException(
             MappingFailedException::class,
-            'Failed to map data at path /: Expected int, got array',
+            'Failed to map data at path /: Expected int, got empty array',
             static fn () => $mapper->map([]),
         );
     }

--- a/tests/Compiler/Mapper/Wrapper/MapOptionalTest.php
+++ b/tests/Compiler/Mapper/Wrapper/MapOptionalTest.php
@@ -33,7 +33,7 @@ class MapOptionalTest extends MapperCompilerTestCase
 
         self::assertException(
             MappingFailedException::class,
-            'Failed to map data at path /: Expected int, got empty array',
+            'Failed to map data at path /: Expected int, got empty list',
             static fn () => $mapper->map([]),
         );
     }

--- a/tests/Compiler/Mapper/Wrapper/MapOptionalTest.php
+++ b/tests/Compiler/Mapper/Wrapper/MapOptionalTest.php
@@ -33,7 +33,7 @@ class MapOptionalTest extends MapperCompilerTestCase
 
         self::assertException(
             MappingFailedException::class,
-            'Failed to map data at path /: Expected int, got array',
+            'Failed to map data at path /: Expected int, got empty array',
             static fn () => $mapper->map([]),
         );
     }

--- a/tests/Compiler/Validator/Array/AssertListLengthTest.php
+++ b/tests/Compiler/Validator/Array/AssertListLengthTest.php
@@ -34,7 +34,7 @@ class AssertListLengthTest extends ValidatorCompilerTestCase
 
         self::assertException(
             MappingFailedException::class,
-            'Failed to map data at path /: Expected list with at least 2 items, got array',
+            'Failed to map data at path /: Expected list with at least 2 items, got list with 1 item',
             static fn () => $validator->map(['a']),
         );
     }
@@ -50,7 +50,7 @@ class AssertListLengthTest extends ValidatorCompilerTestCase
 
         self::assertException(
             MappingFailedException::class,
-            'Failed to map data at path /: Expected list with at most 5 items, got array',
+            'Failed to map data at path /: Expected list with at most 5 items, got list with 6 items',
             static fn () => $validator->map(['a', 'b', 'c', 'd', 'e', 'f']),
         );
     }
@@ -67,13 +67,13 @@ class AssertListLengthTest extends ValidatorCompilerTestCase
 
         self::assertException(
             MappingFailedException::class,
-            'Failed to map data at path /: Expected list with at least 1 items, got array',
+            'Failed to map data at path /: Expected list with at least 1 items, got empty array',
             static fn () => $validator->map([]),
         );
 
         self::assertException(
             MappingFailedException::class,
-            'Failed to map data at path /: Expected list with at most 5 items, got array',
+            'Failed to map data at path /: Expected list with at most 5 items, got list with 6 items',
             static fn () => $validator->map(['a', 'b', 'c', 'd', 'e', 'f']),
         );
     }
@@ -88,7 +88,7 @@ class AssertListLengthTest extends ValidatorCompilerTestCase
 
         self::assertException(
             MappingFailedException::class,
-            'Failed to map data at path /: Expected list with exactly 5 items, got array',
+            'Failed to map data at path /: Expected list with exactly 5 items, got empty array',
             static fn () => $validator->map([]),
         );
     }

--- a/tests/Compiler/Validator/Array/AssertListLengthTest.php
+++ b/tests/Compiler/Validator/Array/AssertListLengthTest.php
@@ -67,7 +67,7 @@ class AssertListLengthTest extends ValidatorCompilerTestCase
 
         self::assertException(
             MappingFailedException::class,
-            'Failed to map data at path /: Expected list with at least 1 items, got empty array',
+            'Failed to map data at path /: Expected list with at least 1 items, got empty list',
             static fn () => $validator->map([]),
         );
 
@@ -88,7 +88,7 @@ class AssertListLengthTest extends ValidatorCompilerTestCase
 
         self::assertException(
             MappingFailedException::class,
-            'Failed to map data at path /: Expected list with exactly 5 items, got empty array',
+            'Failed to map data at path /: Expected list with exactly 5 items, got empty list',
             static fn () => $validator->map([]),
         );
     }

--- a/tests/Runtime/Exception/MappingFailedExceptionTest.php
+++ b/tests/Runtime/Exception/MappingFailedExceptionTest.php
@@ -108,7 +108,25 @@ class MappingFailedExceptionTest extends InputMapperTestCase
 
         yield 'array' => [
             MappingFailedException::incorrectValue([], ['foo'], 'int'),
-            'Failed to map data at path /foo: Expected int, got array',
+            'Failed to map data at path /foo: Expected int, got empty array',
+            ['foo'],
+        ];
+
+        yield 'list' => [
+            MappingFailedException::incorrectValue(['a', 'b', 'c'], ['foo'], 'int'),
+            'Failed to map data at path /foo: Expected int, got list with 3 items',
+            ['foo'],
+        ];
+
+        yield 'list with single item' => [
+            MappingFailedException::incorrectValue(['a'], ['foo'], 'int'),
+            'Failed to map data at path /foo: Expected int, got list with 1 item',
+            ['foo'],
+        ];
+
+        yield 'non-list array' => [
+            MappingFailedException::incorrectValue(['a' => 1, 'b' => 2], ['foo'], 'int'),
+            'Failed to map data at path /foo: Expected int, got array with 2 items',
             ['foo'],
         ];
 

--- a/tests/Runtime/Exception/MappingFailedExceptionTest.php
+++ b/tests/Runtime/Exception/MappingFailedExceptionTest.php
@@ -108,7 +108,7 @@ class MappingFailedExceptionTest extends InputMapperTestCase
 
         yield 'array' => [
             MappingFailedException::incorrectValue([], ['foo'], 'int'),
-            'Failed to map data at path /foo: Expected int, got empty array',
+            'Failed to map data at path /foo: Expected int, got empty list',
             ['foo'],
         ];
 


### PR DESCRIPTION
`MappingFailedException::incorrectValue()` described every array as `array`, because `describeValue()` fell through to `get_debug_type()`. A list-length failure therefore read:

```
Expected list with at most 500 items, got array
```

The message hid the one fact the reader needs: how long the list was. The same text also appeared for a non-list array, so the reader could not tell a too-long list from a wrong shape.

`describeValue()` now reports the shape and the size of an array:

```
Expected list with at most 500 items, got list with 735 items
Expected list with at least 2 items, got list with 1 item
Expected list, got array with 3 items
Expected int, got empty list
```

Only the `got …` part of the message changes. Existing tests that asserted `got array` are updated, and `MappingFailedExceptionTest` gains cases for a list, a single-item list and a non-list array.

Motivation: a production consumer (translations service) rejected requests with the old message for weeks; the size of the list was the missing clue.

Asana: https://app.asana.com/0/0/1217814245582002

Co-Authored-By: Claude Code